### PR TITLE
feat(ADD): add feature flags killswitch to poll logic

### DIFF
--- a/infrastructure/account-data-deleter/src/dataDeleterApp.ts
+++ b/infrastructure/account-data-deleter/src/dataDeleterApp.ts
@@ -169,6 +169,14 @@ export class DataDeleterApp extends Construct {
               name: 'STRIPE_KEY',
               valueFrom: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/STRIPE_KEY`,
             },
+            {
+              name: 'UNLEASH_ENDPOINT',
+              valueFrom: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/UNLEASH_ENDPOINT`,
+            },
+            {
+              name: 'UNLEASH_KEY',
+              valueFrom: `arn:aws:secretsmanager:${region.name}:${caller.accountId}:secret:${config.name}/${config.environment}/UNLEASH_KEY`,
+            },
           ],
         },
       ],

--- a/infrastructure/account-data-deleter/src/dataDeleterApp.ts
+++ b/infrastructure/account-data-deleter/src/dataDeleterApp.ts
@@ -171,7 +171,7 @@ export class DataDeleterApp extends Construct {
             },
             {
               name: 'UNLEASH_ENDPOINT',
-              valueFrom: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/UNLEASH_ENDPOINT`,
+              valueFrom: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/Shared/${config.environment}/UNLEASH_ENDPOINT`,
             },
             {
               name: 'UNLEASH_KEY',

--- a/packages/feature-flags-client/src/index.spec.ts
+++ b/packages/feature-flags-client/src/index.spec.ts
@@ -1,10 +1,10 @@
-import { getUnleash, mockUnleash } from '.';
+import { getClient, mockClient } from '.';
 import { Unleash, destroy } from 'unleash-client';
 
 describe('feature flags client', () => {
   afterEach(() => destroy());
   it('returns an unleash client instance', () => {
-    const client = getUnleash({
+    const client = getClient({
       appName: 'test-app',
       url: 'http://localhost:4949',
       refreshInterval: 0,
@@ -12,7 +12,9 @@ describe('feature flags client', () => {
     expect(client).toBeInstanceOf(Unleash);
   });
   it('creates a mock instance if mock options are provided', () => {
-    const { unleash: client } = mockUnleash([]);
+    const { unleash: client } = mockClient([], {
+      appName: 'test-app',
+    });
     expect(client).toBeInstanceOf(Unleash);
     expect(client.getFeatureToggleDefinitions()).toEqual([]);
   });
@@ -27,13 +29,50 @@ describe('feature flags client', () => {
       strategies: [],
       impressionData: false,
     };
-    const { unleash: client } = mockUnleash([testFeatureToggle], {
+    const { unleash: client } = mockClient([testFeatureToggle], {
       appName: 'test-app',
-      url: 'http://localhost:4949',
     });
     expect(client).toBeInstanceOf(Unleash);
     expect(client.getFeatureToggleDefinition('test-toggle')).toEqual(
       testFeatureToggle,
     );
+  });
+  it('does not overrwrite bootstrapped data with fallback', () => {
+    const testFeatureToggle = {
+      enabled: true,
+      name: 'test-toggle',
+      stale: false,
+      type: 'release',
+      project: 'default',
+      variants: [],
+      strategies: [],
+      impressionData: false,
+    };
+    const { unleash: client } = mockClient([testFeatureToggle], {
+      appName: 'test-app',
+      url: 'http://localhost:4949',
+    });
+    expect(client).toBeInstanceOf(Unleash);
+    expect(client.isEnabled('test-toggle', undefined, false)).toEqual(true);
+  });
+  it('allows for changing values', () => {
+    const testFeatureToggle = {
+      enabled: true,
+      name: 'test-toggle',
+      stale: false,
+      type: 'release',
+      project: 'default',
+      variants: [],
+      strategies: [],
+      impressionData: false,
+    };
+    const { unleash: client, repo } = mockClient([testFeatureToggle], {
+      appName: 'test-app',
+      url: 'http://localhost:4949',
+    });
+    expect(client).toBeInstanceOf(Unleash);
+    expect(client.isEnabled('test-toggle', undefined, false)).toEqual(true);
+    repo.setToggle('test-toggle', { ...testFeatureToggle, enabled: false });
+    expect(client.isEnabled('test-toggle', undefined, true)).toEqual(false);
   });
 });

--- a/packages/feature-flags-client/src/index.spec.ts
+++ b/packages/feature-flags-client/src/index.spec.ts
@@ -1,29 +1,18 @@
-import { getClient } from '.';
+import { getUnleash, mockUnleash } from '.';
 import { Unleash, destroy } from 'unleash-client';
 
 describe('feature flags client', () => {
   afterEach(() => destroy());
   it('returns an unleash client instance', () => {
-    const client = getClient({
-      config: {
-        appName: 'test-app',
-        url: 'http://localhost:4949',
-        refreshInterval: 0,
-      },
+    const client = getUnleash({
+      appName: 'test-app',
+      url: 'http://localhost:4949',
+      refreshInterval: 0,
     });
     expect(client).toBeInstanceOf(Unleash);
   });
   it('creates a mock instance if mock options are provided', () => {
-    const client = getClient({
-      config: {
-        appName: 'test-app',
-        url: 'http://localhost:4949',
-        refreshInterval: 0,
-      },
-      mockOptions: {
-        shouldMock: true,
-      },
-    });
+    const { unleash: client } = mockUnleash([]);
     expect(client).toBeInstanceOf(Unleash);
     expect(client.getFeatureToggleDefinitions()).toEqual([]);
   });
@@ -38,16 +27,9 @@ describe('feature flags client', () => {
       strategies: [],
       impressionData: false,
     };
-    const client = getClient({
-      config: {
-        appName: 'test-app',
-        url: 'http://localhost:4949',
-        refreshInterval: 0,
-      },
-      mockOptions: {
-        shouldMock: true,
-        bootstrap: [testFeatureToggle],
-      },
+    const { unleash: client } = mockUnleash([testFeatureToggle], {
+      appName: 'test-app',
+      url: 'http://localhost:4949',
     });
     expect(client).toBeInstanceOf(Unleash);
     expect(client.getFeatureToggleDefinition('test-toggle')).toEqual(

--- a/packages/feature-flags-client/src/index.spec.ts
+++ b/packages/feature-flags-client/src/index.spec.ts
@@ -1,10 +1,10 @@
-import { getClient, mockClient } from '.';
+import { getUnleash, mockUnleash } from '.';
 import { Unleash, destroy } from 'unleash-client';
 
 describe('feature flags client', () => {
   afterEach(() => destroy());
   it('returns an unleash client instance', () => {
-    const client = getClient({
+    const client = getUnleash({
       appName: 'test-app',
       url: 'http://localhost:4949',
       refreshInterval: 0,
@@ -12,7 +12,7 @@ describe('feature flags client', () => {
     expect(client).toBeInstanceOf(Unleash);
   });
   it('creates a mock instance if mock options are provided', () => {
-    const { unleash: client } = mockClient([], {
+    const { unleash: client } = mockUnleash([], {
       appName: 'test-app',
     });
     expect(client).toBeInstanceOf(Unleash);
@@ -29,7 +29,7 @@ describe('feature flags client', () => {
       strategies: [],
       impressionData: false,
     };
-    const { unleash: client } = mockClient([testFeatureToggle], {
+    const { unleash: client } = mockUnleash([testFeatureToggle], {
       appName: 'test-app',
     });
     expect(client).toBeInstanceOf(Unleash);
@@ -48,7 +48,7 @@ describe('feature flags client', () => {
       strategies: [],
       impressionData: false,
     };
-    const { unleash: client } = mockClient([testFeatureToggle], {
+    const { unleash: client } = mockUnleash([testFeatureToggle], {
       appName: 'test-app',
       url: 'http://localhost:4949',
     });
@@ -66,7 +66,7 @@ describe('feature flags client', () => {
       strategies: [],
       impressionData: false,
     };
-    const { unleash: client, repo } = mockClient([testFeatureToggle], {
+    const { unleash: client, repo } = mockUnleash([testFeatureToggle], {
       appName: 'test-app',
       url: 'http://localhost:4949',
     });

--- a/packages/feature-flags-client/src/index.ts
+++ b/packages/feature-flags-client/src/index.ts
@@ -17,13 +17,12 @@ export { mockUnleash } from './mockClient';
  * connect to a real server instance.
  * @returns Unleash client instance (globally set)
  */
-export function getUnleash(config: UnleashConfig) {
+export function getUnleash(config: UnleashConfig): Unleash {
   // The actual unleash client. Note that this is not a blocking
   // call, so it's possible that the application uses stale toggles
   // on startup (defaults to any fallback values provided to `isEnabled`,
   // etc. until client is marked as ready).
-  let unleash: Unleash;
-  unleash = initialize(config);
+  const unleash = initialize(config);
   unleash.on('error', (err) =>
     serverLogger.error('Unleash errror', { data: err }),
   );

--- a/packages/feature-flags-client/src/index.ts
+++ b/packages/feature-flags-client/src/index.ts
@@ -1,17 +1,8 @@
 import { initialize, Unleash, UnleashConfig } from 'unleash-client';
-import { FeatureInterface } from 'unleash-client/lib/feature';
 import { serverLogger } from '@pocket-tools/ts-logger';
-import mockClient from './mockClient';
+export { mockUnleash } from './mockClient';
 
-export type FeatureFlagsOptions = {
-  config: UnleashConfig;
-  mockOptions?: {
-    shouldMock?: boolean;
-    bootstrap?: FeatureInterface[];
-  };
-};
-
-/**
+/*
  * Create and return an Unleash client instance (global).
  *
  * Note that the client setup is asynchronous and non-blocking.
@@ -26,21 +17,15 @@ export type FeatureFlagsOptions = {
  * connect to a real server instance.
  * @returns Unleash client instance (globally set)
  */
-export function getClient(options: FeatureFlagsOptions) {
-  const { config, mockOptions = {} } = options;
-  const { shouldMock = false, bootstrap = [] } = mockOptions;
+export function getUnleash(config: UnleashConfig) {
   // The actual unleash client. Note that this is not a blocking
   // call, so it's possible that the application uses stale toggles
   // on startup (defaults to any fallback values provided to `isEnabled`,
   // etc. until client is marked as ready).
   let unleash: Unleash;
-  if (!shouldMock) {
-    unleash = initialize(config);
-    unleash.on('error', (err) =>
-      serverLogger.error('Unleash errror', { data: err }),
-    );
-  } else {
-    return mockClient(config, bootstrap);
-  }
+  unleash = initialize(config);
+  unleash.on('error', (err) =>
+    serverLogger.error('Unleash errror', { data: err }),
+  );
   return unleash;
 }

--- a/packages/feature-flags-client/src/mockClient.ts
+++ b/packages/feature-flags-client/src/mockClient.ts
@@ -1,4 +1,4 @@
-import { Unleash, UnleashEvents, UnleashConfig } from 'unleash-client';
+import { initialize, UnleashEvents, UnleashConfig } from 'unleash-client';
 import { RepositoryInterface } from 'unleash-client/lib/repository';
 import { EventEmitter } from 'events';
 import { FeatureInterface } from 'unleash-client/lib/feature';
@@ -18,15 +18,19 @@ import { Segment } from 'unleash-client/lib/strategy/strategy';
  *
  * @param bootstrap Feature flags toggles (used for testing)
  */
-const client = (config: UnleashConfig, bootstrap?: FeatureInterface[]) => {
+
+export function mockUnleash(
+  bootstrap: FeatureInterface[],
+  config?: Partial<Pick<UnleashConfig, 'appName' | 'url'>>,
+) {
   // Have to construct a custom repository and
   // emit the UnleashEvents.Ready event from it;
   // If using bootstrap data alone and not connecting
   // to a real unleash server, the client will override
   // bootstrapped data with fallback if provided
   class LocalRepo extends EventEmitter implements RepositoryInterface {
-    private toggleData: { [key: string]: FeatureInterface };
-    constructor(private data: FeatureInterface[]) {
+    public toggleData: { [key: string]: FeatureInterface };
+    constructor(public data: FeatureInterface[]) {
       super();
       this.toggleData = data.reduce((compiled, curr) => {
         compiled[curr.name] = curr;
@@ -51,8 +55,9 @@ const client = (config: UnleashConfig, bootstrap?: FeatureInterface[]) => {
   }
   const repo = new LocalRepo(bootstrap);
 
-  const unleash = new Unleash({
-    ...config,
+  const unleash = initialize({
+    appName: config?.appName ?? 'mock-unleash',
+    url: 'not-needed',
     refreshInterval: 0,
     disableMetrics: true,
     repository: repo,
@@ -65,7 +70,5 @@ const client = (config: UnleashConfig, bootstrap?: FeatureInterface[]) => {
   // If this isn't done, any fallbacks provided to `isEnabled`
   // or similar will override the passed data.
   repo.emit(UnleashEvents.Ready);
-  return unleash;
-};
-
-export default client;
+  return { unleash, repo };
+}

--- a/packages/feature-flags-client/src/mockClient.ts
+++ b/packages/feature-flags-client/src/mockClient.ts
@@ -52,19 +52,24 @@ export function mockUnleash(
     getToggle(name: string): FeatureInterface {
       return this.toggleData[name];
     }
+    setToggle(name: string, toggleData: FeatureInterface): FeatureInterface {
+      this.toggleData[name] = toggleData;
+      const dataIndex = this.data.findIndex((toggle) => toggle.name === name);
+      if (dataIndex > -1) {
+        this.data.splice(dataIndex, 1);
+      }
+      this.data.push(toggleData);
+      return toggleData;
+    }
   }
   const repo = new LocalRepo(bootstrap);
 
   const unleash = initialize({
     appName: config?.appName ?? 'mock-unleash',
-    url: 'not-needed',
     refreshInterval: 0,
-    disableMetrics: true,
+    url: 'not-needed',
     repository: repo,
-    bootstrap: undefined,
-    bootstrapOverride: undefined,
-    storageProvider: undefined,
-    strategies: undefined,
+    disableMetrics: true,
   });
   // Notify that it's ready (does not connect to anything)
   // If this isn't done, any fallbacks provided to `isEnabled`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1028,6 +1028,9 @@ importers:
       '@pocket-tools/apollo-utils':
         specifier: workspace:*
         version: link:../../packages/apollo-utils
+      '@pocket-tools/feature-flags-client':
+        specifier: workspace:*
+        version: link:../../packages/feature-flags-client
       '@pocket-tools/ts-logger':
         specifier: workspace:*
         version: link:../../packages/ts-logger
@@ -1089,6 +1092,9 @@ importers:
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
+      unleash-client:
+        specifier: 5.3.2
+        version: 5.3.2
 
   servers/annotations-api:
     dependencies:

--- a/servers/account-data-deleter/package.json
+++ b/servers/account-data-deleter/package.json
@@ -20,6 +20,7 @@
     "@aws-sdk/client-sqs": "3.507.0",
     "@pocket-tools/ts-logger": "workspace:*",
     "@pocket-tools/apollo-utils": "workspace:*",
+    "@pocket-tools/feature-flags-client": "workspace:*",
     "@sentry/node": "7.99.0",
     "@sentry/tracing": "7.99.0",
     "express": "4.18.2",
@@ -40,7 +41,8 @@
     "supertest": "6.3.4",
     "ts-jest": "29.1.2",
     "ts-node": "10.9.2",
-    "tsconfig": "workspace:*"
+    "tsconfig": "workspace:*",
+    "unleash-client": "5.3.2"
   },
   "files": [
     "dist",

--- a/servers/account-data-deleter/src/batchDeleteHandler.spec.ts
+++ b/servers/account-data-deleter/src/batchDeleteHandler.spec.ts
@@ -7,10 +7,12 @@ import * as Sentry from '@sentry/node';
 import { SeverityLevel } from '@sentry/types';
 import { config } from './config';
 import Logger from './logger';
+import { mockUnleash } from '@pocket-tools/feature-flags-client';
 
 describe('batchDeleteHandler', () => {
+  const { unleash: mockClient, repo } = mockUnleash([]);
   const emitter = new EventEmitter();
-  const batchDeleteHandler = new BatchDeleteHandler(emitter, false);
+  const batchDeleteHandler = new BatchDeleteHandler(emitter, false, mockClient);
   const fakeMessageBody: SqsMessage = {
     traceId: 'abc-123',
     primaryKeyNames: ['surname'],
@@ -24,178 +26,221 @@ describe('batchDeleteHandler', () => {
   let sentryStub: jest.SpyInstance;
   let loggerError: jest.SpyInstance;
 
+  const deleteFeatureToggle = {
+    name: config.unleash.flags.deletesDisabled.name,
+    stale: false,
+    type: 'release',
+    project: 'default',
+    variants: [],
+    strategies: [],
+    impressionData: false,
+  };
+
   beforeEach(() => {
     jest.restoreAllMocks();
     scheduleStub = jest
       .spyOn(batchDeleteHandler, 'scheduleNextPoll')
       .mockResolvedValue();
-
     sentryStub = jest.spyOn(Sentry, 'captureException');
     loggerError = jest.spyOn(Logger, 'error');
   });
-
-  it('sends an event when the class is initialized', () => {
-    const eventSpy = jest.spyOn(emitter, 'emit').mockClear();
-    jest.spyOn(BatchDeleteHandler.prototype, 'pollQueue').mockResolvedValue();
-    new BatchDeleteHandler(emitter);
-    expect(eventSpy).toHaveBeenCalledWith('pollBatchDelete');
+  afterAll(() => {
+    mockClient.destroy();
   });
-  it('invokes listener when pollBatchDelete event is emitted', async () => {
-    const listenerStub = jest
-      .spyOn(batchDeleteHandler, 'pollQueue')
-      .mockResolvedValue();
-    emitter.emit('pollBatchDelete');
-    expect(listenerStub).toHaveBeenCalledTimes(1);
-  });
-  it('schedules a poll event after some time if no messages returned', async () => {
-    jest
-      .spyOn(SQSClient.prototype, 'send')
-      .mockImplementation(() => Promise.resolve({ Messages: [] }));
-    await batchDeleteHandler.pollQueue();
-    expect(scheduleStub).toHaveBeenCalledWith(300000);
-    expect(scheduleStub).toHaveBeenCalledTimes(1);
-  });
-  it('logs critical error if could not receive messages, and reschedules', async () => {
-    const error = new Error(`You got Q'd`);
-    jest.spyOn(SQSClient.prototype, 'send').mockImplementation(() => {
-      throw error;
-    });
-    await batchDeleteHandler.pollQueue();
-    expect(sentryStub).toHaveBeenCalledWith(error, {
-      level: 'fatal' as SeverityLevel,
-    });
-    expect(sentryStub).toHaveBeenCalledTimes(1);
-    expect(loggerError).toHaveBeenCalledTimes(1);
-    expect(scheduleStub).toHaveBeenCalledTimes(1);
-    expect(scheduleStub).toHaveBeenCalledWith(300000);
-  });
-  describe('With a message', () => {
-    describe('pollQueue', () => {
-      it('invokes account delete data service if a message is returned from poll', async () => {
-        const deleteStub = jest
-          .spyOn(
-            AccountDeleteDataService.prototype,
-            'batchDeleteUserInformation',
-          )
-          .mockResolvedValue();
-        jest.spyOn(SQSClient.prototype, 'send').mockImplementation(() =>
-          Promise.resolve({
-            Messages: [{ Body: JSON.stringify(fakeMessageBody) }],
-          }),
-        );
-        await batchDeleteHandler.pollQueue();
-        expect(deleteStub).toHaveBeenCalledWith(
-          'officers',
-          {
-            primaryKeyNames: ['surname'],
-            primaryKeyValues: [['spock'], ['picard'], ['riker'], ['ohura']],
-          },
-          'abc-123',
-          config.queueDelete.limitOverrides,
-        );
-        expect(deleteStub).toHaveBeenCalledTimes(1);
+  describe('with feature flags', () => {
+    describe('killswitch enabled', () => {
+      beforeAll(() => {
+        repo.setToggle(config.unleash.flags.deletesDisabled.name, {
+          ...deleteFeatureToggle,
+          enabled: true,
+        });
       });
-      it('schedules polling another message after a delay', async () => {
-        jest.spyOn(SQSClient.prototype, 'send').mockImplementation(() =>
-          Promise.resolve({
-            Messages: [{ Body: JSON.stringify(fakeMessageBody) }],
-          }),
-        );
-        jest.spyOn(batchDeleteHandler, 'handleMessage').mockResolvedValue(true);
-        jest.spyOn(batchDeleteHandler, 'deleteMessage').mockResolvedValue();
-        await batchDeleteHandler.pollQueue();
-        expect(scheduleStub).toHaveBeenCalledWith(500);
-        expect(scheduleStub).toHaveBeenCalledTimes(1);
-      });
-      it('sends a delete if message was successfully processed', async () => {
-        jest.spyOn(batchDeleteHandler, 'handleMessage').mockResolvedValue(true);
-        const sqsStub = jest
+      it('does not process any messages if kill switch is enabled, and schedules new poll', async () => {
+        const sendSpy = jest
           .spyOn(SQSClient.prototype, 'send')
-          .mockImplementationOnce(() =>
+          .mockImplementation(() => Promise.resolve());
+        await batchDeleteHandler.pollQueue();
+        expect(sendSpy).not.toHaveBeenCalled();
+        expect(scheduleStub).toHaveBeenCalledOnce();
+      });
+    });
+  });
+  describe('without feature flags', () => {
+    beforeAll(() => {
+      repo.setToggle(config.unleash.flags.deletesDisabled.name, {
+        ...deleteFeatureToggle,
+        enabled: false,
+      });
+    });
+    it('sends an event when the class is initialized', () => {
+      mockClient.destroy();
+      const eventSpy = jest.spyOn(emitter, 'emit').mockClear();
+      jest.spyOn(BatchDeleteHandler.prototype, 'pollQueue').mockResolvedValue();
+      new BatchDeleteHandler(emitter);
+      expect(eventSpy).toHaveBeenCalledWith('pollBatchDelete');
+    });
+    it('invokes listener when pollBatchDelete event is emitted', async () => {
+      const listenerStub = jest
+        .spyOn(batchDeleteHandler, 'pollQueue')
+        .mockResolvedValue();
+      emitter.emit('pollBatchDelete');
+      expect(listenerStub).toHaveBeenCalledTimes(1);
+    });
+    it('schedules a poll event after some time if no messages returned', async () => {
+      jest
+        .spyOn(SQSClient.prototype, 'send')
+        .mockImplementation(() => Promise.resolve({ Messages: [] }));
+      await batchDeleteHandler.pollQueue();
+      expect(scheduleStub).toHaveBeenCalledWith(300000);
+      expect(scheduleStub).toHaveBeenCalledTimes(1);
+    });
+    it('logs critical error if could not receive messages, and reschedules', async () => {
+      const error = new Error(`You got Q'd`);
+      jest.spyOn(SQSClient.prototype, 'send').mockImplementation(() => {
+        throw error;
+      });
+      await batchDeleteHandler.pollQueue();
+      expect(sentryStub).toHaveBeenCalledWith(error, {
+        level: 'fatal' as SeverityLevel,
+      });
+      expect(sentryStub).toHaveBeenCalledTimes(1);
+      expect(loggerError).toHaveBeenCalledTimes(1);
+      expect(scheduleStub).toHaveBeenCalledTimes(1);
+      expect(scheduleStub).toHaveBeenCalledWith(300000);
+    });
+
+    describe('With a message', () => {
+      describe('pollQueue', () => {
+        it('invokes account delete data service if a message is returned from poll', async () => {
+          const deleteStub = jest
+            .spyOn(
+              AccountDeleteDataService.prototype,
+              'batchDeleteUserInformation',
+            )
+            .mockResolvedValue();
+          jest.spyOn(SQSClient.prototype, 'send').mockImplementation(() =>
             Promise.resolve({
               Messages: [{ Body: JSON.stringify(fakeMessageBody) }],
             }),
-          )
-          .mockImplementation(() => Promise.resolve());
-        await batchDeleteHandler.pollQueue();
-        expect(sqsStub).toHaveBeenCalledTimes(2);
-        expect(sqsStub.mock.calls[1][0].input).toEqual(
-          new DeleteMessageCommand({
-            QueueUrl: config.aws.sqs.accountDeleteQueue.url,
-            ReceiptHandle: undefined,
-          }).input,
-        );
-      });
-      it('does not delete if message was unsuccessfully processed', async () => {
-        jest
-          .spyOn(batchDeleteHandler, 'handleMessage')
-          .mockResolvedValue(false);
-        const sqsStub = jest
-          .spyOn(SQSClient.prototype, 'send')
-          .mockImplementationOnce(() =>
+          );
+          await batchDeleteHandler.pollQueue();
+          expect(deleteStub).toHaveBeenCalledWith(
+            'officers',
+            {
+              primaryKeyNames: ['surname'],
+              primaryKeyValues: [['spock'], ['picard'], ['riker'], ['ohura']],
+            },
+            'abc-123',
+            config.queueDelete.limitOverrides,
+          );
+          expect(deleteStub).toHaveBeenCalledTimes(1);
+        });
+        it('schedules polling another message after a delay', async () => {
+          jest.spyOn(SQSClient.prototype, 'send').mockImplementation(() =>
             Promise.resolve({
               Messages: [{ Body: JSON.stringify(fakeMessageBody) }],
             }),
-          )
-          .mockImplementation(() => Promise.resolve());
-        await batchDeleteHandler.pollQueue();
-        expect(sqsStub).toHaveBeenCalledTimes(1);
+          );
+          jest
+            .spyOn(batchDeleteHandler, 'handleMessage')
+            .mockResolvedValue(true);
+          jest.spyOn(batchDeleteHandler, 'deleteMessage').mockResolvedValue();
+          await batchDeleteHandler.pollQueue();
+          expect(scheduleStub).toHaveBeenCalledWith(500);
+          expect(scheduleStub).toHaveBeenCalledTimes(1);
+        });
+        it('sends a delete if message was successfully processed', async () => {
+          jest
+            .spyOn(batchDeleteHandler, 'handleMessage')
+            .mockResolvedValue(true);
+          const sqsStub = jest
+            .spyOn(SQSClient.prototype, 'send')
+            .mockImplementationOnce(() =>
+              Promise.resolve({
+                Messages: [{ Body: JSON.stringify(fakeMessageBody) }],
+              }),
+            )
+            .mockImplementation(() => Promise.resolve());
+          await batchDeleteHandler.pollQueue();
+          expect(sqsStub).toHaveBeenCalledTimes(2);
+          expect(sqsStub.mock.calls[1][0].input).toEqual(
+            new DeleteMessageCommand({
+              QueueUrl: config.aws.sqs.accountDeleteQueue.url,
+              ReceiptHandle: undefined,
+            }).input,
+          );
+        });
+        it('does not delete if message was unsuccessfully processed', async () => {
+          jest
+            .spyOn(batchDeleteHandler, 'handleMessage')
+            .mockResolvedValue(false);
+          const sqsStub = jest
+            .spyOn(SQSClient.prototype, 'send')
+            .mockImplementationOnce(() =>
+              Promise.resolve({
+                Messages: [{ Body: JSON.stringify(fakeMessageBody) }],
+              }),
+            )
+            .mockImplementation(() => Promise.resolve());
+          await batchDeleteHandler.pollQueue();
+          expect(sqsStub).toHaveBeenCalledTimes(1);
+        });
       });
-    });
-    describe('handleMessage', () => {
-      it('sends error to Sentry and Cloudwatch if data service call fails, and schedules poll', async () => {
-        const error = new Error(`You got Q'd`);
-        jest
-          .spyOn(
-            AccountDeleteDataService.prototype,
-            'batchDeleteUserInformation',
-          )
-          .mockImplementation(() => {
-            throw error;
-          });
-        await batchDeleteHandler.handleMessage(fakeMessageBody);
-        expect(sentryStub).toHaveBeenCalledWith(error);
-        expect(sentryStub).toHaveBeenCalledTimes(1);
-        expect(loggerError).toHaveBeenCalledTimes(1);
-      });
+      describe('handleMessage', () => {
+        it('sends error to Sentry and Cloudwatch if data service call fails, and schedules poll', async () => {
+          const error = new Error(`You got Q'd`);
+          jest
+            .spyOn(
+              AccountDeleteDataService.prototype,
+              'batchDeleteUserInformation',
+            )
+            .mockImplementation(() => {
+              throw error;
+            });
+          await batchDeleteHandler.handleMessage(fakeMessageBody);
+          expect(sentryStub).toHaveBeenCalledWith(error);
+          expect(sentryStub).toHaveBeenCalledTimes(1);
+          expect(loggerError).toHaveBeenCalledTimes(1);
+        });
 
-      it('deletes from campaign_target_vars when campaign_target is deleted', async () => {
-        const deleteStub = jest
-          .spyOn(
-            AccountDeleteDataService.prototype,
-            'batchDeleteUserInformation',
-          )
-          .mockResolvedValue();
+        it('deletes from campaign_target_vars when campaign_target is deleted', async () => {
+          const deleteStub = jest
+            .spyOn(
+              AccountDeleteDataService.prototype,
+              'batchDeleteUserInformation',
+            )
+            .mockResolvedValue();
 
-        const args = {
-          primaryKeyNames: ['id'],
-          primaryKeyValues: [[1], [2], [3], [4]],
-        };
+          const args = {
+            primaryKeyNames: ['id'],
+            primaryKeyValues: [[1], [2], [3], [4]],
+          };
 
-        const fakeMessageBody = {
-          traceId: 'abc-123',
-          userId: 123,
-          tableName: 'readitla_ril-tmp.campaign_target',
-          email: 'q@q.continuum',
-          isPremium: true,
-          ...args,
-        };
+          const fakeMessageBody = {
+            traceId: 'abc-123',
+            userId: 123,
+            tableName: 'readitla_ril-tmp.campaign_target',
+            email: 'q@q.continuum',
+            isPremium: true,
+            ...args,
+          };
 
-        await batchDeleteHandler.handleMessage(fakeMessageBody);
-        expect(deleteStub).toHaveBeenCalledTimes(2);
-        const calls = deleteStub.mock.calls;
-        expect(calls[0]).toStrictEqual([
-          'readitla_ril-tmp.campaign_target',
-          args,
-          fakeMessageBody.traceId,
-          config.queueDelete.limitOverrides,
-        ]);
-        expect(calls[1]).toStrictEqual([
-          'readitla_ril-tmp.campaign_target_vars',
-          args,
-          fakeMessageBody.traceId,
-          config.queueDelete.limitOverrides,
-        ]);
+          await batchDeleteHandler.handleMessage(fakeMessageBody);
+          expect(deleteStub).toHaveBeenCalledTimes(2);
+          const calls = deleteStub.mock.calls;
+          expect(calls[0]).toStrictEqual([
+            'readitla_ril-tmp.campaign_target',
+            args,
+            fakeMessageBody.traceId,
+            config.queueDelete.limitOverrides,
+          ]);
+          expect(calls[1]).toStrictEqual([
+            'readitla_ril-tmp.campaign_target_vars',
+            args,
+            fakeMessageBody.traceId,
+            config.queueDelete.limitOverrides,
+          ]);
+        });
       });
     });
   });

--- a/servers/account-data-deleter/src/config/index.ts
+++ b/servers/account-data-deleter/src/config/index.ts
@@ -10,6 +10,7 @@ if (!awsEnvironments.includes(process.env.NODE_ENV)) {
 export const config = {
   app: {
     name: 'Account Data Deletion',
+    serviceName: 'Account-Data-Deleter',
     environment: process.env.NODE_ENV || 'development',
     defaultMaxAge: 86400,
     port: 4015,
@@ -74,6 +75,19 @@ export const config = {
       url:
         process.env.SQS_BATCH_DELETE_QUEUE_URL ||
         'http://localhost:4566/000000000000/pocket-list-delete-queue',
+    },
+  },
+  unleash: {
+    clientKey: process.env.UNLEASH_KEY || 'unleash-key-fake',
+    endpoint: process.env.UNLEASH_ENDPOINT || 'http://localhost:4242/api',
+    refreshInterval: 60 * 1000, // ms
+    timeout: 2 * 1000, // ms
+    namePrefix: 'temp.backend',
+    flags: {
+      deletesDisabled: {
+        name: 'temp.backend.account_delete_disabled',
+        fallback: true,
+      },
     },
   },
 };

--- a/servers/account-data-deleter/src/server.ts
+++ b/servers/account-data-deleter/src/server.ts
@@ -7,7 +7,7 @@ import { BatchDeleteHandler } from './batchDeleteHandler';
 import Logger from './logger';
 import { setMorgan } from '@pocket-tools/ts-logger';
 import { initSentry, sentryPocketMiddleware } from '@pocket-tools/apollo-utils';
-
+import { unleash } from './unleash';
 const app: Application = express();
 
 // Sentry Setup
@@ -15,6 +15,9 @@ initSentry(app, {
   ...config.sentry,
   debug: config.sentry.environment == 'development',
 });
+
+// Initialize unleash client
+unleash();
 
 // RequestHandler creates a separate execution context, so that all
 // transactions/spans/breadcrumbs are isolated across requests

--- a/servers/account-data-deleter/src/unleash.ts
+++ b/servers/account-data-deleter/src/unleash.ts
@@ -1,0 +1,18 @@
+import { getUnleash } from '@pocket-tools/feature-flags-client';
+import { config } from './config';
+import { Unleash } from 'unleash-client';
+
+let _unleash: Unleash;
+
+export function unleash(): Unleash {
+  if (_unleash != null) return _unleash;
+  _unleash = getUnleash({
+    url: config.unleash.endpoint,
+    appName: config.app.serviceName,
+    customHeaders: { Authorization: config.unleash.clientKey },
+    timeout: config.unleash.timeout,
+    namePrefix: config.unleash.namePrefix,
+    refreshInterval: config.unleash.refreshInterval,
+  });
+  return _unleash;
+}


### PR DESCRIPTION
Add unleash client to account-data-deleter. Do not poll for messages if the killswitch is on, to enable turning the delete logic on/off.

The unleash client refreshes toggles once per minute. 

Feature flags are created in prod and dev.

![image](https://github.com/Pocket/pocket-monorepo/assets/34227334/a941a568-9a76-4ce3-ba6e-d733e9900558)
