### PR TITLE
feat(parser): resolve item from short url

### DIFF
--- a/servers/parser-graphql-wrapper/src/database/mysql.ts
+++ b/servers/parser-graphql-wrapper/src/database/mysql.ts
@@ -93,6 +93,7 @@ export type SharedUrlsResolverRepository = Repository<ShareUrls> & {
   ): Promise<number>;
   getShareUrls(itemId: number): Promise<ShareUrls>;
   batchGetShareUrlsById(itemIds: number[]): Promise<ShareUrls[]>;
+  fetchByShareId(shareId: number): Promise<ShareUrls>;
 };
 
 /**
@@ -140,6 +141,13 @@ export const getSharedUrlsResolverRepo = async () => {
         { itemIds: itemIds },
       );
       return query.getMany();
+    },
+    async fetchByShareId(id: number): Promise<ShareUrls> {
+      const query = this.createQueryBuilder('sharedUrls').where(
+        'sharedUrls.shareUrlId = :id',
+        { id },
+      );
+      return query.getOneOrFail();
     },
   });
 };

--- a/servers/parser-graphql-wrapper/src/resolvers.spec.ts
+++ b/servers/parser-graphql-wrapper/src/resolvers.spec.ts
@@ -5,6 +5,7 @@ import { ItemResolverRepository } from './database/mysql';
 const urlToParse = 'https://example.com/article-slug';
 const itemId = '3';
 const articleBody = '<div  lang=\\"en\\"><p>a cool article</p></div>';
+let itemRepo: ItemResolverRepository;
 
 describe('Resolvers', () => {
   beforeEach(() => {
@@ -32,17 +33,25 @@ describe('Resolvers', () => {
   });
 
   it('resolves getByUrl Query', async () => {
-    const response: any = await resolvers.Query.getItemByUrl(null, {
-      url: urlToParse,
-    });
+    const response: any = await resolvers.Query.getItemByUrl(
+      null,
+      {
+        url: urlToParse,
+      },
+      { repositories: itemRepo },
+    );
 
     expect(response.normalUrl).toBe(urlToParse);
   });
 
   it('resolves byUrl Query', async () => {
-    const response: any = await resolvers.Query.itemByUrl(null, {
-      url: urlToParse,
-    });
+    const response: any = await resolvers.Query.itemByUrl(
+      null,
+      {
+        url: urlToParse,
+      },
+      { repositories: itemRepo },
+    );
 
     expect(response.normalUrl).toBe(urlToParse);
   });

--- a/servers/parser-graphql-wrapper/src/shortUrl/shortUrl.spec.ts
+++ b/servers/parser-graphql-wrapper/src/shortUrl/shortUrl.spec.ts
@@ -1,4 +1,10 @@
-import { getShortCodeForId, getShortUrl, shareUrl } from './shortUrl';
+import {
+  getIdFromShortCode,
+  getShortCodeForId,
+  getShortUrl,
+  shareUrl,
+  extractCodeFromShortUrl,
+} from './shortUrl';
 import config from '../config';
 
 describe('ShortUrl', () => {
@@ -16,7 +22,23 @@ describe('ShortUrl', () => {
   it('getShortCodeForId', () => {
     expect(getShortCodeForId(123)).toBe('cb');
   });
-
+  it.each([
+    4294967294, 2147483647, 844596301, 844596300, 61, 62, 60, 610000, 609999,
+    610001,
+  ])('shortCode round trips: %i', (id) => {
+    const shortCode = getShortCodeForId(id);
+    const idCalc = getIdFromShortCode(shortCode);
+    expect(idCalc).toEqual(id);
+  });
+  it('shortCode round trip - 100 random numbers', () => {
+    const max = 2147483647 + 1;
+    const min = 1;
+    const randBetween = () => Math.floor(Math.random() * (max - min + 1) + min);
+    const ids = Array.from(Array(100).keys()).map(randBetween);
+    const codes = ids.map((id) => getShortCodeForId(id));
+    const idsCalc = codes.map((code) => getIdFromShortCode(code));
+    expect(ids).toEqual(idsCalc);
+  });
   it('shortUrl returns short url for given http url', async () => {
     const shortUrl = await getShortUrl(
       123,
@@ -35,5 +57,33 @@ describe('ShortUrl', () => {
       sharedRepo,
     );
     expect(shortUrl).toBe(`https://${config.shortUrl.short_prefix_secure}cb`);
+  });
+  it.each([
+    {
+      // http, short prefix alternative 1
+      url: `http://${config.shortUrl.short_prefix}dR32_lr`,
+      expected: 'dR32_lr',
+    },
+    {
+      // https, short prefix alternative 2
+      url: `https://${config.shortUrl.short_prefix_secure}LSxopD`,
+      expected: 'LSxopD',
+    },
+    // contains character not in charset, partial match (if not considering end of string)
+    { url: `${config.shortUrl.short_prefix}z_eE0wEp`, expected: undefined }, // 0 is not in charset
+    // contains character not in charset at end of string
+    { url: `${config.shortUrl.short_prefix}z_eEwEp-`, expected: undefined },
+    // no http, alternative 1
+    { url: `${config.shortUrl.short_prefix}z_eE9wEp`, expected: 'z_eE9wEp' },
+    // no http, alternative 2
+    {
+      url: `${config.shortUrl.short_prefix_secure}MBvhI`,
+      expected: 'MBvhI',
+    },
+    // very similar domain (local.com vs. local.co)
+    { url: 'http://local.com/aBN2u9', expected: undefined },
+    { url: 'http://local.com/bmNwdK', expected: undefined },
+  ])('extracts code if the URL is a short URL', ({ url, expected }) => {
+    expect(extractCodeFromShortUrl(url)).toEqual(expected);
   });
 });


### PR DESCRIPTION
Adds ability to resolve an Item entity from a short Pocket Share URL. The Pocket Share URL is created on request and redirects to the original page (currently controlled by Web repo).

[POCKET-9547]

[POCKET-9547]: https://mozilla-hub.atlassian.net/browse/POCKET-9547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ