### PR TITLE
feat(shareablelists): uniquenes logic in db model

### DIFF
--- a/servers/shareable-lists-api/prisma/migrations/20240124212856_item_unique_per_list/migration.sql
+++ b/servers/shareable-lists-api/prisma/migrations/20240124212856_item_unique_per_list/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[listId,itemId]` on the table `ListItem` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX `ListItem_listId_itemId_key` ON `ListItem`(`listId`, `itemId`);

--- a/servers/shareable-lists-api/prisma/schema.prisma
+++ b/servers/shareable-lists-api/prisma/schema.prisma
@@ -77,6 +77,12 @@ model ListItem {
 
   // *** Additional indexes and constraints ***
   @@unique([externalId])
+  // Ideally this would be listId and url,
+  // but we can't do generated columns with Prisma
+  // (e.g. making a hash column from url),
+  // and the url column has too many bytes to be used
+  // in a uniquenes constraint.
+  @@unique([listId, itemId])
 }
 
 model PilotUser {


### PR DESCRIPTION
Only allow an itemId to appear once per list.

Would be preferable to use a generated column
which contains the URL hash, but prisma does not
support this feature.