### PR TITLE
fix(tf): build prefix for workspace to avoid TF_WORKSPACE variable use

### DIFF
--- a/.circleci/common.yml
+++ b/.circleci/common.yml
@@ -203,7 +203,6 @@ jobs:
             . /home/circleci/.codebuild_shims_wrapper.sh
             cd << parameters.stack-output-path >>
             tfenv use
-            echo 'export TF_WORKSPACE="<< parameters.workspace >>"' >> "$BASH_ENV"
             terraform init
       - when:
           condition: <<parameters.save_app_spec>>

--- a/infrastructure/annotations-api/src/main.ts
+++ b/infrastructure/annotations-api/src/main.ts
@@ -44,7 +44,11 @@ class AnnotationsAPI extends TerraformStack {
     new RemoteBackend(this, {
       hostname: 'app.terraform.io',
       organization: 'Pocket',
-      workspaces: [{ prefix: `${config.name}-` }],
+      workspaces: [
+        {
+          name: `${config.name}-${config.environment}`,
+        },
+      ],
     });
 
     const region = new DataAwsRegion(this, 'region');

--- a/infrastructure/fxa-webhook-proxy/src/main.ts
+++ b/infrastructure/fxa-webhook-proxy/src/main.ts
@@ -34,7 +34,11 @@ class FxAWebhookProxy extends TerraformStack {
     new RemoteBackend(this, {
       hostname: 'app.terraform.io',
       organization: 'Pocket',
-      workspaces: [{ prefix: `${config.name}-` }],
+      workspaces: [
+        {
+          name: `${config.name}-${config.environment}`,
+        },
+      ],
     });
 
     const vpc = new PocketVPC(this, 'pocket-shared-vpc');

--- a/infrastructure/image-api/src/main.ts
+++ b/infrastructure/image-api/src/main.ts
@@ -40,7 +40,11 @@ class ImageAPI extends TerraformStack {
     new RemoteBackend(this, {
       hostname: 'app.terraform.io',
       organization: 'Pocket',
-      workspaces: [{ prefix: `${config.name}-` }],
+      workspaces: [
+        {
+          name: `${config.name}-${config.environment}`,
+        },
+      ],
     });
 
     const pocketVPC = new PocketVPC(this, 'pocket-vpc');

--- a/infrastructure/parser-graphql-wrapper/src/main.ts
+++ b/infrastructure/parser-graphql-wrapper/src/main.ts
@@ -35,7 +35,7 @@ class ParserGraphQLWrapper extends TerraformStack {
       organization: 'Pocket',
       workspaces: [
         {
-          prefix: `${config.name}-`,
+          name: `${config.name}-${config.environment}`,
         },
       ],
     });

--- a/infrastructure/pocket-router/src/main.ts
+++ b/infrastructure/pocket-router/src/main.ts
@@ -61,7 +61,7 @@ class PocketRouter extends TerraformStack {
         {
           response: 'ok',
           // TODO: Do I need the port?
-          url: `${config.domain}:4000/.well-known/apollo/server-health`,
+          url: `${config.domain}/.well-known/apollo/server-health`,
         },
       ],
     });

--- a/infrastructure/shared-snowplow-consumer/src/main.ts
+++ b/infrastructure/shared-snowplow-consumer/src/main.ts
@@ -46,7 +46,11 @@ class SnowplowSharedConsumerStack extends TerraformStack {
     new RemoteBackend(this, {
       hostname: 'app.terraform.io',
       organization: 'Pocket',
-      workspaces: [{ prefix: `${config.name}-` }],
+      workspaces: [
+        {
+          name: `${config.name}-${config.environment}`,
+        },
+      ],
     });
 
     const region = new DataAwsRegion(this, 'region');

--- a/infrastructure/transactional-emails/src/main.ts
+++ b/infrastructure/transactional-emails/src/main.ts
@@ -36,7 +36,11 @@ class TransactionalEmails extends TerraformStack {
     new RemoteBackend(this, {
       hostname: 'app.terraform.io',
       organization: 'Pocket',
-      workspaces: [{ prefix: `${config.name}-` }],
+      workspaces: [
+        {
+          name: `${config.name}-${config.environment}`,
+        },
+      ],
     });
 
     const region = new DataAwsRegion(this, 'region');

--- a/infrastructure/user-api/src/main.ts
+++ b/infrastructure/user-api/src/main.ts
@@ -38,7 +38,11 @@ class UserAPI extends TerraformStack {
     new RemoteBackend(this, {
       hostname: 'app.terraform.io',
       organization: 'Pocket',
-      workspaces: [{ prefix: `${config.name}-` }],
+      workspaces: [
+        {
+          name: `${config.name}-${config.environment}`,
+        },
+      ],
     });
 
     new PocketVPC(this, 'pocket-vpc');


### PR DESCRIPTION
Because we were using a non-default state, terraform was setting a prefix for the s3 backend to something like `env:/Prod/pocket-router` for the pocket-router. Then because of the different run contexts, etc. it was not pulling the correct state file.

We are going to remove the cloud backend, and the naming/account compartmentalization of the s3 buckets for the state files obviates the need for workspace. This change builds the workspace directly in cdktf vs. relying on the environment variable, so that we can do both the s3 and cloud backends without any additional changes.