### PR TITLE
fix(cache-size): limit our cache size by reducing age

### DIFF
--- a/infrastructure/parser-graphql-wrapper/src/main.ts
+++ b/infrastructure/parser-graphql-wrapper/src/main.ts
@@ -405,7 +405,9 @@ class ParserGraphQLWrapper extends TerraformStack {
         // Our original redis pre-serverless only had 7GB of data, but right now we are using 125Gb
         // with a 50% cache hit rate, so lets limit it a bit to save $$.
         // Not going to limit Ecpu atm berccuase that is charged per million ecpus and we are well under the first bill number.
-        cacheUsageLimits: [{ dataStorage: [{ maximum: 100, unit: 'GB' }] }],
+
+        // Add back once https://github.com/hashicorp/terraform-provider-aws/issues/35897 is fixed.
+        // cacheUsageLimits: [{ dataStorage: [{ maximum: 100, unit: 'GB' }] }],
         // add on a serverless to the name, because our previous elasticache will still exist at the old name
         prefix: `${config.prefix}-serverless`,
       },

--- a/servers/parser-graphql-wrapper/src/config/index.ts
+++ b/servers/parser-graphql-wrapper/src/config/index.ts
@@ -11,7 +11,7 @@ export default {
   },
   app: {
     environment: process.env.NODE_ENV || 'development',
-    defaultMaxAge: 86400,
+    defaultMaxAge: 21100, // ~6 hours
     serverPort: 4001,
   },
   redis: {


### PR DESCRIPTION
## goal

There is a bug in terraform for adjusting serverless cache usage. So for now we can sidestep by reducing the TTL.