### PR TITLE
fix(sha1): specifiying the git sha1 in the task definition

### DIFF
--- a/infrastructure/account-data-deleter/src/config/index.ts
+++ b/infrastructure/account-data-deleter/src/config/index.ts
@@ -8,10 +8,10 @@ const domainPrefix = 'account-data-deleter-api';
 const domain = isDev
   ? `${domainPrefix}.getpocket.dev`
   : `${domainPrefix}.readitlater.com`;
-
 const userApiDomain = isDev
   ? `user-api.getpocket.dev`
   : `user-api.readitlater.com`;
+const releaseSha = process.env.CIRCLE_SHA1;
 
 export const config = {
   name,
@@ -20,6 +20,7 @@ export const config = {
   circleCIPrefix: `/${name}/CircleCI/${environment}`,
   constructName,
   domain,
+  releaseSha,
   dynamodb: {
     historicalDeletedUsers: {
       tableName: 'HistoricalDeletedUsers-Pending',

--- a/infrastructure/account-data-deleter/src/dataDeleterApp.ts
+++ b/infrastructure/account-data-deleter/src/dataDeleterApp.ts
@@ -88,6 +88,7 @@ export class DataDeleterApp extends Construct {
       containerConfigs: [
         {
           name: 'app',
+          imageSha: config.releaseSha,
           envVars: [
             {
               name: 'AWS_XRAY_CONTEXT_MISSING',

--- a/infrastructure/annotations-api/src/config/index.ts
+++ b/infrastructure/annotations-api/src/config/index.ts
@@ -11,6 +11,7 @@ const cacheNodes = isDev ? 2 : 2;
 const cacheSize = isDev ? 'cache.t3.micro' : 'cache.t3.micro';
 const appPort = 4008;
 const s3LogsBucket = isDev ? 'pocket-data-items-dev' : 'pocket-data-items';
+const releaseSha = process.env.CIRCLE_SHA1;
 
 export const config = {
   name,
@@ -27,6 +28,7 @@ export const config = {
   s3LogsBucket,
   reservedConcurrencyLimit: 1,
   cacheSize,
+  releaseSha,
   healthCheck: {
     command: [
       'CMD-SHELL',

--- a/infrastructure/annotations-api/src/main.ts
+++ b/infrastructure/annotations-api/src/main.ts
@@ -257,6 +257,7 @@ class AnnotationsAPI extends TerraformStack {
       containerConfigs: [
         {
           name: 'app',
+          imageSha: config.releaseSha,
           portMappings: [
             {
               hostPort: config.port,

--- a/infrastructure/client-api/src/config/index.ts
+++ b/infrastructure/client-api/src/config/index.ts
@@ -8,6 +8,7 @@ const domain = isDev
 const graphqlVariant = isDev ? 'development' : 'current';
 const isProd = process.env.NODE_ENV === 'production';
 const s3LogsBucket = isDev ? 'pocket-data-items-dev' : 'pocket-data-items';
+const releaseSha = process.env.CIRCLE_SHA1;
 
 //Arbitrary size and count for cache. No logic was used in deciding this.
 /*
@@ -37,6 +38,7 @@ export const config = {
   cacheSize,
   s3LogsBucket,
   isDev,
+  releaseSha,
   tags: {
     service: name,
     environment,

--- a/infrastructure/client-api/src/main.ts
+++ b/infrastructure/client-api/src/main.ts
@@ -147,6 +147,7 @@ class ClientAPI extends TerraformStack {
       containerConfigs: [
         {
           name: 'app',
+          imageSha: config.releaseSha,
           portMappings: [
             {
               hostPort: 4001,

--- a/infrastructure/feature-flags/src/config/index.ts
+++ b/infrastructure/feature-flags/src/config/index.ts
@@ -10,10 +10,7 @@ const rds = {
   minCapacity: 2,
   maxCapacity: isDev ? 2 : 16,
 };
-const githubConnectionArn = isDev
-  ? 'arn:aws:codestar-connections:us-east-1:410318598490:connection/7426c139-1aa0-49e2-aabc-5aef11092032'
-  : 'arn:aws:codestar-connections:us-east-1:996905175585:connection/5fa5aa2b-a2d2-43e3-ab5a-72ececfc1870';
-const branch = isDev ? 'dev' : 'main';
+const releaseSha = process.env.CIRCLE_SHA1;
 
 export const config = {
   name,
@@ -25,11 +22,7 @@ export const config = {
   domain,
   graphqlVariant,
   rds,
-  codePipeline: {
-    githubConnectionArn,
-    repository: 'pocket/feature-flags',
-    branch,
-  },
+  releaseSha,
   tags: {
     service: name,
     environment,

--- a/infrastructure/feature-flags/src/main.ts
+++ b/infrastructure/feature-flags/src/main.ts
@@ -148,6 +148,7 @@ class FeatureFlags extends TerraformStack {
       containerConfigs: [
         {
           name: 'app',
+          imageSha: config.releaseSha,
           portMappings: [
             {
               hostPort: 4242,

--- a/infrastructure/image-api/src/config/index.ts
+++ b/infrastructure/image-api/src/config/index.ts
@@ -8,10 +8,7 @@ const domain = isDev
   ? `${domainPrefix}.getpocket.dev`
   : `${domainPrefix}.readitlater.com`;
 const graphqlVariant = isDev ? 'development' : 'current';
-const githubConnectionArn = isDev
-  ? 'arn:aws:codestar-connections:us-east-1:410318598490:connection/7426c139-1aa0-49e2-aabc-5aef11092032'
-  : 'arn:aws:codestar-connections:us-east-1:996905175585:connection/5fa5aa2b-a2d2-43e3-ab5a-72ececfc1870';
-const branch = isDev ? 'dev' : 'main';
+const releaseSha = process.env.CIRCLE_SHA1;
 
 const appPort = 4867;
 
@@ -32,11 +29,7 @@ export const config = {
   graphqlVariant,
   cacheNodes,
   cacheSize,
-  codePipeline: {
-    githubConnectionArn,
-    repository: 'pocket/image-api',
-    branch,
-  },
+  releaseSha,
   tags: {
     service: name,
     environment,

--- a/infrastructure/image-api/src/main.ts
+++ b/infrastructure/image-api/src/main.ts
@@ -164,6 +164,7 @@ class ImageAPI extends TerraformStack {
       containerConfigs: [
         {
           name: 'app',
+          imageSha: config.releaseSha,
           portMappings: [
             {
               hostPort: config.appPort,

--- a/infrastructure/list-api/src/config/index.ts
+++ b/infrastructure/list-api/src/config/index.ts
@@ -7,10 +7,7 @@ const domain = isDev
   ? `${domainPrefix}.getpocket.dev`
   : `${domainPrefix}.readitlater.com`;
 const graphqlVariant = isDev ? 'development' : 'current';
-const githubConnectionArn = isDev
-  ? 'arn:aws:codestar-connections:us-east-1:410318598490:connection/7426c139-1aa0-49e2-aabc-5aef11092032'
-  : 'arn:aws:codestar-connections:us-east-1:996905175585:connection/5fa5aa2b-a2d2-43e3-ab5a-72ececfc1870';
-const branch = isDev ? 'dev' : 'main';
+const releaseSha = process.env.CIRCLE_SHA1;
 
 export const config = {
   name,
@@ -18,7 +15,7 @@ export const config = {
   prefix,
   circleCIPrefix: `/${name}/CircleCI/${environment}`,
   shortName: 'LSTAPI',
-
+  releaseSha,
   environment,
   rds: {
     minCapacity: 1,
@@ -28,11 +25,6 @@ export const config = {
   },
   domain,
   graphqlVariant,
-  codePipeline: {
-    githubConnectionArn,
-    repository: 'pocket/list-api',
-    branch,
-  },
   tags: {
     service: name,
     environment,

--- a/infrastructure/list-api/src/main.ts
+++ b/infrastructure/list-api/src/main.ts
@@ -204,6 +204,7 @@ class ListAPI extends TerraformStack {
       containerConfigs: [
         {
           name: 'app',
+          imageSha: config.releaseSha,
           portMappings: [
             {
               hostPort: 4005,

--- a/infrastructure/parser-graphql-wrapper/src/config/index.ts
+++ b/infrastructure/parser-graphql-wrapper/src/config/index.ts
@@ -7,6 +7,7 @@ const domain = isDev
   ? `${domainPrefix}.getpocket.dev`
   : `${domainPrefix}.readitlater.com`;
 const graphqlVariant = isDev ? 'development' : 'current';
+const releaseSha = process.env.CIRCLE_SHA1;
 
 const cacheNodes = 2;
 const cacheSize = isDev ? 'cache.t3.micro' : 'cache.m6g.large';
@@ -19,6 +20,7 @@ export const config = {
   graphqlVariant,
   isDev,
   isProd,
+  releaseSha,
   environment,
   domain,
   cacheNodes,

--- a/infrastructure/parser-graphql-wrapper/src/main.ts
+++ b/infrastructure/parser-graphql-wrapper/src/main.ts
@@ -164,6 +164,7 @@ class ParserGraphQLWrapper extends TerraformStack {
       containerConfigs: [
         {
           name: 'app',
+          imageSha: config.releaseSha,
           envVars: [
             {
               name: 'AWS_XRAY_CONTEXT_MISSING',

--- a/infrastructure/shareable-lists-api/src/config/index.ts
+++ b/infrastructure/shareable-lists-api/src/config/index.ts
@@ -12,6 +12,7 @@ const rds = {
   maxCapacity: isDev ? 1 : undefined,
 };
 const eventBusName = `PocketEventBridge-${environment}-Shared-Event-Bus`;
+const releaseSha = process.env.CIRCLE_SHA1;
 
 const cacheNodes = isDev ? 2 : 2;
 const cacheSize = isDev ? 'cache.t3.micro' : 'cache.t3.micro';
@@ -23,6 +24,7 @@ export const config = {
   prefix: `${name}-${environment}`,
   circleCIPrefix: `/${name}/CircleCI/${environment}`,
   shortName: 'SLAPI',
+  releaseSha,
   environment,
   domain,
   graphqlVariant,

--- a/infrastructure/shareable-lists-api/src/main.ts
+++ b/infrastructure/shareable-lists-api/src/main.ts
@@ -259,6 +259,7 @@ class ShareableListsAPI extends TerraformStack {
       containerConfigs: [
         {
           name: 'app',
+          imageSha: config.releaseSha,
           portMappings: [
             {
               hostPort: 4029,

--- a/infrastructure/shared-snowplow-consumer/src/config/index.ts
+++ b/infrastructure/shared-snowplow-consumer/src/config/index.ts
@@ -5,7 +5,7 @@ const environment = isDev ? 'Dev' : 'Prod';
 const domain = isDev
   ? `${domainPrefix}.getpocket.dev`
   : `${domainPrefix}.readitlater.com`;
-const graphqlVariant = isDev ? 'development' : 'current';
+const releaseSha = process.env.CIRCLE_SHA1;
 
 //Arbitrary size and count for cache. No logic was used in deciding this.
 const cacheNodes = isDev ? 2 : 2;
@@ -22,9 +22,9 @@ export const config = {
   prefix: `${name}-${environment}`,
   circleCIPrefix: `/${name}/CircleCI/${environment}`,
   shortName: 'SSPC', //change to your service name, limit to 6 characters, match shared-infrastructure short name
+  releaseSha,
   environment,
   domain,
-  graphqlVariant,
   cacheNodes,
   cacheSize,
   tracing: {

--- a/infrastructure/shared-snowplow-consumer/src/sharedSnowplowConsumerApp.ts
+++ b/infrastructure/shared-snowplow-consumer/src/sharedSnowplowConsumerApp.ts
@@ -55,6 +55,7 @@ export class SharedSnowplowConsumerApp extends Construct {
       containerConfigs: [
         {
           name: 'app',
+          imageSha: config.releaseSha,
           logMultilinePattern: '^\\S.+',
           logGroup: this.createCustomLogGroup('app'),
           portMappings: [

--- a/infrastructure/transactional-emails/src/transactionalEmailSQSLambda.ts
+++ b/infrastructure/transactional-emails/src/transactionalEmailSQSLambda.ts
@@ -30,7 +30,7 @@ export class TransactionalEmailSQSLambda extends Construct {
       },
       functionResponseTypes: ['ReportBatchItemFailures'],
       lambda: {
-        runtime: LAMBDA_RUNTIMES.NODEJS16,
+        runtime: LAMBDA_RUNTIMES.NODEJS18,
         handler: 'index.handler',
         timeout: 120,
         environment: {

--- a/infrastructure/user-api/src/config/index.ts
+++ b/infrastructure/user-api/src/config/index.ts
@@ -6,29 +6,21 @@ const domain = isDev
   ? `${domainPrefix}.getpocket.dev`
   : `${domainPrefix}.readitlater.com`;
 const graphqlVariant = isDev ? 'development' : 'current';
-const githubConnectionArn = isDev
-  ? 'arn:aws:codestar-connections:us-east-1:410318598490:connection/7426c139-1aa0-49e2-aabc-5aef11092032'
-  : 'arn:aws:codestar-connections:us-east-1:996905175585:connection/5fa5aa2b-a2d2-43e3-ab5a-72ececfc1870';
 const pinpointApplicationId = isDev
   ? '6458063ecdc74e4eac884ee18933cd6a'
   : '5c59691a6a7b421c9eef4467fb61d499';
-const branch = isDev ? 'dev' : 'main';
 const eventBusName = `PocketEventBridge-${environment}-Shared-Event-Bus`;
+const releaseSha = process.env.CIRCLE_SHA1;
 
 export const config = {
   name,
   prefix: `${name}-${environment}`,
   circleCIPrefix: `/${name}/CircleCI/${environment}`,
   shortName: 'USRAPI',
-
+  releaseSha,
   environment,
   domain,
   graphqlVariant,
-  codePipeline: {
-    githubConnectionArn,
-    repository: 'pocket/user-api',
-    branch,
-  },
   database: {
     port: '3306',
   },

--- a/infrastructure/user-api/src/main.ts
+++ b/infrastructure/user-api/src/main.ts
@@ -16,7 +16,6 @@ import { DataAwsSnsTopic } from '@cdktf/provider-aws/lib/data-aws-sns-topic';
 import { config } from './config';
 import {
   PocketALBApplication,
-  PocketECSCodePipeline,
   PocketPagerDuty,
   PocketVPC,
 } from '@pocket-tools/terraform-modules';
@@ -83,22 +82,6 @@ class UserAPI extends TerraformStack {
   }
 
   /**
-   * Create CodePipeline to build and deploy terraform and ecs
-   * @param app
-   * @private
-   */
-  private createApplicationCodePipeline(app: PocketALBApplication) {
-    new PocketECSCodePipeline(this, 'code-pipeline', {
-      prefix: config.prefix,
-      source: {
-        codeStarConnectionArn: config.codePipeline.githubConnectionArn,
-        repository: config.codePipeline.repository,
-        branchName: config.codePipeline.branch,
-      },
-    });
-  }
-
-  /**
    * Create PagerDuty service for alerts
    * @private
    */
@@ -150,6 +133,7 @@ class UserAPI extends TerraformStack {
       containerConfigs: [
         {
           name: 'app',
+          imageSha: config.releaseSha,
           portMappings: [
             {
               hostPort: 4006,

--- a/packages/terraform-modules/src/base/ApplicationECSContainerDefinition.ts
+++ b/packages/terraform-modules/src/base/ApplicationECSContainerDefinition.ts
@@ -41,6 +41,7 @@ interface Ulimit {
 
 export interface ApplicationECSContainerDefinitionProps {
   containerImage?: string;
+  imageSha?: string;
   logDatetimeFormat?: string;
   logGroup?: string;
   logGroupRegion?: string;

--- a/packages/terraform-modules/src/base/ApplicationECSService.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationECSService.spec.ts
@@ -155,6 +155,45 @@ describe('ApplicationECSService', () => {
     expect(synthed).toMatchSnapshot();
   });
 
+  it('renders an ECS service without an image container definition props and with a sha specified', () => {
+    BASE_CONFIG.launchType = 'ROCKET';
+    BASE_CONFIG.deploymentMaximumPercent = 400;
+    BASE_CONFIG.deploymentMinimumHealthyPercent = 80;
+    BASE_CONFIG.desiredCount = 4;
+    BASE_CONFIG.lifecycleIgnoreChanges = ['bowling', 'donnie', 'autobahn'];
+    BASE_CONFIG.containerConfigs = [
+      {
+        portMappings: [
+          {
+            containerPort: 3002,
+            hostPort: 3001,
+          },
+        ],
+        logGroup: 'test/log/group',
+        name: 'lebowski',
+        imageSha: '123asdasdasd24432',
+        repositoryCredentialsParam: 'someArn',
+        envVars: [
+          {
+            name: 'rug',
+            value: 'tiedtheroomtogether',
+          },
+        ],
+        secretEnvVars: [
+          {
+            name: 'donnie',
+            valueFrom: 'throwinrockstonight',
+          },
+        ],
+      },
+    ];
+
+    const synthed = Testing.synthScope((stack) => {
+      new ApplicationECSService(stack, 'testECSService', BASE_CONFIG);
+    });
+    expect(synthed).toMatchSnapshot();
+  });
+
   it('renders an ECS service with full container definition props and ALB security group config', () => {
     BASE_CONFIG.containerConfigs = [
       {

--- a/packages/terraform-modules/src/base/ApplicationECSService.ts
+++ b/packages/terraform-modules/src/base/ApplicationECSService.ts
@@ -489,6 +489,7 @@ export class ApplicationECSService extends Construct {
       tags: this.config.tags,
       dependsOn: ecrRepos,
       provider: this.config.provider,
+      skipDestroy: true,
     });
 
     if (this.config.efsConfig) {

--- a/packages/terraform-modules/src/base/ApplicationECSService.ts
+++ b/packages/terraform-modules/src/base/ApplicationECSService.ts
@@ -405,6 +405,10 @@ export class ApplicationECSService extends Construct {
     // figure out if we need to create an ECR for each container definition
     // also build a container definition JSON for each container
     this.config.containerConfigs.forEach((def) => {
+      if (def.imageSha && def.containerImage) {
+        throw new Error('Only one of imageSha or containerImage can be userd');
+      }
+
       // if an image has been given, it must already live somewhere, so an ECR isn't needed
       if (!def.containerImage) {
         const ecrConfig: ECRProps = {
@@ -415,7 +419,7 @@ export class ApplicationECSService extends Construct {
 
         const ecr = new ApplicationECR(this, `ecr-${def.name}`, ecrConfig);
         //Set the image to the latest one for now
-        def.containerImage = `${ecr.repo.repositoryUrl}:latest`;
+        def.containerImage = `${ecr.repo.repositoryUrl}:${def.imageSha ?? 'latest'}`;
         //The task and service need to depend on the repository existing.
         ecrRepos.push(ecr.repo);
       }

--- a/packages/terraform-modules/src/base/__snapshots__/ApplicationECSService.spec.ts.snap
+++ b/packages/terraform-modules/src/base/__snapshots__/ApplicationECSService.spec.ts.snap
@@ -1552,3 +1552,151 @@ exports[`ApplicationECSService renders an ECS service without an image container
   }
 }"
 `;
+
+exports[`ApplicationECSService renders an ECS service without an image container definition props and with a sha specified 1`] = `
+"{
+  "data": {
+    "aws_iam_policy_document": {
+      "testECSService_ecs-iam_ecs-task-assume_97906D9E": {
+        "statement": [
+          {
+            "actions": [
+              "sts:AssumeRole"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
+                ],
+                "type": "Service"
+              }
+            ]
+          }
+        ],
+        "version": "2012-10-17"
+      }
+    }
+  },
+  "resource": {
+    "aws_ecr_lifecycle_policy": {
+      "testECSService_ecr-lebowski_ecr-repo-lifecyclepolicy_19C9732F": {
+        "depends_on": [
+          "aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86"
+        ],
+        "policy": "{\\"rules\\":[{\\"rulePriority\\":1,\\"description\\":\\"expire old images\\",\\"selection\\":{\\"tagStatus\\":\\"any\\",\\"countType\\":\\"imageCountMoreThan\\",\\"countNumber\\":800},\\"action\\":{\\"type\\":\\"expire\\"}}]}",
+        "repository": "\${aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86.name}"
+      }
+    },
+    "aws_ecr_repository": {
+      "testECSService_ecr-lebowski_ecr-repo_6D07DF86": {
+        "image_scanning_configuration": {
+          "scan_on_push": true
+        },
+        "name": "abides-dev-lebowski"
+      }
+    },
+    "aws_ecs_service": {
+      "testECSService_ecs-service_33F309B3": {
+        "cluster": "gorp",
+        "depends_on": [
+          "aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86"
+        ],
+        "deployment_controller": {
+          "type": "ECS"
+        },
+        "deployment_maximum_percent": 400,
+        "deployment_minimum_healthy_percent": 80,
+        "desired_count": 4,
+        "launch_type": "ROCKET",
+        "lifecycle": {
+          "ignore_changes": [
+            "bowling",
+            "donnie",
+            "autobahn"
+          ]
+        },
+        "load_balancer": [
+        ],
+        "name": "abides-dev",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testECSService_ecs_security_group_67979722.id}"
+          ],
+          "subnets": [
+            "1.1.1.1",
+            "2.2.2.2"
+          ]
+        },
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}"
+      }
+    },
+    "aws_ecs_task_definition": {
+      "testECSService_ecs-task_A268C927": {
+        "container_definitions": "[{\\"dnsSearchDomains\\":null,\\"environmentFiles\\":null,\\"logConfiguration\\":{\\"logDriver\\":\\"awslogs\\",\\"secretOptions\\":[],\\"options\\":{\\"awslogs-group\\":\\"test/log/group\\",\\"awslogs-region\\":\\"us-east-1\\",\\"awslogs-stream-prefix\\":\\"ecs\\"}},\\"entryPoint\\":null,\\"portMappings\\":[{\\"containerPort\\":3002,\\"hostPort\\":3001}],\\"linuxParameters\\":null,\\"cpu\\":0,\\"environment\\":[{\\"name\\":\\"rug\\",\\"value\\":\\"tiedtheroomtogether\\"}],\\"resourceRequirements\\":null,\\"ulimits\\":null,\\"repositoryCredentials\\":{\\"credentialsParameter\\":\\"someArn\\"},\\"dnsServers\\":null,\\"mountPoints\\":[],\\"workingDirectory\\":null,\\"secrets\\":[{\\"name\\":\\"donnie\\",\\"valueFrom\\":\\"throwinrockstonight\\"}],\\"dockerSecurityOptions\\":null,\\"memory\\":null,\\"memoryReservation\\":null,\\"volumesFrom\\":[],\\"stopTimeout\\":null,\\"image\\":\\"\${aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86.repository_url}:123asdasdasd24432\\",\\"startTimeout\\":null,\\"firelensConfiguration\\":null,\\"dependsOn\\":null,\\"disableNetworking\\":null,\\"interactive\\":null,\\"healthCheck\\":null,\\"essential\\":true,\\"links\\":null,\\"hostname\\":null,\\"extraHosts\\":null,\\"pseudoTerminal\\":null,\\"user\\":null,\\"readonlyRootFilesystem\\":false,\\"dockerLabels\\":null,\\"systemControls\\":null,\\"privileged\\":null,\\"name\\":\\"lebowski\\"}]",
+        "cpu": "512",
+        "depends_on": [
+          "aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86"
+        ],
+        "execution_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}",
+        "family": "abides-dev",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
+        ],
+        "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
+        "volume": [
+        ]
+      }
+    },
+    "aws_iam_role": {
+      "testECSService_ecs-iam_ecs-execution-role_88EFEECE": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskExecutionRole"
+      },
+      "testECSService_ecs-iam_ecs-task-role_83E10144": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskRole"
+      }
+    },
+    "aws_iam_role_policy_attachment": {
+      "testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7": {
+        "policy_arn": "someArn",
+        "role": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}"
+      }
+    },
+    "aws_security_group": {
+      "testECSService_ecs_security_group_67979722": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
+            ],
+            "prefix_list_ids": [
+            ],
+            "protocol": "-1",
+            "security_groups": [
+            ],
+            "self": null,
+            "to_port": 0
+          }
+        ],
+        "ingress": [
+        ],
+        "lifecycle": {
+          "create_before_destroy": true
+        },
+        "name_prefix": "abides-dev-ECSSecurityGroup",
+        "vpc_id": "myhouse"
+      }
+    }
+  }
+}"
+`;

--- a/packages/terraform-modules/src/base/__snapshots__/ApplicationECSService.spec.ts.snap
+++ b/packages/terraform-modules/src/base/__snapshots__/ApplicationECSService.spec.ts.snap
@@ -98,6 +98,7 @@ exports[`ApplicationECSService attaches persistent (efs) storage to a ECS task 1
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
         "volume": [
           {
@@ -303,6 +304,7 @@ exports[`ApplicationECSService renders an ECS service with code deploy 1`] = `
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
         "volume": [
         ]
@@ -432,6 +434,7 @@ exports[`ApplicationECSService renders an ECS service with code deploy and exclu
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
         "volume": [
         ]
@@ -561,6 +564,7 @@ exports[`ApplicationECSService renders an ECS service with code deploy notificat
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
         "volume": [
         ]
@@ -690,6 +694,7 @@ exports[`ApplicationECSService renders an ECS service with full container defini
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
         "volume": [
         ]
@@ -871,6 +876,7 @@ exports[`ApplicationECSService renders an ECS service with full container defini
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
         "volume": [
         ]
@@ -1015,6 +1021,7 @@ exports[`ApplicationECSService renders an ECS service with minimal config 1`] = 
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
         "volume": [
         ]
@@ -1206,6 +1213,7 @@ exports[`ApplicationECSService renders an ECS service with mountPoints deduplica
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
         "volume": [
           {
@@ -1350,6 +1358,7 @@ exports[`ApplicationECSService renders an ECS service without a log group contai
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
         "volume": [
         ]
@@ -1498,6 +1507,7 @@ exports[`ApplicationECSService renders an ECS service without an image container
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
         "volume": [
         ]
@@ -1646,6 +1656,7 @@ exports[`ApplicationECSService renders an ECS service without an image container
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
         "volume": [
         ]

--- a/packages/terraform-modules/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
+++ b/packages/terraform-modules/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
@@ -435,6 +435,7 @@ exports[`PocketALBApplication renders a Pocket App with attached persistent stor
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
           {
@@ -1094,6 +1095,7 @@ exports[`PocketALBApplication renders a Pocket App with attached waf 1`] = `
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -1771,6 +1773,7 @@ exports[`PocketALBApplication renders an Pocket App with code deploy 1`] = `
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -2478,6 +2481,7 @@ exports[`PocketALBApplication renders an Pocket App with code deploy and creates
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -3183,6 +3187,7 @@ exports[`PocketALBApplication renders an Pocket App with code deploy notificatio
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -3865,6 +3870,7 @@ exports[`PocketALBApplication renders an Pocket App with custom Alarm Descriptio
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -4442,6 +4448,7 @@ exports[`PocketALBApplication renders an Pocket App with logs and dashboard in a
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -5042,6 +5049,7 @@ exports[`PocketALBApplication renders an application alarms 1`] = `
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -5632,6 +5640,7 @@ exports[`PocketALBApplication renders an application custom default alarms 1`] =
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -6247,6 +6256,7 @@ exports[`PocketALBApplication renders an application with autoscaling group and 
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "tags": {
           "hobby": "bowling",
           "name": "thedude"
@@ -6846,6 +6856,7 @@ exports[`PocketALBApplication renders an application with custom task sizes 1`] 
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -7461,6 +7472,7 @@ exports[`PocketALBApplication renders an application with default autoscaling gr
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "tags": {
           "hobby": "bowling",
           "name": "thedude"
@@ -8060,6 +8072,7 @@ exports[`PocketALBApplication renders an application with minimal config 1`] = `
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -8662,6 +8675,7 @@ exports[`PocketALBApplication renders an application with modified container def
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -9324,6 +9338,7 @@ exports[`PocketALBApplication renders an external application 1`] = `
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -9932,6 +9947,7 @@ exports[`PocketALBApplication renders an internal application 1`] = `
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -10547,6 +10563,7 @@ exports[`PocketALBApplication renders an internal application with tags 1`] = `
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "tags": {
           "hobby": "bowling",
           "name": "thedude"

--- a/packages/terraform-modules/src/pocket/__snapshots__/PocketECSApplication.spec.ts.snap
+++ b/packages/terraform-modules/src/pocket/__snapshots__/PocketECSApplication.spec.ts.snap
@@ -287,6 +287,7 @@ exports[`PocketECSApplication renders an Pocket App with logs and dashboard in a
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -639,6 +640,7 @@ exports[`PocketECSApplication renders an application with autoscaling group and 
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "tags": {
           "hobby": "bowling",
           "name": "thedude"
@@ -991,6 +993,7 @@ exports[`PocketECSApplication renders an application with custom task sizes 1`] 
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -1343,6 +1346,7 @@ exports[`PocketECSApplication renders an application with default autoscaling gr
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "tags": {
           "hobby": "bowling",
           "name": "thedude"
@@ -1695,6 +1699,7 @@ exports[`PocketECSApplication renders an application with minimal config 1`] = `
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]
@@ -2056,6 +2061,7 @@ exports[`PocketECSApplication renders an application with modified container def
         "requires_compatibilities": [
           "FARGATE"
         ],
+        "skip_destroy": true,
         "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
         "volume": [
         ]


### PR DESCRIPTION
## Goal

I noticed that our task definitions were always set to the `latest` image. This would mean that if a scaling event occurred during a deployment or after a failed deploy, the tasks would not pull the correct currently "live" image. This change ensures that the task defintion always is pointing to a specific sha tag of the docker image.