### PR TITLE
fix(client): bump router max height limit

### DIFF
--- a/servers/client-api/config/router.yaml
+++ b/servers/client-api/config/router.yaml
@@ -17,7 +17,7 @@ limits:
   parser_max_tokens: 15000 # This is the default value.
   parser_max_recursion: 4096 # This is the default value.
   max_depth: 100 # Must be 15 or larger to support standard introspection query
-  max_height: 200
+  max_height: 225
   max_aliases: 30
   max_root_fields: 20
 authentication:


### PR DESCRIPTION
The introspection query used by our codegen library has > 200 height.

https://github.com/graphql/graphql-js/blob/main/src/utilities/getIntrospectionQuery.ts\#L131-L170

Bump the height restriction to accomodate.