### PR TITLE
fix(annotations-api): fixing flakey annotations tests

### DIFF
--- a/servers/annotations-api/src/test/mutation/highlights-batchwrite.integration.ts
+++ b/servers/annotations-api/src/test/mutation/highlights-batchwrite.integration.ts
@@ -284,6 +284,7 @@ describe('Highlights batchWrite', () => {
         .set(headers)
         .send({ query: print(BATCH_WRITE_HIGHLIGHTS), variables });
       const result = res.body.data?.batchWriteHighlights;
+      expect(res.body.errors).toBeUndefined();
 
       const matchers = {
         id: expect.toBeString(),

--- a/servers/annotations-api/src/test/mutation/highlights-create.integration.ts
+++ b/servers/annotations-api/src/test/mutation/highlights-create.integration.ts
@@ -201,11 +201,8 @@ describe('Highlights creation', () => {
 
     it('should mark the list item as updated and log the highlight mutation', async () => {
       const updateDate = new Date(2022, 3, 3);
-
-      jest.useFakeTimers({
-        now: updateDate,
-        advanceTimers: true,
-      });
+      jest.useFakeTimers({advanceTimers: true});
+      jest.setSystemTime(updateDate);
 
       const variables: { input: HighlightInput[] } = {
         input: [
@@ -221,11 +218,11 @@ describe('Highlights creation', () => {
         .post(graphQLUrl)
         .set(headers)
         .send({ query: print(CREATE_HIGHLIGHTS), variables });
-      const usersMetaRecord = await writeDb('users_meta')
+      const usersMetaRecord = await readDb('users_meta')
         .where({ user_id: '1', property: UsersMeta.propertiesMap.account })
         .pluck('value');
 
-      const listRecord = await writeDb('list')
+      const listRecord = await readDb('list')
         .where({ user_id: '1', item_id: '3' })
         .pluck('time_updated');
 

--- a/servers/annotations-api/src/test/query/highlights-fixtures.ts
+++ b/servers/annotations-api/src/test/query/highlights-fixtures.ts
@@ -1,4 +1,6 @@
 import { gql } from 'graphql-tag';
+import { mysqlTimeString } from '../../dataservices/utils';
+import config from '../../config';
 
 export const GET_HIGHLIGHTS = gql`
   query GetHighlights($itemId: ID) {
@@ -19,6 +21,13 @@ export const GET_HIGHLIGHTS = gql`
   }
 `;
 export const seedData = (now) => ({
+  users_meta: [{
+    user_id: 1,
+    property: 41,
+    value: mysqlTimeString(now, config.database.tz),
+    time_updated: now, // Web repo uses NOW() instead of server timestamp
+  }
+  ],
   user_annotations: [
     {
       // One highlight on an item


### PR DESCRIPTION
## Goal

Annotations api had some flakey tests that were inhibiting prs and causing us to re-run them 

https://mozilla-hub.atlassian.net/browse/POCKET-9477

## Findings

### Batch Writes
This was causing 2 calls to the logAnnotationMutation that was hit intermittently based on what tests ran before  the batch tests. I got the test to always fail by adding users_meta to the seed list which caused a duplicate key error on every run. 

It seems that something about how a transaction runs it wasnt always deleting the old value first if logAnnotationMutation was called multiple times. I fixed this by only calling it once from the batch call, and making other calls conditional.

### system time

For some reason the createHighlight test had issues with Jest.fake timers unless I called setSystemTime.. no idea why. but in local testing this worked