### PR TITLE
fix(shareable-lists): matching version

### DIFF
--- a/infrastructure/shareable-lists-api/src/main.ts
+++ b/infrastructure/shareable-lists-api/src/main.ts
@@ -202,7 +202,7 @@ class ShareableListsAPI extends TerraformStack {
         masterUsername: 'pkt_slists',
         engine: 'aurora-mysql',
         engineMode: 'provisioned',
-        engineVersion: '8.0.mysql_aurora.3.05.1',
+        engineVersion: '8.0.mysql_aurora.3.05.2',
         serverlessv2ScalingConfiguration: {
           minCapacity: config.rds.minCapacity,
           maxCapacity: config.rds.maxCapacity,


### PR DESCRIPTION
## Goal

Looks like a minor upgrade auto occured on AWS, so matching the version in the infra code.