### PR TITLE
fix(shareablelists): use db for uuid generation

### DIFF
--- a/servers/shareable-lists-api/prisma/migrations/20240124225016_db_default_uuid/migration.sql
+++ b/servers/shareable-lists-api/prisma/migrations/20240124225016_db_default_uuid/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `externalId` on the `List` table. The data in that column could be lost. The data in that column will be cast from `VarChar(255)` to `VarChar(36)`.
+  - You are about to alter the column `externalId` on the `ListItem` table. The data in that column could be lost. The data in that column will be cast from `VarChar(255)` to `VarChar(36)`.
+
+*/
+-- AlterTable
+ALTER TABLE `List` MODIFY `externalId` VARCHAR(36) NOT NULL DEFAULT (UUID());
+
+-- AlterTable
+ALTER TABLE `ListItem` MODIFY `externalId` VARCHAR(36) NOT NULL DEFAULT (UUID());

--- a/servers/shareable-lists-api/prisma/schema.prisma
+++ b/servers/shareable-lists-api/prisma/schema.prisma
@@ -25,7 +25,7 @@ model List {
   // Prisma needs an integer ID to make relationships between tables
   id                     BigInt           @id @default(autoincrement())
   // This is our public-facing ID for use in Admin Tools and Snowplow event reporting
-  externalId             String           @default(uuid()) @db.VarChar(255)
+  externalId             String           @default(dbgenerated("(UUID())")) @db.VarChar(36)
   // This is the Pocket ID. Sourced externally from a mutation input
   userId                 BigInt
   slug                   String?          @db.VarChar(300)
@@ -55,7 +55,7 @@ model ListItem {
   // Prisma needs an integer ID to make relationships between tables
   id         BigInt   @id @default(autoincrement())
   // This is our public-facing ID for use in Admin Tools and Snowplow event reporting
-  externalId String   @default(uuid()) @db.VarChar(255)
+  externalId String   @default(dbgenerated("(UUID())")) @db.VarChar(36)
   // The link to the parent List
   listId     BigInt
   // Required ID of Parser Item and Item props outside of this subgraph's control


### PR DESCRIPTION
Avoid relying on prisma, so that we are not
locked into the ORM.