### PR TITLE
fix(cache): revert serverless for now

### DIFF
--- a/infrastructure/image-api/src/main.ts
+++ b/infrastructure/image-api/src/main.ts
@@ -48,13 +48,13 @@ class ImageAPI extends TerraformStack {
     const region = new DataAwsRegion(this, 'region');
     const caller = new DataAwsCallerIdentity(this, 'caller');
 
-    const { primaryEndpoint, readerEndpoint } = this.createElasticache(
+    this.createElasticache(this, pocketVPC);
+
+    //TOOD: Remove after new serverless cache is live
+    const { primaryEndpoint, readerEndpoint } = this.createOldElasticache(
       this,
       pocketVPC,
     );
-
-    //TOOD: Remove after new serverless cache is live
-    this.createOldElasticache(this, pocketVPC);
 
     this.createPocketAlbApplication({
       pagerDuty: this.createPagerDuty(),

--- a/infrastructure/parser-graphql-wrapper/src/main.ts
+++ b/infrastructure/parser-graphql-wrapper/src/main.ts
@@ -42,13 +42,13 @@ class ParserGraphQLWrapper extends TerraformStack {
     const region = new DataAwsRegion(this, 'region');
     const caller = new DataAwsCallerIdentity(this, 'caller');
     const vpc = new PocketVPC(this, 'pocket-vpc');
-    const { primaryEndpoint, readerEndpoint } = this.createElasticache(
+    this.createElasticache(this, vpc);
+
+    //TOOD: Remove after new serverless cache is live
+    const { primaryEndpoint, readerEndpoint } = this.createOldElasticache(
       this,
       vpc,
     );
-
-    //TOOD: Remove after new serverless cache is live
-    this.createOldElasticache(this, vpc);
 
     this.createPocketAlbApplication({
       pagerDuty: this.createPagerDuty(),


### PR DESCRIPTION
## Goal

Something is wrong with the serverless cache, reverting the endpoints for now