### PR TITLE
fix(client-api): do not set headers to empty string

### DIFF
--- a/servers/client-api/rhai/claims_forwarding.rhai
+++ b/servers/client-api/rhai/claims_forwarding.rhai
@@ -27,8 +27,9 @@ fn process_request(request) {
         claim = claim.reduce(|concat, v|
           if concat == () { v.to_string() } else { concat + `,${v}`});
       }
-      claim = if claim == () {""} else {claim};
-      request.subgraph.headers[claim_names_map[claim_name]] = claim.to_string();
+      if (claim != ()) { 
+        request.subgraph.headers[claim_names_map[claim_name]] = claim.to_string() 
+      };
     }
     // Indicate if the subject is a Mozilla account ID (formerly Firefox Account)
     if (claims["iss"] == "fxa-webhook-proxy") {


### PR DESCRIPTION
Our downstream services, like user-api, expect
to receive undefined and not empty strings.