### PR TITLE
 feat(serverless-redis): adding in support for the serverless redis cache

### DIFF
--- a/infrastructure/image-api/src/main.ts
+++ b/infrastructure/image-api/src/main.ts
@@ -8,6 +8,7 @@ import {
 import { config } from './config';
 import {
   ApplicationRedis,
+  ApplicationServerlessRedis,
   PocketALBApplication,
   PocketPagerDuty,
   PocketVPC,
@@ -50,6 +51,9 @@ class ImageAPI extends TerraformStack {
       this,
       pocketVPC,
     );
+
+    //TOOD: Remove after new serverless cache is live
+    this.createOldElasticache(this, pocketVPC);
 
     this.createPocketAlbApplication({
       pagerDuty: this.createPagerDuty(),
@@ -308,6 +312,44 @@ class ImageAPI extends TerraformStack {
    * @private
    */
   private createElasticache(
+    scope: Construct,
+    pocketVPC: PocketVPC,
+  ): {
+    primaryEndpoint: string;
+    readerEndpoint: string;
+  } {
+    const elasticache = new ApplicationServerlessRedis(
+      scope,
+      'serverless_redis',
+      {
+        //Usually we would set the security group ids of the service that needs to hit this.
+        //However we don't have the necessary security group because it gets created in PocketALBApplication
+        //So instead we set it to null and allow anything within the vpc to access it.
+        //This is not ideal..
+        //Ideally we need to be able to add security groups to the ALB application.
+        allowedIngressSecurityGroupIds: undefined,
+        subnetIds: pocketVPC.privateSubnetIds,
+        tags: config.tags,
+        vpcId: pocketVPC.vpc.id,
+        // add on a serverless to the name, because our previous elasticache will still exist at the old name
+        prefix: `${config.prefix}-serverless`,
+      },
+    );
+
+    return {
+      primaryEndpoint: elasticache.elasticache.endpoint.get(0).address,
+      readerEndpoint: elasticache.elasticache.readerEndpoint.get(0).address,
+    };
+  }
+
+  /**
+   * THIS IS HERE SO THAT TASKS CYCLE, REMOVE AFTER THIS CODE HAS RUN ON MAIN ONCE.
+   *
+   * Creates the elasticache and returns the node address list
+   * @param scope
+   * @private
+   */
+  private createOldElasticache(
     scope: Construct,
     pocketVPC: PocketVPC,
   ): {

--- a/packages/terraform-modules/src/base/ApplicationElasticacheCluster.ts
+++ b/packages/terraform-modules/src/base/ApplicationElasticacheCluster.ts
@@ -109,66 +109,68 @@ export abstract class ApplicationElasticacheCluster extends Construct {
   }
 
   /**
-   * Create a security group and a subnet group for Elasticache
+   * Create a subnet group for Elasticache
    * @param scope
    * @param config
    * @param appVpc
    * @param port
    * @protected
    */
-  protected static createSecurityGroupAndSubnet(
+  protected static createSubnet(
+    scope: Construct,
+    config: ApplicationElasticacheClusterProps,
+  ): ElasticacheSubnetGroup {
+    return new ElasticacheSubnetGroup(scope, 'elasticache_subnet_group', {
+      name: `${config.prefix.toLowerCase()}-ElasticacheSubnetGroup`,
+      subnetIds: config.subnetIds,
+      provider: config.provider,
+      tags: config.tags,
+    });
+  }
+
+  /**
+   * Create a security group for Elasticache
+   * @param scope
+   * @param config
+   * @param appVpc
+   * @param port
+   * @protected
+   */
+  protected static createSecurityGroup(
     scope: Construct,
     config: ApplicationElasticacheClusterProps,
     appVpc: DataAwsVpc,
     port: number,
-  ): {
-    securityGroup: SecurityGroup;
-    subnetGroup: ElasticacheSubnetGroup;
-  } {
-    const securityGroup = new SecurityGroup(
-      scope,
-      'elasticache_security_group',
-      {
-        namePrefix: config.prefix,
-        description: 'Managed by Terraform',
-        vpcId: appVpc.id,
-        ingress: [
-          {
-            fromPort: port,
-            toPort: port,
-            protocol: 'tcp',
+  ): SecurityGroup {
+    return new SecurityGroup(scope, 'elasticache_security_group', {
+      namePrefix: config.prefix,
+      description: 'Managed by Terraform',
+      vpcId: appVpc.id,
+      ingress: [
+        {
+          fromPort: port,
+          toPort: port,
+          protocol: 'tcp',
 
-            //If we have a ingress security group it takes precedence
-            securityGroups: config.allowedIngressSecurityGroupIds
-              ? config.allowedIngressSecurityGroupIds
-              : null,
+          //If we have a ingress security group it takes precedence
+          securityGroups: config.allowedIngressSecurityGroupIds
+            ? config.allowedIngressSecurityGroupIds
+            : null,
 
-            //IF we do not have a ingress security group lets all the whole vpc access
-            cidrBlocks: config.allowedIngressSecurityGroupIds
-              ? null
-              : [appVpc.cidrBlock],
+          //IF we do not have a ingress security group lets all the whole vpc access
+          cidrBlocks: config.allowedIngressSecurityGroupIds
+            ? null
+            : [appVpc.cidrBlock],
 
-            // the following are included due to a bug
-            // https://github.com/hashicorp/terraform-cdk/issues/223
-            description: null,
-            ipv6CidrBlocks: null,
-            prefixListIds: null,
-          },
-        ],
-        tags: config.tags,
-        provider: config.provider,
-      },
-    );
-    const subnetGroup = new ElasticacheSubnetGroup(
-      scope,
-      'elasticache_subnet_group',
-      {
-        name: `${config.prefix.toLowerCase()}-ElasticacheSubnetGroup`,
-        subnetIds: config.subnetIds,
-        provider: config.provider,
-        tags: config.tags,
-      },
-    );
-    return { securityGroup, subnetGroup };
+          // the following are included due to a bug
+          // https://github.com/hashicorp/terraform-cdk/issues/223
+          description: null,
+          ipv6CidrBlocks: null,
+          prefixListIds: null,
+        },
+      ],
+      tags: config.tags,
+      provider: config.provider,
+    });
   }
 }

--- a/packages/terraform-modules/src/base/ApplicationMemcache.ts
+++ b/packages/terraform-modules/src/base/ApplicationMemcache.ts
@@ -54,12 +54,14 @@ export class ApplicationMemcache extends ApplicationElasticacheCluster {
     const engine = ApplicationElasticacheEngine.MEMCACHED;
     const port = ApplicationElasticacheCluster.getPortForEngine(engine);
 
-    const { securityGroup, subnetGroup } = this.createSecurityGroupAndSubnet(
+    const securityGroup = ApplicationMemcache.createSecurityGroup(
       scope,
       config,
       appVpc,
       port,
     );
+
+    const subnetGroup = ApplicationMemcache.createSubnet(scope, config);
 
     return new ElasticacheCluster(scope, `elasticache_cluster`, {
       clusterId: config.prefix.toLowerCase(),

--- a/packages/terraform-modules/src/base/ApplicationRedis.ts
+++ b/packages/terraform-modules/src/base/ApplicationRedis.ts
@@ -55,13 +55,14 @@ export class ApplicationRedis extends ApplicationElasticacheCluster {
     const engine = ApplicationElasticacheEngine.REDIS;
     const port = ApplicationElasticacheCluster.getPortForEngine(engine);
 
-    const { securityGroup, subnetGroup } =
-      ApplicationRedis.createSecurityGroupAndSubnet(
-        scope,
-        config,
-        appVpc,
-        port,
-      );
+    const securityGroup = ApplicationRedis.createSecurityGroup(
+      scope,
+      config,
+      appVpc,
+      port,
+    );
+
+    const subnetGroup = ApplicationRedis.createSubnet(scope, config);
 
     return new ElasticacheReplicationGroup(
       scope,

--- a/packages/terraform-modules/src/base/ApplicationServerlessRedis.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationServerlessRedis.spec.ts
@@ -4,6 +4,7 @@ import {
   ApplicationServerlessRedis,
   ApplicationServerlessRedisProps,
 } from './ApplicationServerlessRedis';
+import { DataAwsSubnets } from '@cdktf/provider-aws/lib/data-aws-subnets';
 
 const BASE_CONFIG: ApplicationServerlessRedisProps = {
   allowedIngressSecurityGroupIds: [],
@@ -34,27 +35,18 @@ describe('ApplicationRedis', () => {
     expect(synthed).toMatchSnapshot();
   });
 
-  it('renders redis with more then 3 subnets', () => {
+  it('renders redis using data aws subnet', () => {
     const config: ApplicationServerlessRedisProps = {
       ...BASE_CONFIG,
-      subnetIds: ['subnet-1', 'subnet-2', 'subnet-3', 'subnet-4'],
     };
     const synthed = Testing.synthScope((stack) => {
-      new ApplicationServerlessRedis(stack, 'testRedis', config);
+      const subnets = new DataAwsSubnets(stack, 'subnets', {});
+
+      new ApplicationServerlessRedis(stack, 'testRedis', {
+        ...config,
+        subnetIds: subnets.ids,
+      });
     });
     expect(synthed).toMatchSnapshot();
-  });
-
-  it('errors redis with less then 2 subnets', () => {
-    const config: ApplicationServerlessRedisProps = {
-      ...BASE_CONFIG,
-      subnetIds: ['subnet-1'],
-    };
-
-    Testing.synthScope((stack) => {
-      expect(() => {
-        new ApplicationServerlessRedis(stack, 'testRedis', config);
-      }).toThrow('Elasticache serverless requires at least 2 subnets');
-    });
   });
 });

--- a/packages/terraform-modules/src/base/ApplicationServerlessRedis.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationServerlessRedis.spec.ts
@@ -1,0 +1,60 @@
+import { Testing } from 'cdktf';
+
+import {
+  ApplicationServerlessRedis,
+  ApplicationServerlessRedisProps,
+} from './ApplicationServerlessRedis';
+
+const BASE_CONFIG: ApplicationServerlessRedisProps = {
+  allowedIngressSecurityGroupIds: [],
+  subnetIds: ['subnet-1', 'subnet-2', 'subnet-3'],
+  vpcId: 'cool-vpc',
+  prefix: `abides-dev`,
+};
+
+describe('ApplicationRedis', () => {
+  it('renders redis with minimal config', () => {
+    const synthed = Testing.synthScope((stack) => {
+      new ApplicationServerlessRedis(stack, 'testRedis', BASE_CONFIG);
+    });
+    expect(synthed).toMatchSnapshot();
+  });
+
+  it('renders redis with tags', () => {
+    const config: ApplicationServerlessRedisProps = {
+      ...BASE_CONFIG,
+      tags: {
+        letsgo: 'bowling',
+        donnie: 'throwinrockstonight',
+      },
+    };
+    const synthed = Testing.synthScope((stack) => {
+      new ApplicationServerlessRedis(stack, 'testRedis', config);
+    });
+    expect(synthed).toMatchSnapshot();
+  });
+
+  it('renders redis with more then 3 subnets', () => {
+    const config: ApplicationServerlessRedisProps = {
+      ...BASE_CONFIG,
+      subnetIds: ['subnet-1', 'subnet-2', 'subnet-3', 'subnet-4'],
+    };
+    const synthed = Testing.synthScope((stack) => {
+      new ApplicationServerlessRedis(stack, 'testRedis', config);
+    });
+    expect(synthed).toMatchSnapshot();
+  });
+
+  it('errors redis with less then 2 subnets', () => {
+    const config: ApplicationServerlessRedisProps = {
+      ...BASE_CONFIG,
+      subnetIds: ['subnet-1'],
+    };
+
+    Testing.synthScope((stack) => {
+      expect(() => {
+        new ApplicationServerlessRedis(stack, 'testRedis', config);
+      }).toThrow('Elasticache serverless requires at least 2 subnets');
+    });
+  });
+});

--- a/packages/terraform-modules/src/base/ApplicationServerlessRedis.ts
+++ b/packages/terraform-modules/src/base/ApplicationServerlessRedis.ts
@@ -4,7 +4,7 @@ import {
   ApplicationElasticacheEngine,
 } from './ApplicationElasticacheCluster';
 import { Construct } from 'constructs';
-import { Fn, TerraformIterator, Token } from 'cdktf';
+import { Fn } from 'cdktf';
 import { DataAwsVpc } from '@cdktf/provider-aws/lib/data-aws-vpc';
 import { ElasticacheServerlessCache } from '@cdktf/provider-aws/lib/elasticache-serverless-cache';
 

--- a/packages/terraform-modules/src/base/ApplicationServerlessRedis.ts
+++ b/packages/terraform-modules/src/base/ApplicationServerlessRedis.ts
@@ -1,0 +1,77 @@
+import {
+  ApplicationElasticacheCluster,
+  ApplicationElasticacheClusterProps,
+  ApplicationElasticacheEngine,
+} from './ApplicationElasticacheCluster';
+import { Construct } from 'constructs';
+import { DataAwsVpc } from '@cdktf/provider-aws/lib/data-aws-vpc';
+import { ElasticacheServerlessCache } from '@cdktf/provider-aws/lib/elasticache-serverless-cache';
+
+export type ApplicationServerlessRedisProps = Omit<
+  ApplicationElasticacheClusterProps,
+  'node' | 'overrideEngineVersion'
+>;
+
+export class ApplicationServerlessRedis extends ApplicationElasticacheCluster {
+  public elasticache: ElasticacheServerlessCache;
+
+  constructor(
+    scope: Construct,
+    name: string,
+    config: ApplicationServerlessRedisProps,
+  ) {
+    super(scope, name);
+
+    const appVpc = ApplicationElasticacheCluster.getVpc(this, config);
+    this.elasticache = ApplicationServerlessRedis.createElasticacheServerless(
+      this,
+      appVpc,
+      config,
+    );
+  }
+
+  /**
+   * Creates the elasticache serverless cluster to be used
+   * @param scope
+   * @param appVpc
+   * @param config
+   * @private
+   */
+  private static createElasticacheServerless(
+    scope: Construct,
+    appVpc: DataAwsVpc,
+    config: ApplicationServerlessRedisProps,
+  ): ElasticacheServerlessCache {
+    const engine = ApplicationElasticacheEngine.REDIS;
+    const port = ApplicationElasticacheCluster.getPortForEngine(engine);
+
+    const securityGroup = ApplicationServerlessRedis.createSecurityGroup(
+      scope,
+      config,
+      appVpc,
+      port,
+    );
+
+    let subnetIds = config.subnetIds;
+    if (subnetIds.length > 3) {
+      console.warn(
+        'More then 3 subnetIds were passed to elasticache and it only supports up to 3 will only use the first 3.',
+      );
+      subnetIds = config.subnetIds.slice(0, 3);
+    }
+
+    if (subnetIds.length < 2) {
+      throw new Error('Elasticache serverless requires at least 2 subnets');
+    }
+
+    return new ElasticacheServerlessCache(scope, 'elasticache_serverless', {
+      engine: engine,
+      name: config.prefix,
+      description: `Redis for ${config.prefix}`,
+      provider: config.provider,
+      securityGroupIds: [securityGroup.id],
+      subnetIds: subnetIds,
+      tags: config.tags,
+    });
+  }
+}

--- a/packages/terraform-modules/src/base/__snapshots__/ApplicationServerlessRedis.spec.ts.snap
+++ b/packages/terraform-modules/src/base/__snapshots__/ApplicationServerlessRedis.spec.ts.snap
@@ -1,0 +1,180 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ApplicationRedis renders redis with minimal config 1`] = `
+"{
+  "data": {
+    "aws_vpc": {
+      "testRedis_vpc_442CAD26": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "cool-vpc"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "resource": {
+    "aws_elasticache_serverless_cache": {
+      "testRedis_elasticache_serverless_E5B11082": {
+        "description": "Redis for abides-dev",
+        "engine": "redis",
+        "name": "abides-dev",
+        "security_group_ids": [
+          "\${aws_security_group.testRedis_elasticache_security_group_36C6CB6D.id}"
+        ],
+        "subnet_ids": [
+          "subnet-1",
+          "subnet-2",
+          "subnet-3"
+        ]
+      }
+    },
+    "aws_security_group": {
+      "testRedis_elasticache_security_group_36C6CB6D": {
+        "description": "Managed by Terraform",
+        "ingress": [
+          {
+            "cidr_blocks": null,
+            "description": null,
+            "from_port": 6379,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "security_groups": [
+            ],
+            "self": null,
+            "to_port": 6379
+          }
+        ],
+        "name_prefix": "abides-dev",
+        "vpc_id": "\${data.aws_vpc.testRedis_vpc_442CAD26.id}"
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationRedis renders redis with more then 3 subnets 1`] = `
+"{
+  "data": {
+    "aws_vpc": {
+      "testRedis_vpc_442CAD26": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "cool-vpc"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "resource": {
+    "aws_elasticache_serverless_cache": {
+      "testRedis_elasticache_serverless_E5B11082": {
+        "description": "Redis for abides-dev",
+        "engine": "redis",
+        "name": "abides-dev",
+        "security_group_ids": [
+          "\${aws_security_group.testRedis_elasticache_security_group_36C6CB6D.id}"
+        ],
+        "subnet_ids": [
+          "subnet-1",
+          "subnet-2",
+          "subnet-3"
+        ]
+      }
+    },
+    "aws_security_group": {
+      "testRedis_elasticache_security_group_36C6CB6D": {
+        "description": "Managed by Terraform",
+        "ingress": [
+          {
+            "cidr_blocks": null,
+            "description": null,
+            "from_port": 6379,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "security_groups": [
+            ],
+            "self": null,
+            "to_port": 6379
+          }
+        ],
+        "name_prefix": "abides-dev",
+        "vpc_id": "\${data.aws_vpc.testRedis_vpc_442CAD26.id}"
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationRedis renders redis with tags 1`] = `
+"{
+  "data": {
+    "aws_vpc": {
+      "testRedis_vpc_442CAD26": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "cool-vpc"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "resource": {
+    "aws_elasticache_serverless_cache": {
+      "testRedis_elasticache_serverless_E5B11082": {
+        "description": "Redis for abides-dev",
+        "engine": "redis",
+        "name": "abides-dev",
+        "security_group_ids": [
+          "\${aws_security_group.testRedis_elasticache_security_group_36C6CB6D.id}"
+        ],
+        "subnet_ids": [
+          "subnet-1",
+          "subnet-2",
+          "subnet-3"
+        ],
+        "tags": {
+          "donnie": "throwinrockstonight",
+          "letsgo": "bowling"
+        }
+      }
+    },
+    "aws_security_group": {
+      "testRedis_elasticache_security_group_36C6CB6D": {
+        "description": "Managed by Terraform",
+        "ingress": [
+          {
+            "cidr_blocks": null,
+            "description": null,
+            "from_port": 6379,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "security_groups": [
+            ],
+            "self": null,
+            "to_port": 6379
+          }
+        ],
+        "name_prefix": "abides-dev",
+        "tags": {
+          "donnie": "throwinrockstonight",
+          "letsgo": "bowling"
+        },
+        "vpc_id": "\${data.aws_vpc.testRedis_vpc_442CAD26.id}"
+      }
+    }
+  }
+}"
+`;

--- a/packages/terraform-modules/src/base/__snapshots__/ApplicationServerlessRedis.spec.ts.snap
+++ b/packages/terraform-modules/src/base/__snapshots__/ApplicationServerlessRedis.spec.ts.snap
@@ -1,8 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ApplicationRedis renders redis with minimal config 1`] = `
+exports[`ApplicationRedis renders redis using data aws subnet 1`] = `
 "{
   "data": {
+    "aws_subnets": {
+      "subnets": {
+      }
+    },
     "aws_vpc": {
       "testRedis_vpc_442CAD26": {
         "filter": [
@@ -25,11 +29,7 @@ exports[`ApplicationRedis renders redis with minimal config 1`] = `
         "security_group_ids": [
           "\${aws_security_group.testRedis_elasticache_security_group_36C6CB6D.id}"
         ],
-        "subnet_ids": [
-          "subnet-1",
-          "subnet-2",
-          "subnet-3"
-        ]
+        "subnet_ids": "\${slice(data.aws_subnets.subnets.ids, 0, 3)}"
       }
     },
     "aws_security_group": {
@@ -57,7 +57,7 @@ exports[`ApplicationRedis renders redis with minimal config 1`] = `
 }"
 `;
 
-exports[`ApplicationRedis renders redis with more then 3 subnets 1`] = `
+exports[`ApplicationRedis renders redis with minimal config 1`] = `
 "{
   "data": {
     "aws_vpc": {
@@ -82,11 +82,7 @@ exports[`ApplicationRedis renders redis with more then 3 subnets 1`] = `
         "security_group_ids": [
           "\${aws_security_group.testRedis_elasticache_security_group_36C6CB6D.id}"
         ],
-        "subnet_ids": [
-          "subnet-1",
-          "subnet-2",
-          "subnet-3"
-        ]
+        "subnet_ids": "\${slice([\\"subnet-1\\", \\"subnet-2\\", \\"subnet-3\\"], 0, 3)}"
       }
     },
     "aws_security_group": {
@@ -139,11 +135,7 @@ exports[`ApplicationRedis renders redis with tags 1`] = `
         "security_group_ids": [
           "\${aws_security_group.testRedis_elasticache_security_group_36C6CB6D.id}"
         ],
-        "subnet_ids": [
-          "subnet-1",
-          "subnet-2",
-          "subnet-3"
-        ],
+        "subnet_ids": "\${slice([\\"subnet-1\\", \\"subnet-2\\", \\"subnet-3\\"], 0, 3)}",
         "tags": {
           "donnie": "throwinrockstonight",
           "letsgo": "bowling"

--- a/packages/terraform-modules/src/index.ts
+++ b/packages/terraform-modules/src/index.ts
@@ -30,6 +30,7 @@ export * from './base/ApplicationLoadBalancer';
 export * from './base/ApplicationMemcache';
 export * from './base/ApplicationRDSCluster';
 export * from './base/ApplicationRedis';
+export * from './base/ApplicationServerlessRedis';
 export * from './base/ApplicationSQSQueue';
 export * from './base/ApplicationSqsSnsTopicSubscription';
 export * from './base/ApplicationTargetGroup';


### PR DESCRIPTION
## Goal

Enable support for AWS Serverless Elasticache, starting with Redis for our use case.

Subsequently, switch Parser and Image api to the new redis

https://mozilla-hub.atlassian.net/browse/POCKET-9588