### PR TITLE
fix(parser): fix short code generation for non-https

### DIFF
--- a/servers/parser-graphql-wrapper/src/shortUrl/shortUrl.spec.ts
+++ b/servers/parser-graphql-wrapper/src/shortUrl/shortUrl.spec.ts
@@ -46,7 +46,7 @@ describe('ShortUrl', () => {
       'http://www.google.com',
       sharedRepo,
     );
-    expect(shortUrl).toBe(`https://${config.shortUrl.short_prefix}cb`);
+    expect(shortUrl).toBe(`http://${config.shortUrl.short_prefix}cb`);
   });
 
   it('shortUrl returns short url for given https url', async () => {

--- a/servers/parser-graphql-wrapper/src/shortUrl/shortUrl.ts
+++ b/servers/parser-graphql-wrapper/src/shortUrl/shortUrl.ts
@@ -76,12 +76,10 @@ export function getIdFromShortCode(code: string): number {
  * @returns shortUrl
  */
 function generateShortUrl(url: string, shortCode: string): string {
-  const protocol = 'https://';
-  const domain = url.startsWith('https://')
-    ? config.shortUrl.short_prefix_secure
-    : config.shortUrl.short_prefix;
-
-  return protocol + domain + shortCode;
+  const urlPrefix = url.startsWith('https://')
+    ? `https://${config.shortUrl.short_prefix_secure}`
+    : `http://${config.shortUrl.short_prefix}`;
+  return urlPrefix + shortCode;
 }
 
 /**


### PR DESCRIPTION
Fix incorrect test assertion and ensure http protocol is used for non-secure short code urls (https for secure).