### PR TITLE
feat(schema): [MC-573] Extend CorpusItem with `datePublished` field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ coverage
 # misc
 .DS_Store
 *.pem
+.idea
 
 # debug
 npm-debug.log*

--- a/servers/parser-graphql-wrapper/schema.graphql
+++ b/servers/parser-graphql-wrapper/schema.graphql
@@ -416,6 +416,10 @@ extend type CorpusItem @key(fields: "url") {
   shortUrl: Url @tag(name: "beta")
   url: Url! @external
   """
+  The date the article was published.
+  """
+  datePublished: DateString
+  """
   Time to read in minutes. Is nullable.
   """
   timeToRead: Int

--- a/servers/parser-graphql-wrapper/src/datePublished/datePublished.integration.ts
+++ b/servers/parser-graphql-wrapper/src/datePublished/datePublished.integration.ts
@@ -1,0 +1,107 @@
+import { ApolloServer } from '@apollo/server';
+import { IContext } from '../context';
+import { startServer } from '../server';
+import nock from 'nock';
+import { print } from 'graphql/index';
+import { gql } from 'graphql-tag';
+import request from 'supertest';
+import { Application } from 'express';
+
+describe('datePublished', () => {
+  const testUrl = 'https://someurl.com';
+
+  let app: Application;
+  let server: ApolloServer<IContext>;
+  let graphQLUrl: string;
+
+  let parserItem = {
+    given_url: testUrl,
+    normal_url: testUrl,
+    item_id: '1',
+    resolved_id: '1',
+    domain_metadata: {
+      name: 'domain',
+      logo: 'logo',
+    },
+    authors: [],
+    images: [],
+    videos: [],
+    date_published: '2024-02-26 21:13:41',
+  };
+
+  beforeAll(async () => {
+    // port 0 tells express to dynamically assign an available port
+    ({ app, server, url: graphQLUrl } = await startServer(0));
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  it('should return `datePublished` for a CorpusItem when parser item has `datePublished` property', async () => {
+    // mock the Parser call to return a parser item with `datePublished` filled in
+    nock(`http://example-parser.com`)
+      .get(`/?url=${encodeURIComponent(testUrl)}&getItem=1&output=regular`)
+      .reply(200, {
+        item: parserItem,
+      });
+
+    const corpus_item_query_ = gql`
+      query CorpusItem {
+        _entities(
+          representations: {
+            url: "https://someurl.com"
+            __typename: "CorpusItem"
+          }
+        ) {
+          ... on CorpusItem {
+            url
+            datePublished
+          }
+        }
+      }
+    `;
+
+    const res = await request(app)
+      .post(graphQLUrl)
+      .send({ query: print(corpus_item_query_) });
+    expect(res.body).not.toBeNull();
+    console.log(res.body.data);
+    expect(res.body.data._entities[0].datePublished).toBe(
+      parserItem.date_published,
+    );
+  });
+
+  it('should return null `datePublished` for a CorpusItem when parser item does not have a `datePublished` property', async () => {
+    parserItem = { ...parserItem, date_published: null };
+
+    // mock the Parser call to return a parser item with `datePublished` as null
+    nock(`http://example-parser.com`)
+      .get(`/?url=${encodeURIComponent(testUrl)}&getItem=1&output=regular`)
+      .reply(200, {
+        item: parserItem,
+      });
+
+    const corpus_item_query_ = gql`
+      query CorpusItem {
+        _entities(
+          representations: {
+            url: "https://someurl.com"
+            __typename: "CorpusItem"
+          }
+        ) {
+          ... on CorpusItem {
+            url
+            datePublished
+          }
+        }
+      }
+    `;
+
+    const res = await request(app)
+      .post(graphQLUrl)
+      .send({ query: print(corpus_item_query_) });
+    expect(res.body).not.toBeNull();
+    expect(res.body.data._entities[0].datePublished).toBe(null);
+  });
+});

--- a/servers/parser-graphql-wrapper/src/parserApiUtils.ts
+++ b/servers/parser-graphql-wrapper/src/parserApiUtils.ts
@@ -99,7 +99,7 @@ export const extractDomainMeta = (rawItem): any => {
 };
 
 /**
- * Takes dates that can be returned from the parser and makes somse sense of them.
+ * Takes dates that can be returned from the parser and makes some sense of them.
  * @param date
  */
 

--- a/servers/parser-graphql-wrapper/src/resolvers.ts
+++ b/servers/parser-graphql-wrapper/src/resolvers.ts
@@ -189,6 +189,20 @@ export const resolvers = {
         repo,
       );
     },
+    datePublished: async (
+      { url },
+      args,
+      context: IContext,
+    ): Promise<string | undefined | null> => {
+      // datePublished is not a guaranteed field on CorpusItem - we shouldn't
+      // return underlying parser errors to clients if this call fails
+      // (as some clients will fail outright if any graph errors are present)
+      try {
+        return (await getItemByUrl(url)).datePublished;
+      } catch (e) {
+        return null;
+      }
+    },
     timeToRead: async (
       { url },
       args,


### PR DESCRIPTION
## Goal

Extend CorpusItem with `datePublished` field. Added this to be able to show publication date for curated corpus items on the Schedule page in Curation Admin Tools.

- Added a resolver, integration tests.

- Updated .gitignore to ignore WebStorm config files.


## Reference 

https://mozilla-hub.atlassian.net/browse/MC-573