### PR TITLE
chore(shareable-lists): db-generated timestamps

### DIFF
--- a/servers/shareable-lists-api/prisma/migrations/20240126172230_db_generated_default_timestamps/migration.sql
+++ b/servers/shareable-lists-api/prisma/migrations/20240126172230_db_generated_default_timestamps/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `updatedAt` on the `List` table. The data in that column could be lost. The data in that column will be cast from `DateTime(3)` to `DateTime(0)`.
+  - You are about to alter the column `updatedAt` on the `ListItem` table. The data in that column could be lost. The data in that column will be cast from `DateTime(3)` to `DateTime(0)`.
+
+*/
+-- AlterTable
+ALTER TABLE `List` MODIFY `createdAt` DATETIME(0) NOT NULL DEFAULT now(),
+    MODIFY `updatedAt` DATETIME(0) NOT NULL DEFAULT now();
+
+-- AlterTable
+ALTER TABLE `ListItem` MODIFY `createdAt` DATETIME(0) NOT NULL DEFAULT now(),
+    MODIFY `updatedAt` DATETIME(0) NOT NULL DEFAULT now();

--- a/servers/shareable-lists-api/prisma/schema.prisma
+++ b/servers/shareable-lists-api/prisma/schema.prisma
@@ -5,6 +5,12 @@ generator client {
   output          = "../node_modules/.prisma/client"
 }
 
+generator kysely {
+    provider = "prisma-kysely"
+    output = "../node_modules/.kysely/client"
+    fileName = "types.ts"
+}
+
 datasource db {
   provider = "mysql"
   url      = env("DATABASE_URL")
@@ -38,8 +44,8 @@ model List {
   moderationDetails      String?          @db.Text
   restorationReason      String?          @db.Text
   listItemNoteVisibility Visibility       @default(PRIVATE)
-  createdAt              DateTime         @default(now()) @db.DateTime(0)
-  updatedAt              DateTime         @updatedAt
+  createdAt              DateTime         @default(dbgenerated("now()")) @db.DateTime(0)
+  updatedAt              DateTime         @default(dbgenerated("now()")) @db.DateTime(0)
 
   // *** Associated models ***
   listItems ListItem[]
@@ -69,8 +75,8 @@ model ListItem {
   publisher  String?  @db.VarChar(300)
   authors    String?  @db.VarChar(1000)
   sortOrder  Int      @default(0)
-  createdAt  DateTime @default(now()) @db.DateTime(0)
-  updatedAt  DateTime @updatedAt
+  createdAt  DateTime @default(dbgenerated("now()")) @db.DateTime(0)
+  updatedAt  DateTime @default(dbgenerated("now()")) @db.DateTime(0)
 
   // *** Associated models ***
   list List @relation(fields: [listId], references: [id])

--- a/servers/shareable-lists-api/prisma/seed.ts
+++ b/servers/shareable-lists-api/prisma/seed.ts
@@ -1,11 +1,10 @@
-import { Visibility, PilotUser, PrismaClient } from '.prisma/client';
+import { PilotUser, PrismaClient } from '.prisma/client';
 import {
   createPilotUserHelper,
   createShareableListHelper,
   createShareableListItemHelper,
 } from '../src/test/helpers';
 import { faker } from '@faker-js/faker';
-import { updateShareableList } from '../src/database/mutations';
 import { setLogger } from '@pocket-tools/ts-logger';
 
 const prismaSeedLogger = setLogger();
@@ -41,15 +40,16 @@ async function main() {
       userId: randomUser.userId,
     });
 
-    // Turn some lists public so that the status changes and a slug is generated.
-    // This seed data is created for the benefit of testing the admin tools after all.
-    if (Math.random() > 0.5) {
-      await updateShareableList(
-        prisma,
-        { externalId: list.externalId, status: Visibility.PUBLIC },
-        randomUser.userId,
-      );
-    }
+    // The code paths this seeder uses were commented out
+    // // Turn some lists public so that the status changes and a slug is generated.
+    // // This seed data is created for the benefit of testing the admin tools after all.
+    // if (Math.random() > 0.5) {
+    //   await updateShareableList(
+    //     prisma,
+    //     { externalId: list.externalId, status: Visibility.PUBLIC },
+    //     randomUser.userId,
+    //   );
+    // }
 
     // add between 5 and 10 Pocket stories to this list
     const numberOfStories = Math.floor(Math.random() * 5) + 5;


### PR DESCRIPTION
Runs a migration to generate timestamps using DB defaults rather than prisma. Relying less on the prisma client leaves less opportunity for mistakes when we're not using it. Using it with transactions has been unreliable and has resulted in OOMs in some test cases.

Running the migration in dev first.

Also, fixes the seeder script, which wasn't updated when the code paths for making lists public were commented out.

