### PR TITLE
fix(tslib): requiring tslib in the lambda

### DIFF
--- a/lambdas/annotations-api-events/package.json
+++ b/lambdas/annotations-api-events/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "node-fetch": "^2.6.7",
     "@aws-sdk/client-lambda": "3.391.0",
-    "@sentry/serverless": "7.88.0"
+    "@sentry/serverless": "7.88.0",
+    "tslib": "2.6.2"
   },
   "devDependencies": {
     "tsconfig": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       node-fetch:
         specifier: ^2.6.7
         version: 2.7.0
+      tslib:
+        specifier: 2.6.2
+        version: 2.6.2
     devDependencies:
       '@types/aws-lambda':
         specifier: 8.10.130


### PR DESCRIPTION
## Goal

Fix lambda failing by force including tslib. Because this comes from tsconfig, it didn't include it. Will need to rethink that package.