### PR TITLE
fix(name): ensuring that the same name is always used for cache

### DIFF
--- a/packages/terraform-modules/src/base/ApplicationServerlessRedis.ts
+++ b/packages/terraform-modules/src/base/ApplicationServerlessRedis.ts
@@ -55,7 +55,7 @@ export class ApplicationServerlessRedis extends ApplicationElasticacheCluster {
 
     return new ElasticacheServerlessCache(scope, 'elasticache_serverless', {
       engine: engine,
-      name: config.prefix,
+      name: config.prefix.toLowerCase(),
       description: `Redis for ${config.prefix}`,
       provider: config.provider,
       securityGroupIds: [securityGroup.id],


### PR DESCRIPTION
## Goal

Ensure that we use the lowercase cache name... otherwise terraform tries to recreate it.