### PR TITLE
fix(terraform-modules): ensuring that the modules does not synth

### DIFF
--- a/packages/terraform-modules/package.json
+++ b/packages/terraform-modules/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build:dev": "rm -rf dist && NODE_ENV=development npm run synth",
     "build": "tsup src/index.ts --format cjs,esm --dts",
-    "synth": "cdktf synth",
+    "example:synth": "cdktf synth",
     "compile": "tsc --pretty",
     "test:watch": "npm test -- --watch --watch-extensions ts -R min --watch-files src",
     "test": "jest --ci --maxWorkers=4 --logHeapUsage",


### PR DESCRIPTION
## Goal

I noticed that the terraform modules was synth'ing during terraform plans/apply cause it had a synth script defined. This just renames it to avoid that conflict.