### PR TITLE
fix(list-api): switching off list-api codepipeline

### DIFF
--- a/infrastructure/list-api/src/main.ts
+++ b/infrastructure/list-api/src/main.ts
@@ -339,7 +339,7 @@ class ListAPI extends TerraformStack {
       ],
       codeDeploy: {
         useCodeDeploy: true,
-        useCodePipeline: true,
+        useCodePipeline: false,
         useTerraformBasedCodeDeploy: false,
         notifications: {
           notifyOnFailed: true,


### PR DESCRIPTION
## Goal

Saw I forgot to turn off list-api use codepipeline and it was causing terraform to think a destroy was needed instead of a replace (service was still deploying just fine though)