### PR TITLE
chore(deps): make renovate group & not digest docker-compose

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>Pocket/renovate-config"
+    "local>Pocket/renovate-config",
+    "group:monorepos"
   ],
   "packageRules": [{
     "managers": ["docker-compose"],
-    "updateTypes": ["digest"],
+    "updateTypes": ["digest", "pinDigest"],
     "enabled": false
   }]
 }


### PR DESCRIPTION
## Goal

* Disable pinning of docker-compose digests, we want that to pull native architecture images for development so those on M1's dont have to emulate x64
* Get opentelemetry and any other monorepos grouped together.