### PR TITLE
fix(xray): adding xray to annotations api

### DIFF
--- a/infrastructure/annotations-api/src/main.ts
+++ b/infrastructure/annotations-api/src/main.ts
@@ -410,6 +410,22 @@ class AnnotationsAPI extends TerraformStack {
         taskRolePolicyStatements: [
           {
             actions: [
+              'logs:PutLogEvents',
+              'logs:CreateLogGroup',
+              'logs:CreateLogStream',
+              'logs:DescribeLogStreams',
+              'logs:DescribeLogGroups',
+              'xray:PutTraceSegments',
+              'xray:PutTelemetryRecords',
+              'xray:GetSamplingRules',
+              'xray:GetSamplingTargets',
+              'xray:GetSamplingStatisticSummaries',
+            ],
+            resources: ['*'],
+            effect: 'Allow',
+          },
+          {
+            actions: [
               'dynamodb:BatchGet*',
               'dynamodb:DescribeTable',
               'dynamodb:Get*',


### PR DESCRIPTION
## Goal

I noticed that we had xray errors in AWS for the annotations api due to missing xray permissions

```
2024-02-08T01:39:47.601Z error exporterhelper/common.go:174 Exporting failed. Rejecting data. {"kind": "exporter", "data_type": "traces", "name": "awsxray", "error": "Permanent error: AccessDeniedException: User: arn:aws:sts::sdasdasd:assumed-role/AnnotationsAPI-Prod-TaskRole/asdasdasdasd is not authorized to perform: xray:PutTraceSegments because no identity-based policy allows the xray:PutTraceSegments action\n\tstatus code: 403, request id: asdasdasdasd", "rejected_items": 224} 
```