### PR TITLE
feat(list): add filter that matches v3 video filter

### DIFF
--- a/servers/list-api/schema.graphql
+++ b/servers/list-api/schema.graphql
@@ -318,6 +318,10 @@ enum SavedItemsContentType {
   """
   HAS_VIDEO
   """
+  Item is a video or a parsed article that contains videos
+  """
+  HAS_VIDEO_INCLUSIVE
+  """
   Item is a parsed page can be opened in reader view
   """
   IS_READABLE

--- a/servers/list-api/src/dataService/listPaginationService.ts
+++ b/servers/list-api/src/dataService/listPaginationService.ts
@@ -656,6 +656,9 @@ export class ListPaginationService {
       case 'HAS_VIDEO':
         baseQuery.where('readitla_b.items_extended.video', 1);
         break;
+      case 'HAS_VIDEO_INCLUSIVE':
+        baseQuery.where('readitla_b.items_extended.video', '!=', 0);
+        break;
       case 'IS_IMAGE':
         baseQuery.where('readitla_b.items_extended.image', 2);
         break;

--- a/servers/list-api/src/test/graphql/queries/savedItems-filters-offset.integration.ts
+++ b/servers/list-api/src/test/graphql/queries/savedItems-filters-offset.integration.ts
@@ -513,6 +513,25 @@ describe('getSavedItemsByOffset filter', () => {
     };
     expect(res.body.data?._entities[0].savedItemsByOffset).toEqual(expected);
   });
+  it('should return articles that are videos or contain videos', async () => {
+    const variables = {
+      id: '1',
+      filter: { contentType: 'HAS_VIDEO_INCLUSIVE' },
+    };
+    const res = await request(app).post(url).set(headers).send({
+      query: GET_SAVED_ITEMS,
+      variables,
+    });
+    expect(res.body.errors).toBeUndefined();
+    const expected = {
+      totalCount: 2,
+      entries: expect.toIncludeSameMembers([
+        { url: 'http://opq' },
+        { url: 'http://abc' },
+      ]),
+    };
+    expect(res.body.data?._entities[0].savedItemsByOffset).toEqual(expected);
+  });
   it('should return images', async () => {
     const variables = {
       id: '1',

--- a/servers/list-api/src/test/graphql/queries/savedItems-filters.integration.ts
+++ b/servers/list-api/src/test/graphql/queries/savedItems-filters.integration.ts
@@ -528,6 +528,22 @@ describe('getSavedItems filter', () => {
       res.body.data?._entities[0].savedItems.edges[0].node.item.savedItem.id,
     ).toBe('5');
   });
+  it('should return items that contain videos or are videos', async () => {
+    const variables = {
+      id: '1',
+      filter: { contentType: 'HAS_VIDEO_INCLUSIVE' },
+    };
+    const res = await request(app).post(url).set(headers).send({
+      query: GET_SAVED_ITEMS,
+      variables,
+    });
+    expect(res.body.errors).toBeUndefined();
+    expect(res.body.data?._entities[0].savedItems.edges.length).toBe(2);
+    const ids = res.body.data?._entities[0].savedItems.edges.map(
+      (edge) => edge.node.item.savedItem.id,
+    );
+    expect(ids).toIncludeSameMembers(['5', '1']);
+  });
   it('should return images', async () => {
     const variables = {
       id: '1',

--- a/servers/list-api/src/types/index.ts
+++ b/servers/list-api/src/types/index.ts
@@ -101,6 +101,7 @@ export enum SavedItemsContentType {
   HAS_VIDEO = 'HAS_VIDEO',
   IS_READABLE = 'IS_READABLE',
   IS_EXTERNAL = 'IS_EXTERNAL',
+  HAS_VIDEO_INCLUSIVE = 'HAS_VIDEO_INCLUSIVE',
 }
 
 export type SavedItemsFilter = {


### PR DESCRIPTION
HAS_VIDEO_INCLUSIVE matches items that either _are_ a video or _contain_ videos.

[POCKET-9660]