### PR TITLE
chore(client-api): set blue/green task set termination to 5 mins

### DIFF
--- a/infrastructure/client-api/src/main.ts
+++ b/infrastructure/client-api/src/main.ts
@@ -234,8 +234,7 @@ class ClientAPI extends TerraformStack {
         useCodePipeline: false,
         useTerraformBasedCodeDeploy: false,
         snsNotificationTopicArn: snsTopic.arn,
-        // TODO: Turn this back to 5 after initial deployment
-        successTerminationWaitTimeInMinutes: 60,
+        successTerminationWaitTimeInMinutes: 5,
         notifications: {
           //only notify on failed deploys
           notifyOnFailed: true,


### PR DESCRIPTION
We set it to an hour to give us more validation time, set it to 5 minutes now.