### PR TITLE
feat(list): enable users to update title of a save

### DIFF
--- a/servers/list-api/schema.graphql
+++ b/servers/list-api/schema.graphql
@@ -664,12 +664,15 @@ type Mutation {
 
   """
   Update the title display of a Saved Item, retrieved by ID.
-  This is user-save specific (does not update the metadata saved by the parser)
+  This is user-save specific (does not update the metadata saved by the parser).
+  Clients should ensure the input fits in the utf8mb3 character set (BMP only,
+  which means no emoji) to avoid being rejected by the database.
+  In the future this will be more permissive.
   """
   updateSavedItemTitle(
     id: ID!
     timestamp: ISOString!
-    title: String! @constraint(minLength: 1, maxLength: 80)
+    title: String! @constraint(minLength: 1, maxLength: 75)
   ): SavedItem
 
   """
@@ -817,11 +820,14 @@ type Mutation {
   """
   Update the title display of a Saved Item, retrieved by URL.
   This is user-save specific (does not update the metadata saved by the parser)
+  Clients should ensure the input fits in the utf8mb3 character set (BMP only,
+  which means no emoji) to avoid being rejected by the database.
+  In the future this will be more permissive.
   """
   savedItemUpdateTitle(
     givenUrl: Url!
     timestamp: ISOString!
-    title: String! @constraint(minLength: 1, maxLength: 80)
+    title: String! @constraint(minLength: 1, maxLength: 75)
   ): SavedItem
 }
 

--- a/servers/list-api/schema.graphql
+++ b/servers/list-api/schema.graphql
@@ -152,11 +152,8 @@ type SavedItem implements RemoteEntity @key(fields: "id") @key(fields: "url") {
   url: String!
   """
   The title for user saved item. Set by the user and if not, set by the parser.
-  For third party clients use-case only.
   """
   title: String
-    @deprecated(reason: "internal clients must use item.title")
-    @tag(name: "alpha")
   """
   Helper property to indicate if the SavedItem is favorited
   """
@@ -666,6 +663,16 @@ type Mutation {
   updateSavedItemUnFavorite(id: ID!): SavedItem!
 
   """
+  Update the title display of a Saved Item, retrieved by ID.
+  This is user-save specific (does not update the metadata saved by the parser)
+  """
+  updateSavedItemTitle(
+    id: ID!
+    timestamp: ISOString!
+    title: String! @constraint(minLength: 1, maxLength: 80)
+  ): SavedItem
+
+  """
   Set the Tags that are associated with a SavedItem.
   Will replace any existing Tag associations on the SavedItem.
   To remove all Tags from a SavedItem, use `updateSavedItemRemoveTags`.
@@ -806,6 +813,16 @@ type Mutation {
   'hard-deleted' (record removed from the database entirely).
   """
   savedItemUnDelete(givenUrl: Url!, timestamp: ISOString!): SavedItem
+
+  """
+  Update the title display of a Saved Item, retrieved by URL.
+  This is user-save specific (does not update the metadata saved by the parser)
+  """
+  savedItemUpdateTitle(
+    givenUrl: Url!
+    timestamp: ISOString!
+    title: String! @constraint(minLength: 1, maxLength: 80)
+  ): SavedItem
 }
 
 # """

--- a/servers/list-api/src/businessEvents/types.ts
+++ b/servers/list-api/src/businessEvents/types.ts
@@ -14,6 +14,7 @@ export enum EventType {
   REMOVE_TAGS = 'REMOVE_TAGS',
   RENAME_TAG = 'RENAME_TAG',
   DELETE_TAG = 'DELETE_TAG',
+  UPDATE_TITLE = 'UPDATE_TITLE',
 }
 
 // Data fields required for all events
@@ -83,7 +84,7 @@ export type UnifiedEventType =
 export type EventTypeString = keyof typeof EventType;
 export type RequiredEvents = Exclude<
   EventTypeString,
-  'DELETE_TAG' | 'RENAME_TAG'
+  'DELETE_TAG' | 'RENAME_TAG' | 'UPDATE_TITLE'
 >;
 export const UnifiedEventMap: Record<RequiredEvents, UnifiedEventType> = {
   ADD_ITEM: 'user-list-item-created',
@@ -115,10 +116,11 @@ export type SnowplowEventType =
   | 'unarchive'
   | 'favorite'
   | 'unfavorite'
-  | 'tags_update';
+  | 'tags_update'
+  | 'title_update';
 
 export const SnowplowEventMap: Record<
-  Exclude<RequiredEvents, 'DELETE_TAG' | 'RENAME_TAG'>,
+  RequiredEvents & 'UPDATE_TITLE',
   SnowplowEventType
 > = {
   ADD_ITEM: 'save',
@@ -131,6 +133,7 @@ export const SnowplowEventMap: Record<
   REPLACE_TAGS: 'tags_update',
   REMOVE_TAGS: 'tags_update',
   CLEAR_TAGS: 'tags_update',
+  UPDATE_TITLE: 'title_update',
 };
 
 export type SavedItemTypeString = keyof typeof SavedItemStatus;

--- a/servers/list-api/src/models/SavedItem.ts
+++ b/servers/list-api/src/models/SavedItem.ts
@@ -260,6 +260,33 @@ export class SavedItemModel {
   }
 
   /**
+   * U
+   * @param id
+   * @param timestamp
+   * @param title
+   * @returns
+   */
+  public async updateTitleById(
+    id: string,
+    timestamp: Date,
+    title: string,
+  ): Promise<SavedItem | null> {
+    const savedItem = await this.saveService.updateTitle(id, timestamp, title);
+    if (savedItem == null) {
+      throw new NotFoundError(this.defaultNotFoundMessage);
+    } else {
+      this.context.emitItemEvent(EventType.UPDATE_TITLE, savedItem);
+    }
+    return savedItem;
+  }
+
+  public async updateTitleByUrl(url: string, timestamp: Date, title: string) {
+    const id = await this.fetchIdFromUrl(url);
+    // Will throw if fails or returns null
+    return this.updateTitleById(id, timestamp, title);
+  }
+
+  /**
    * Given a URL, fetch the itemId associated with it from the Parser
    * service. This is part of the primary key to identify the savedItem
    * (combined with userId).

--- a/servers/list-api/src/resolvers/index.ts
+++ b/servers/list-api/src/resolvers/index.ts
@@ -271,6 +271,28 @@ const resolvers = {
         args.timestamp,
       );
     },
+    savedItemUpdateTitle: async (
+      _,
+      args: { givenUrl: string; timestamp: Date; title: string },
+      context: IContext,
+    ): Promise<SavedItem | null> => {
+      return await context.models.savedItem.updateTitleByUrl(
+        args.givenUrl,
+        args.timestamp,
+        args.title,
+      );
+    },
+    updateSavedItemTitle: async (
+      _,
+      args: { id: string; timestamp: Date; title: string },
+      context: IContext,
+    ): Promise<SavedItem | null> => {
+      return await context.models.savedItem.updateTitleById(
+        args.id,
+        args.timestamp,
+        args.title,
+      );
+    },
   },
 };
 

--- a/servers/list-api/src/test/graphql/mutations/savedItem/savedItemUpdateTitle.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/savedItem/savedItemUpdateTitle.integration.ts
@@ -1,0 +1,219 @@
+import { readClient, writeClient } from '../../../../database/client';
+import { ContextManager } from '../../../../server/context';
+import { startServer } from '../../../../server/apollo';
+import { Express } from 'express';
+import { ApolloServer } from '@apollo/server';
+import { gql } from 'graphql-tag';
+import { print } from 'graphql';
+import request from 'supertest';
+import { mockParserGetItemIdRequest } from '../../../utils/parserMocks';
+
+describe('savedItemArchive mutation', function () {
+  const writeDb = writeClient();
+  const readDb = readClient();
+  const eventSpy = jest.spyOn(ContextManager.prototype, 'emitItemEvent');
+  const headers = { userid: '1' };
+  const date = new Date('2020-10-03T10:20:30.000Z'); // Consistent date for seeding
+  const date1 = new Date('2020-10-03T10:30:30.000Z'); // Consistent date for seeding
+  let app: Express;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+
+  const UPDATE_TITLE_MUTATION = gql`
+    mutation savedItemUpdateTitle(
+      $givenUrl: Url!
+      $timestamp: ISOString!
+      $title: String!
+    ) {
+      savedItemUpdateTitle(
+        givenUrl: $givenUrl
+        timestamp: $timestamp
+        title: $title
+      ) {
+        id
+        title
+        url
+        _updatedAt
+      }
+    }
+  `;
+
+  const UPDATE_TITLE_MUTATION_BY_ID = gql`
+    mutation updateSavedItemTitle(
+      $id: ID!
+      $timestamp: ISOString!
+      $title: String!
+    ) {
+      updateSavedItemTitle(id: $id, timestamp: $timestamp, title: $title) {
+        id
+        title
+        url
+        _updatedAt
+      }
+    }
+  `;
+
+  beforeEach(async () => {
+    await writeDb('list').truncate();
+    const inputData = [
+      { item_id: 0, status: 0, favorite: 0 },
+      { item_id: 1, status: 0, favorite: 0 },
+      // One that's already archived
+      { item_id: 2, status: 1, favorite: 0 },
+    ].map((row) => {
+      return {
+        ...row,
+        user_id: 1,
+        resolved_id: row.item_id,
+        given_url: `http://${row.item_id}`,
+        title: `title ${row.item_id}`,
+        time_added: date,
+        time_updated: date1,
+        time_read: row.status === 1 ? date : '0000-00-00 00:00:00',
+        time_favorited: date,
+        api_id: 'apiid',
+        api_id_updated: 'apiid',
+      };
+    });
+    await writeDb('list').insert(inputData);
+  });
+
+  beforeAll(async () => {
+    ({ app, server, url } = await startServer(0));
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    await writeDb.destroy();
+    await readDb.destroy();
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('updates the title of a saved item, by url', async () => {
+    const givenUrl = 'http://1';
+    mockParserGetItemIdRequest(givenUrl, '1');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const testEpoch = new Date(testTimestamp).getTime() / 1000;
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+      title: "Baldur's Gate 3 is the best. Period.",
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UPDATE_TITLE_MUTATION), variables });
+
+    expect(res.body.errors).toBeUndefined();
+    expect(res.body.data.savedItemUpdateTitle).toStrictEqual({
+      id: '1',
+      url: givenUrl,
+      title: "Baldur's Gate 3 is the best. Period.",
+      _updatedAt: testEpoch,
+    });
+  });
+  it('updates the title of a saved item, by id', async () => {
+    const givenUrl = 'http://1';
+    const id = '1';
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const testEpoch = new Date(testTimestamp).getTime() / 1000;
+    const variables = {
+      id,
+      timestamp: testTimestamp,
+      title: "Baldur's Gate 3 Wins 2023 Game of the Year",
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UPDATE_TITLE_MUTATION_BY_ID), variables });
+
+    expect(res.body.errors).toBeUndefined();
+    expect(res.body.data.updateSavedItemTitle).toStrictEqual({
+      id,
+      url: givenUrl,
+      title: "Baldur's Gate 3 Wins 2023 Game of the Year",
+      _updatedAt: testEpoch,
+    });
+  });
+  it('throws NotFound error if the savedItem does not have an itemId', async () => {
+    const givenUrl = 'http://999';
+    mockParserGetItemIdRequest(givenUrl, null);
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+      title: "Why you need to replay Baldur's Gate 3",
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UPDATE_TITLE_MUTATION), variables });
+    expect(res.body.errors).toContainEqual(
+      expect.objectContaining({
+        extensions: { code: 'NOT_FOUND' },
+        message: expect.stringContaining('SavedItem does not exist'),
+      }),
+    );
+  });
+  it('should not emit a title change event if the savedItem did not have an itemId', async () => {
+    const givenUrl = 'http://999';
+    mockParserGetItemIdRequest(givenUrl, null);
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+      title: "I did an evil playthrough of Baldur's Gate 3 and I'm not sorry",
+    };
+    await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UPDATE_TITLE_MUTATION), variables });
+    expect(eventSpy).toHaveBeenCalledTimes(0);
+  });
+  it('throws NotFound error and does not emit event if the savedItem is not in the user saves', async () => {
+    const givenUrl = 'http://999';
+    mockParserGetItemIdRequest(givenUrl, '999');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+      title: "Why playing the good guy is more rewarding in Baldur's Gate 3",
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UPDATE_TITLE_MUTATION), variables });
+    expect(res.body.errors).toContainEqual(
+      expect.objectContaining({
+        extensions: { code: 'NOT_FOUND' },
+        message: expect.stringContaining('SavedItem does not exist'),
+      }),
+    );
+    expect(eventSpy).toHaveBeenCalledTimes(0);
+  });
+  it('should emit a title update event when a savedItem title is updated', async () => {
+    const givenUrl = 'http://1';
+    mockParserGetItemIdRequest(givenUrl, '1');
+    const testTimestamp = '2023-10-05T14:48:00.000Z';
+    const variables = {
+      givenUrl,
+      timestamp: testTimestamp,
+      title: "Baldur's Gate 3 companion story arcs, ranked",
+    };
+    await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: print(UPDATE_TITLE_MUTATION), variables });
+    expect(eventSpy).toHaveBeenCalledTimes(1);
+    expect(eventSpy.mock.calls[0]).toStrictEqual([
+      'UPDATE_TITLE',
+      expect.objectContaining({
+        url: givenUrl,
+        time_updated: new Date(testTimestamp),
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
Mutation to update the title of a save. Just updates the user's personal save -- not the global metadata for the item stored by the parser.

Emits a new event for the updated title (analytics will need to integrate if they want to use)