### PR TITLE
fix(sentry): ensure sentry does not truncate values

### DIFF
--- a/packages/apollo-utils/src/sentry/initSentry.ts
+++ b/packages/apollo-utils/src/sentry/initSentry.ts
@@ -5,6 +5,8 @@ import { Application } from 'express';
 export const initSentry = (app: Application, options?: NodeOptions) => {
   Sentry.init({
     ...options,
+    includeLocalVariables: true,
+    maxValueLength: 2000,
     integrations: [
       // Autoload will pull in mysql, apollo and graphql
       // https://github.com/getsentry/sentry-javascript/blob/1f3a796e904e2f84148db80304cb5bdb83a04cb1/packages/tracing-internal/src/node/integrations/lazy.ts#L13


### PR DESCRIPTION
## Goal

Sentry by default truncates messages/values to 250 characters https://docs.sentry.io/platforms/node/configuration/options/#max-value-length