### PR TITLE
feat(annotations): add batchWriteHighlights mutation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -669,6 +669,9 @@ importers:
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@20.10.6)
+      jest-extended:
+        specifier: 4.0.2
+        version: 4.0.2(jest@29.7.0)
       nock:
         specifier: 13.4.0
         version: 13.4.0
@@ -7079,7 +7082,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.4.0-dev.20240109
+      typescript: 5.4.0-dev.20240111
     dev: false
 
   /eastasianwidth@0.2.0:
@@ -12445,8 +12448,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.4.0-dev.20240109:
-    resolution: {integrity: sha512-pKDkvh+RizbUm4BEmfvmG74qycZsHw4oFB6jY9D+oKoxPzoZr/edCTks/t50kvU2RdiDn0UKSzZB4YVzrC9WTQ==}
+  /typescript@5.4.0-dev.20240111:
+    resolution: {integrity: sha512-97UgxVdlXJau9HbNNYghxWHaauDT+50ioh3mepeOfOec6Eq2Hsc4ivTg+N4o4sfVF4MNBJ7rYrejqDvhhrE6aw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false

--- a/servers/annotations-api/package.json
+++ b/servers/annotations-api/package.json
@@ -47,7 +47,8 @@
     "nock": "13.4.0",
     "nodemon": "3.0.2",
     "supertest": "6.3.3",
-    "ts-jest": "29.1.1"
+    "ts-jest": "29.1.1",
+    "jest-extended": "4.0.2"
   },
   "files": [
     "dist",

--- a/servers/annotations-api/schema.graphql
+++ b/servers/annotations-api/schema.graphql
@@ -174,6 +174,27 @@ input UpdateHighlightInput {
   note: String
 }
 
+"""
+Input object for creating and deleting highlights using bulk mutation.
+"""
+input BatchWriteHighlightsInput {
+  delete: [ID!] @constraint(maxItems: 20)
+  create: [CreateHighlightInput!] @constraint(maxItems: 20)
+}
+
+"""
+Result object for bulk create/delete highlights mutation.
+Mutation is atomic -- if there is a response, all operations
+were successful.
+
+The corresponding result array will be empty, but present, if there
+were no requests for created/deleted.
+"""
+type BatchWriteHighlightsResult {
+  deleted: [ID!]!
+  created: [Highlight!]!
+}
+
 type Mutation {
   """
   Create new highlight annotation(s). Returns the data for the created Highlight object(s).
@@ -218,4 +239,12 @@ type Mutation {
   Delete a highlight note by the Highlight ID.
   """
   deleteSavedItemHighlightNote(id: ID!): ID!
+
+  """
+  Make requests to create and delete highlights in a single batch.
+  Mutation is atomic -- if there is a response, all operations were successful.
+  """
+  batchWriteHighlights(
+    input: BatchWriteHighlightsInput
+  ): BatchWriteHighlightsResult!
 }

--- a/servers/annotations-api/src/resolvers.ts
+++ b/servers/annotations-api/src/resolvers.ts
@@ -6,6 +6,8 @@ import {
   Highlight,
   HighlightNote,
   HighlightUpdateInput,
+  BatchWriteHighlightsResult,
+  BatchWriteHighlightsInput,
 } from './types';
 import { HighlightsDataService } from './dataservices/highlights';
 
@@ -114,9 +116,20 @@ export const resolvers = {
       args,
       context: IContext,
     ): Promise<string> => {
-      const dataService = await new HighlightsDataService(context);
+      const dataService = new HighlightsDataService(context);
       await dataService.delete(args.id);
       return context.notesService.delete(args.id);
+    },
+    batchWriteHighlights: async (
+      _,
+      args: { input: BatchWriteHighlightsInput },
+      context: IContext,
+    ): Promise<BatchWriteHighlightsResult> => {
+      const dataService = new HighlightsDataService(context);
+      return await dataService.batchWrite(
+        args.input.delete ?? [],
+        args.input.create ?? [],
+      );
     },
   },
 };

--- a/servers/annotations-api/src/test/mutation/highlights-batchwrite.integration.ts
+++ b/servers/annotations-api/src/test/mutation/highlights-batchwrite.integration.ts
@@ -1,0 +1,368 @@
+import { ApolloServer } from '@apollo/server';
+import request from 'supertest';
+import { print } from 'graphql';
+import { IContext } from '../../context';
+import { startServer } from '../../server';
+import { readClient, writeClient } from '../../database/client';
+import { seedData } from '../query/highlights-fixtures';
+import {
+  BATCH_WRITE_HIGHLIGHTS,
+  CREATE_HIGHLIGHTS,
+} from './highlights-mutations';
+import { BatchWriteHighlightsInput } from '../../types';
+import { UsersMeta } from '../../dataservices/usersMeta';
+import { mysqlTimeString } from '../../dataservices/utils';
+import config from '../../config';
+import { v4 as uuid } from 'uuid';
+
+describe('Highlights batchWrite', () => {
+  let app: Express.Application;
+  let server: ApolloServer<IContext>;
+  let graphQLUrl: string;
+  // Variables/data
+  const baseHeaders = { userId: '1', premium: 'false' };
+  const writeDb = writeClient();
+  const readDb = readClient();
+  const now = new Date();
+  const testData = seedData(now);
+  const truncateAndSeed = async () => {
+    await Promise.all(
+      Object.keys(testData).map((table) => writeDb(table).truncate()),
+    );
+    await Promise.all(
+      Object.entries(testData).map(([table, data]) =>
+        writeDb(table).insert(data),
+      ),
+    );
+  };
+
+  beforeAll(async () => {
+    // port 0 tells express to dynamically assign an available port
+    ({ app, server, url: graphQLUrl } = await startServer(0));
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    await writeDb.destroy();
+    await readDb.destroy();
+  });
+
+  beforeEach(async () => {
+    await truncateAndSeed();
+  });
+
+  afterEach(async () => {
+    jest.useRealTimers();
+  });
+
+  describe('any user', () => {
+    const headers = baseHeaders;
+    it('should create a highlight on a SavedItem without any existing highlights', async () => {
+      const variables: { input: BatchWriteHighlightsInput } = {
+        input: {
+          create: [
+            {
+              itemId: '3',
+              version: 2,
+              patch: 'Prow scuttle parrel',
+              quote: 'provost Sail ho shrouds spirits boom',
+            },
+          ],
+        },
+      };
+      const res = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({ query: print(BATCH_WRITE_HIGHLIGHTS), variables });
+      const result = res.body.data?.batchWriteHighlights;
+
+      const expected = {
+        deleted: [],
+        created: expect.toIncludeSameMembers([
+          {
+            id: expect.toBeString(),
+            version: 2,
+            patch: 'Prow scuttle parrel',
+            quote: 'provost Sail ho shrouds spirits boom',
+            _createdAt: expect.toBePositive(),
+            _updatedAt: expect.toBePositive(),
+          },
+        ]),
+      };
+      expect(result).toEqual(expected);
+    });
+    it('should optionally accept a UUID passed from the client and use for the ID', async () => {
+      const id = uuid();
+      const variables: { input: BatchWriteHighlightsInput } = {
+        input: {
+          create: [
+            {
+              id,
+              itemId: '3',
+              version: 2,
+              patch: 'Prow scuttle parrel',
+              quote: 'provost Sail ho shrouds spirits boom',
+            },
+          ],
+        },
+      };
+      const res = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({ query: print(BATCH_WRITE_HIGHLIGHTS), variables });
+      const result = res.body.data?.batchWriteHighlights;
+
+      const expected = {
+        deleted: [],
+        created: expect.toIncludeSameMembers([
+          {
+            id,
+            version: 2,
+            patch: 'Prow scuttle parrel',
+            quote: 'provost Sail ho shrouds spirits boom',
+            _createdAt: expect.toBePositive(),
+            _updatedAt: expect.toBePositive(),
+          },
+        ]),
+      };
+      expect(result).toEqual(expected);
+    });
+    it('should not overrwrite an existing highlight', async () => {
+      const seed = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(CREATE_HIGHLIGHTS),
+          variables: {
+            input: [
+              {
+                id: uuid(),
+                itemId: '1',
+                version: 2,
+                patch: 'Prow scuttle parrel',
+                quote: 'provost Sail ho shrouds spirits boom',
+              },
+            ],
+          },
+        });
+      const seedResult = seed.body.data?.createSavedItemHighlights;
+      expect(seedResult.length).toEqual(1);
+      const id = seedResult[0].id;
+      const variables = {
+        input: {
+          create: [
+            {
+              id,
+              itemId: '1',
+              version: 2,
+              patch: 'Prow scuttle parrel',
+              quote: 'Bring a spring upon her cable holystone',
+            },
+          ],
+        },
+      };
+      const res = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({ query: print(BATCH_WRITE_HIGHLIGHTS), variables });
+      const result = res.body.errors;
+      expect(result.length).toBe(1);
+      expect(result[0].extensions.code).toBe('INTERNAL_SERVER_ERROR');
+    });
+    it('should create a highlight on a SavedItem with existing highlights', async () => {
+      const variables: { input: BatchWriteHighlightsInput } = {
+        input: {
+          create: [
+            {
+              itemId: '1',
+              version: 2,
+              patch: 'Prow scuttle parrel',
+              quote: 'provost Sail ho shrouds spirits boom',
+            },
+          ],
+        },
+      };
+      const res = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({ query: print(BATCH_WRITE_HIGHLIGHTS), variables });
+      const result = res.body.data?.batchWriteHighlights.created;
+
+      expect(result.length).toEqual(1);
+      expect(result[0].quote).toBe('provost Sail ho shrouds spirits boom');
+    });
+    it('should mark the list item as updated and log the highlight mutation', async () => {
+      const updateDate = new Date(2022, 3, 3);
+
+      jest.useFakeTimers({
+        now: updateDate,
+        advanceTimers: true,
+      });
+
+      const variables: { input: BatchWriteHighlightsInput } = {
+        input: {
+          create: [
+            {
+              itemId: '3',
+              version: 2,
+              patch: 'Prow scuttle parrel',
+              quote: 'provost Sail ho shrouds spirits boom',
+            },
+          ],
+        },
+      };
+      await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({ query: print(BATCH_WRITE_HIGHLIGHTS), variables });
+      const usersMetaRecord = await writeDb('users_meta')
+        .where({ user_id: '1', property: UsersMeta.propertiesMap.account })
+        .pluck('value');
+
+      const listRecord = await writeDb('list')
+        .where({ user_id: '1', item_id: '3' })
+        .pluck('time_updated');
+
+      expect(mysqlTimeString(listRecord[0])).toEqual(
+        mysqlTimeString(updateDate, config.database.tz),
+      );
+      expect(usersMetaRecord[0]).toEqual(
+        mysqlTimeString(updateDate, config.database.tz),
+      );
+    });
+    it('should delete an existing highlight', async () => {
+      const variables = {
+        input: {
+          delete: ['b3a95dd3-dd9b-49b0-bb72-dc6daabd809b'],
+        },
+      };
+      const res = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({ query: print(BATCH_WRITE_HIGHLIGHTS), variables });
+      const result = res.body.data?.batchWriteHighlights;
+
+      const expected = {
+        deleted: ['b3a95dd3-dd9b-49b0-bb72-dc6daabd809b'],
+        created: [],
+      };
+      expect(result).toEqual(expected);
+    });
+    it('should delete and create highlights at the same time', async () => {
+      const createInput = [
+        {
+          version: 2,
+          patch: 'broadside cable strike colors',
+          quote: 'Case shot Shiver me timbers gangplank',
+        },
+        {
+          version: 2,
+          patch: 'Prow scuttle parrel',
+          quote: 'provost Sail ho shrouds spirits boom',
+        },
+      ];
+      const variables = {
+        input: {
+          delete: [
+            'b3a95dd3-dd9b-49b0-bb72-dc6daabd809b',
+            'aafa87bc-9742-416c-a517-e3cd801f2761',
+          ],
+          create: [
+            {
+              itemId: '3',
+              ...createInput[0],
+            },
+            {
+              itemId: '1',
+              ...createInput[1],
+            },
+          ],
+        },
+      };
+      const res = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({ query: print(BATCH_WRITE_HIGHLIGHTS), variables });
+      const result = res.body.data?.batchWriteHighlights;
+
+      const matchers = {
+        id: expect.toBeString(),
+        _createdAt: expect.toBePositive(),
+        _updatedAt: expect.toBePositive(),
+      };
+
+      const expected = {
+        deleted: expect.toIncludeSameMembers(variables.input.delete),
+        created: expect.toIncludeSameMembers(
+          createInput.map((create) => ({ ...create, ...matchers })),
+        ),
+      };
+      expect(result).toEqual(expected);
+    });
+    it('should not error if deleting a non-existent highlight', async () => {
+      const variables = {
+        input: {
+          delete: ['b3a95dd3-dd9b-49b0-bb72-dc6daabd809b', 'obviously-fake-id'],
+        },
+      };
+      const res = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({ query: print(BATCH_WRITE_HIGHLIGHTS), variables });
+      const result = res.body.data?.batchWriteHighlights;
+
+      const expected = {
+        deleted: ['b3a95dd3-dd9b-49b0-bb72-dc6daabd809b', 'obviously-fake-id'],
+        created: [],
+      };
+      expect(result).toEqual(expected);
+    });
+    it('should roll back to initial state if any error', async () => {
+      const id = uuid();
+      const variables = {
+        input: {
+          delete: ['b3a95dd3-dd9b-49b0-bb72-dc6daabd809b'],
+          create: [
+            {
+              // Collision, will error out
+              id: 'aafa87bc-9742-416c-a517-e3cd801f2761',
+              itemId: '2',
+              version: 2,
+              patch: 'broadside cable strike colors',
+              quote: 'Case shot Shiver me timbers gangplank',
+            },
+            {
+              id,
+              itemId: '1',
+              version: 2,
+              patch: 'Prow scuttle parrel',
+              quote: 'provost Sail ho shrouds spirits boom',
+            },
+          ],
+        },
+      };
+      const res = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({ query: print(BATCH_WRITE_HIGHLIGHTS), variables });
+      expect(res.body.errors).toBeArrayOfSize(1);
+      expect(res.body.errors[0].extensions.code).toBe('INTERNAL_SERVER_ERROR');
+      const notDeleted = await readDb('user_annotations').where({
+        annotation_id: 'b3a95dd3-dd9b-49b0-bb72-dc6daabd809b',
+      });
+      expect(notDeleted).toBeArrayOfSize(1);
+      const notChanged = await readDb('user_annotations')
+        .where({
+          annotation_id: 'aafa87bc-9742-416c-a517-e3cd801f2761',
+        })
+        .first();
+      expect(notChanged['quote']).toEqual(
+        'You and a thousand of your friends would have to work for a century or so to reproduce it.',
+      );
+      const notAdded = await readDb('user_annotations').where({
+        annotation_id: id,
+      });
+      expect(notAdded).toBeArrayOfSize(0);
+    });
+  });
+});

--- a/servers/annotations-api/src/test/mutation/highlights-mutations.ts
+++ b/servers/annotations-api/src/test/mutation/highlights-mutations.ts
@@ -56,3 +56,19 @@ export const DELETE_HIGHLIGHT = gql`
     deleteSavedItemHighlight(id: $id)
   }
 `;
+
+export const BATCH_WRITE_HIGHLIGHTS = gql`
+  mutation batchWriteHighlights($input: BatchWriteHighlightsInput) {
+    batchWriteHighlights(input: $input) {
+      deleted
+      created {
+        id
+        patch
+        version
+        quote
+        _createdAt
+        _updatedAt
+      }
+    }
+  }
+`;

--- a/servers/annotations-api/src/types.ts
+++ b/servers/annotations-api/src/types.ts
@@ -62,3 +62,13 @@ export type NoteInput = {
   id: string;
   input: string;
 };
+
+export type BatchWriteHighlightsInput = {
+  delete?: string[];
+  create?: HighlightInput[];
+};
+
+export type BatchWriteHighlightsResult = {
+  deleted: string[];
+  created: Highlight[];
+};

--- a/servers/annotations-api/tsconfig.json
+++ b/servers/annotations-api/tsconfig.json
@@ -4,11 +4,7 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "exclude": [
-    "node_modules/",
-    "dist/"
-  ],
-  "include": [
-    "src/**/*.ts", 
-  ]
+  "exclude": ["node_modules/", "dist/"],
+  "include": ["src/**/*.ts"],
+  "files": ["node_modules/jest-extended/types/index.d.ts"]
 }


### PR DESCRIPTION
Add batchWriteHighlights mutation - enables deleting and creating multiple highlights at once.

Done in a single transaction, so either everything failed or everything succeeded.

**WILL NOT CREATE NOTES** (since this feature isn't accepted formally I didn't want to waste time on it).

[POCKET-9272]

[POCKET-9272]: https://mozilla-hub.atlassian.net/browse/POCKET-9272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ