### PR TITLE
fix(deletion): temporarily pause full deletion

### DIFF
--- a/servers/account-data-deleter/src/server.ts
+++ b/servers/account-data-deleter/src/server.ts
@@ -30,7 +30,7 @@ app.use('/queueDelete', queueDeleteRouter);
 app.use('/stripeDelete', stripeDeleteRouter);
 
 // Start batch delete event handler
-new BatchDeleteHandler(new EventEmitter());
+// new BatchDeleteHandler(new EventEmitter());
 
 // Start Express app
 app


### PR DESCRIPTION
## Goal

Pocket is about to perform database maintaince. During this time we want to limit all database traffic. This temporarily pauses our background deletion queue.

In the future this will be turned into a feature flag.