### PR TITLE
feat(search): add offset-based searches to support proxy

### DIFF
--- a/servers/user-list-search/schema.graphql
+++ b/servers/user-list-search/schema.graphql
@@ -1,8 +1,14 @@
 extend schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(
-    url: "https://specs.apollo.dev/federation/v2.0"
-    import: ["@key", "@shareable"]
+    url: "https://specs.apollo.dev/federation/v2.3"
+    import: ["@key", "@composeDirective", "@tag", "@shareable"]
   )
+  # The link directive is required to federate @constraint
+  # It doesn't actually have to be a real spec, but it would be good
+  # to write one and replace this.
+  @link(url: "https://myspecs.dev/myDirective/v1.0", import: ["@constraint"])
+  @composeDirective(name: "@constraint")
 
 scalar Url
 scalar FunctionalBoostValue
@@ -152,13 +158,34 @@ type User @key(fields: "id") {
     sort: SearchSortInput
     pagination: PaginationInput
   ): SavedItemSearchResultConnection
-
   advancedSearch(
     queryString: String
     filter: AdvancedSearchFilters
     sort: SearchSortInput
     pagination: PaginationInput
   ): SavedItemSearchResultConnection
+  searchSavedItemsByOffset(
+    term: String!
+    filter: SearchFilterInput
+    sort: SearchSortInput
+    pagination: OffsetPaginationInput
+  ): SavedItemSearchResultPage @tag(name: "internal")
+  advancedSearchByOffset(
+    queryString: String
+    filter: AdvancedSearchFilters
+    sort: SearchSortInput
+    pagination: OffsetPaginationInput
+  ): SavedItemSearchResultPage @tag(name: "internal")
+}
+
+"""
+A page of SavedItemSearchResult, retrieved by offset-based pagination.
+"""
+type SavedItemSearchResultPage @tag(name: "internal") {
+  entries: [SavedItemSearchResult!]!
+  totalCount: Int!
+  offset: Int!
+  limit: Int!
 }
 
 """
@@ -245,6 +272,16 @@ input PaginationInput {
   this has to set with before/last combination.
   """
   last: Int
+}
+
+"""
+Input for offset-pagination (internal backend use only).
+"""
+input OffsetPaginationInput {
+  """ Defaults to 0 """
+  offset: Int @constraint(min: 0)
+  """ Defaults to 30 """
+  limit: Int @constraint(exclusiveMin: 0, max: 100)
 }
 
 """

--- a/servers/user-list-search/src/datasource/elasticsearch/Paginator.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/Paginator.ts
@@ -1,9 +1,12 @@
 import { SearchResponse } from 'elasticsearch';
 import {
   ElasticSearchSavedItem,
+  SavedItemSearchResult,
   SavedItemSearchResultConnection,
+  SavedItemSearchResultPage,
   SearchSavedItemEdge,
 } from '../../types';
+import { config } from '../../config';
 
 /**
  * Extract and format pagination information from elasticsearch
@@ -23,6 +26,30 @@ export class Paginator {
   }
   public static decodeCursor(cursor: string): string[] {
     return Buffer.from(cursor, 'base64').toString().split(this.cursorSeparator);
+  }
+  public static resultToPage(
+    input: SearchResponse<ElasticSearchSavedItem>,
+  ): Pick<SavedItemSearchResultPage, 'entries' | 'totalCount'> {
+    const entries: SavedItemSearchResult[] = input.hits.hits.map((item) => ({
+      savedItem: {
+        id: item._source.item_id.toString(),
+      },
+      searchHighlights: {
+        ...item.highlight,
+        fullText: item.highlight?.full_text ?? null,
+      },
+    }));
+    // There's a bug in the elasticsearch interface definition
+    // Says it's an integer, but integration testing shows
+    // { value: number, relation: string } (example relation='eq')
+    // Parse it conditionally
+    const totalCount = Number.isInteger(input.hits.total)
+      ? input.hits.total
+      : (input.hits.total as any).value;
+    return {
+      entries,
+      totalCount,
+    };
   }
   public static resultToConnection(
     input: SearchResponse<ElasticSearchSavedItem>,

--- a/servers/user-list-search/src/freeSearch.integration.ts
+++ b/servers/user-list-search/src/freeSearch.integration.ts
@@ -8,77 +8,51 @@ import { Knex } from 'knex';
 import { SavedItemStatus } from './types';
 import { loadItemExtended, loadList } from './searchIntegrationTestHelpers';
 
-async function loadDb(db: Knex) {
-  const favorite = 1;
-  const nonFavorite = 0;
-
-  await loadList(
-    db,
-    favorite,
-    12345,
-    SavedItemStatus.ARCHIVED,
-    'super fun article',
-    'http://test1.com',
-    new Date('2020-10-03 10:20:30'),
-  );
-  await loadItemExtended(
-    db,
-    12345,
-    'http://test1.com',
-    'super fun article',
-    10,
-  );
-  await loadList(
-    db,
-    favorite,
-    123,
-    SavedItemStatus.UNREAD,
-    'another fun article',
-    'http://test2.com',
-    new Date('2021-10-03 10:20:30'),
-  );
-  await loadItemExtended(
-    db,
-    123,
-    'http://test2.com',
-    'another fun article',
-    50,
-  );
-
-  await loadList(
-    db,
-    nonFavorite,
-    456,
-    SavedItemStatus.UNREAD,
-    'winter sports fun',
-    'http://test3.com',
-    new Date('2021-5-03 10:20:30'),
-  );
-  await loadItemExtended(
-    db,
-    456,
-    'http://test3.com',
-    'winter sports fun video',
-    100,
-    0,
-    0,
-    1,
-  );
-  await loadList(
-    db,
-    favorite,
-    101010,
-    SavedItemStatus.DELETED,
-    'deleted article',
-    'http://deleted.com',
-    new Date('2020-10-03 10:20:30'),
-  );
-  await loadItemExtended(
-    db,
-    101010,
-    'http://deleted.com',
-    'deleted article',
-    10,
+async function seedDb(db: Knex) {
+  const data = [
+    {
+      favorite: 1,
+      itemId: 12345,
+      status: SavedItemStatus.ARCHIVED,
+      title: 'super fun article',
+      url: 'http://test1.com',
+      date: new Date('2020-10-03 10:20:30'),
+      wordCount: 10,
+    },
+    {
+      favorite: 1,
+      itemId: 123,
+      status: SavedItemStatus.UNREAD,
+      title: 'another fun article',
+      url: 'http://test2.com',
+      date: new Date('2021-10-03 10:20:30'),
+      wordCount: 50,
+    },
+    {
+      favorite: 0,
+      itemId: 456,
+      status: SavedItemStatus.UNREAD,
+      title: 'winter sports fun',
+      url: 'http://test3.com',
+      date: new Date('2021-5-03 10:20:30'),
+      wordCount: 100,
+      isVideo: 1,
+    },
+    {
+      favorite: 1,
+      itemId: 101010,
+      status: SavedItemStatus.DELETED,
+      title: 'deleted article',
+      url: 'http://deleted.com',
+      date: new Date('2020-10-03 10:20:30'),
+      wordCount: 10,
+    },
+  ];
+  await Promise.all(
+    data.flatMap((record) => [
+      loadItemExtended(db, record),
+      loadList(db, record),
+    ]),
   );
 }
 
@@ -98,7 +72,7 @@ describe('free search test', () => {
 
     await db('readitla_ril-tmp.list').truncate();
     await db('readitla_b.items_extended').truncate();
-    await loadDb(db);
+    await seedDb(db);
   });
 
   beforeEach(async () => {

--- a/servers/user-list-search/src/freeSearchByOffset.integration.ts
+++ b/servers/user-list-search/src/freeSearchByOffset.integration.ts
@@ -1,0 +1,429 @@
+import { startServer } from './server/serverUtils';
+import { ContextManager } from './server/context';
+import { Application } from 'express';
+import { ApolloServer } from '@apollo/server';
+import request from 'supertest';
+import { knexDbClient } from './datasource/clients/knexClient';
+import { Knex } from 'knex';
+import { SavedItemStatus } from './types';
+import {
+  loadItemExtended,
+  loadList,
+  SeedData,
+} from './searchIntegrationTestHelpers';
+
+async function seedDb(db: Knex) {
+  const data: SeedData[] = [
+    {
+      favorite: 1,
+      itemId: 12345,
+      status: SavedItemStatus.ARCHIVED,
+      title: 'super fun article',
+      url: 'http://test1.com',
+      date: new Date('2020-10-03 10:20:30'),
+      wordCount: 10,
+    },
+    {
+      favorite: 1,
+      itemId: 123,
+      status: SavedItemStatus.UNREAD,
+      title: 'another fun article',
+      url: 'http://test2.com',
+      date: new Date('2021-10-03 10:20:30'),
+      wordCount: 50,
+    },
+    {
+      favorite: 0,
+      itemId: 456,
+      status: SavedItemStatus.UNREAD,
+      title: 'winter sports fun',
+      url: 'http://test3.com',
+      date: new Date('2021-5-03 10:20:30'),
+      wordCount: 100,
+      isVideo: 1,
+    },
+    {
+      favorite: 1,
+      itemId: 101010,
+      status: SavedItemStatus.DELETED,
+      title: 'deleted article',
+      url: 'http://deleted.com',
+      date: new Date('2020-10-03 10:20:30'),
+      wordCount: 10,
+    },
+  ];
+  await Promise.all(
+    data.flatMap((record) => [
+      loadItemExtended(db, record),
+      loadList(db, record),
+    ]),
+  );
+}
+
+describe('free-tier search (offset pagination)', () => {
+  let app: Application;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+  const db = knexDbClient();
+  const headers = {
+    userid: '1',
+    premium: 'false',
+  };
+  const updateDate = new Date(2021, 10, 1, 0, 0); // mock date for insert
+
+  beforeAll(async () => {
+    ({ app, server, url } = await startServer(0));
+
+    await db('readitla_ril-tmp.list').truncate();
+    await db('readitla_b.items_extended').truncate();
+    await seedDb(db);
+  });
+
+  beforeEach(async () => {
+    jest.useFakeTimers({ now: updateDate, advanceTimers: true });
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    await db('readitla_ril-tmp.list').truncate();
+    await db('readitla_b.items_extended').truncate();
+    await db.destroy();
+    jest.useRealTimers();
+  });
+
+  const searchResultFragment = `
+  fragment SearchPageFields on SavedItemSearchResultPage {
+    entries {
+      savedItem {
+        id
+      }
+      searchHighlights {
+        tags
+        fullText
+        title
+      }
+    }
+    offset
+    limit
+    totalCount
+  }`;
+
+  it('should search paginated search with limit and offset', async () => {
+    const SEARCH_SAVED_ITEM_QUERY = `
+      ${searchResultFragment}
+      query searchSavedItem(
+        $id: ID!
+        $term: String!
+        $pagination: OffsetPaginationInput
+      ) {
+        _entities(representations: { id: $id, __typename: "User" }) {
+          ... on User {
+            searchSavedItemsByOffset(term: $term, pagination: $pagination) {
+                ...SearchPageFields
+            }
+          }
+        }
+      }
+    `;
+    const variables = {
+      id: '1',
+      term: 'fun',
+      pagination: {
+        limit: 4,
+        offset: 2,
+      },
+    };
+    const res = await request(app).post(url).set(headers).send({
+      query: SEARCH_SAVED_ITEM_QUERY,
+      variables,
+    });
+    const response = res.body.data?._entities[0].searchSavedItemsByOffset;
+    const expected = {
+      entries: [
+        expect.objectContaining({
+          savedItem: { id: '12345' },
+        }),
+      ],
+      totalCount: 3,
+      limit: 4,
+      offset: 2,
+    };
+    expect(response).toEqual(expected);
+  });
+
+  it('should not return deleted articles', async () => {
+    const SEARCH_SAVED_ITEM_QUERY = `
+      ${searchResultFragment}
+      query searchSavedItem(
+        $id: ID!
+        $term: String!
+        $pagination: OffsetPaginationInput
+      ) {
+        _entities(representations: { id: $id, __typename: "User" }) {
+          ... on User {
+            searchSavedItemsByOffset(term: $term, pagination: $pagination) {
+              ...SearchPageFields
+            }
+          }
+        }
+      }
+    `;
+    const variables = {
+      id: '1',
+      term: 'article',
+      pagination: {
+        limit: 30,
+      },
+    };
+
+    const res = await request(app).post(url).set(headers).send({
+      query: SEARCH_SAVED_ITEM_QUERY,
+      variables,
+    });
+    const response = res.body.data?._entities[0].searchSavedItemsByOffset;
+    expect(response.totalCount).toBe(2);
+    const ids = response.entries.map((entry) => entry.savedItem.id);
+    expect(ids).not.toContain('101010');
+  });
+
+  it('should search items based on url', async () => {
+    const SEARCH_SAVED_ITEM_QUERY = `
+      ${searchResultFragment}
+      query searchSavedItem(
+        $id: ID!
+        $term: String!
+        $pagination: OffsetPaginationInput
+      ) {
+        _entities(representations: { id: $id, __typename: "User" }) {
+          ... on User {
+            searchSavedItemsByOffset(term: $term, pagination: $pagination) {
+              ...SearchPageFields
+            }
+          }
+        }
+      }
+    `;
+    const variables = {
+      id: '1',
+      term: 'test2.com',
+      pagination: {
+        limit: 2,
+      },
+    };
+    const res = await request(app).post(url).set(headers).send({
+      query: SEARCH_SAVED_ITEM_QUERY,
+      variables,
+    });
+    const response = res.body.data?._entities[0].searchSavedItemsByOffset;
+    const expected = {
+      entries: [expect.objectContaining({ savedItem: { id: '123' } })],
+      totalCount: 1,
+      limit: 2,
+      offset: 0,
+    };
+    expect(response).toEqual(expected);
+  });
+
+  it('should return empty search result when term not found', async () => {
+    const SEARCH_SAVED_ITEM_QUERY = `
+      ${searchResultFragment}
+      query searchSavedItem(
+        $id: ID!
+        $term: String!
+        $pagination: OffsetPaginationInput
+      ) {
+        _entities(representations: { id: $id, __typename: "User" }) {
+          ... on User {
+            searchSavedItemsByOffset(term: $term, pagination: $pagination) {
+              ...SearchPageFields
+            }
+          }
+        }
+      }
+    `;
+    const variables = {
+      id: '1',
+      term: 'apple',
+      pagination: {
+        limit: 4,
+      },
+    };
+    const res = await request(app).post(url).set(headers).send({
+      query: SEARCH_SAVED_ITEM_QUERY,
+      variables,
+    });
+    const response = res.body.data?._entities[0].searchSavedItemsByOffset;
+    const expected = {
+      entries: [],
+      totalCount: 0,
+      limit: 4,
+      offset: 0,
+    };
+    expect(response).toEqual(expected);
+  });
+  it('should search only unread videos', async () => {
+    const SEARCH_SAVED_ITEM_QUERY = `
+    ${searchResultFragment}
+      query searchSavedItem(
+        $id: ID!
+        $term: String!
+        $pagination: OffsetPaginationInput
+        $filter: SearchFilterInput
+      ) {
+        _entities(representations: { id: $id, __typename: "User" }) {
+          ... on User {
+            searchSavedItemsByOffset(term: $term, pagination: $pagination, filter: $filter) {
+              ...SearchPageFields
+            }
+          }
+        }
+      }
+    `;
+    const variables = {
+      id: '1',
+      term: 'fun',
+      pagination: {
+        limit: 2,
+      },
+      filter: {
+        contentType: `VIDEO`,
+        status: `UNREAD`,
+      },
+    };
+    const res = await request(app).post(url).set(headers).send({
+      query: SEARCH_SAVED_ITEM_QUERY,
+      variables,
+    });
+    const response = res.body.data?._entities[0].searchSavedItemsByOffset;
+    const expected = {
+      entries: [expect.objectContaining({ savedItem: { id: '456' } })],
+      totalCount: 1,
+      limit: 2,
+      offset: 0,
+    };
+    expect(response).toEqual(expected);
+  });
+  it('should sort search result by time to read and asc', async () => {
+    const SEARCH_SAVED_ITEM_QUERY = `
+      ${searchResultFragment}
+      query searchSavedItem(
+        $id: ID!
+        $term: String!
+        $sort: SearchSortInput
+      ) {
+        _entities(representations: { id: $id, __typename: "User" }) {
+          ... on User {
+            searchSavedItemsByOffset(term: $term, sort: $sort) {
+              ...SearchPageFields
+            }
+          }
+        }
+      }
+    `;
+    const variables = {
+      id: '1',
+      term: 'fun',
+      sort: {
+        sortBy: `TIME_TO_READ`,
+        sortOrder: `ASC`,
+      },
+    };
+    const res = await request(app).post(url).set(headers).send({
+      query: SEARCH_SAVED_ITEM_QUERY,
+      variables,
+    });
+    const response = res.body.data?._entities[0].searchSavedItemsByOffset;
+    const expected = expect.objectContaining({
+      entries: [
+        expect.objectContaining({ savedItem: { id: '12345' } }),
+        expect.objectContaining({ savedItem: { id: '123' } }),
+        expect.objectContaining({ savedItem: { id: '456' } }),
+      ],
+      totalCount: 3,
+    });
+    expect(response).toEqual(expected);
+  });
+  it('should sort search result by time created and asc', async () => {
+    const SEARCH_SAVED_ITEM_QUERY = `
+      ${searchResultFragment}
+      query searchSavedItem(
+        $id: ID!
+        $term: String!
+        $sort:SearchSortInput
+      ) {
+        _entities(representations: { id: $id, __typename: "User" }) {
+          ... on User {
+            searchSavedItemsByOffset(term: $term, sort: $sort) {
+              ...SearchPageFields
+            }
+          }
+        }
+      }
+    `;
+    const variables = {
+      id: '1',
+      term: 'fun',
+      sort: {
+        sortBy: `CREATED_AT`,
+        sortOrder: `ASC`,
+      },
+    };
+    const res = await request(app).post(url).set(headers).send({
+      query: SEARCH_SAVED_ITEM_QUERY,
+      variables,
+    });
+    const response = res.body.data?._entities[0].searchSavedItemsByOffset;
+    const expected = expect.objectContaining({
+      entries: [
+        expect.objectContaining({ savedItem: { id: '12345' } }),
+        expect.objectContaining({ savedItem: { id: '456' } }),
+        expect.objectContaining({ savedItem: { id: '123' } }),
+      ],
+      totalCount: 3,
+    });
+    expect(response).toEqual(expected);
+  });
+  it('advancedSearch should return free search for non premium', async () => {
+    // Copy of another test, with the advancedSearch base query
+    const ADVANCED_SEARCH_QUERY = `
+    ${searchResultFragment}
+    query advancedSearch(
+      $id: ID!
+      $queryString: String
+      $pagination: OffsetPaginationInput
+    ) {
+      _entities(representations: { id: $id, __typename: "User" }) {
+        ... on User {
+          advancedSearchByOffset(queryString: $queryString, pagination: $pagination) {
+              ...SearchPageFields
+          }
+        }
+      }
+    }
+  `;
+    const variables = {
+      id: '1',
+      queryString: 'fun',
+      pagination: {
+        limit: 4,
+        offset: 2,
+      },
+    };
+    const res = await request(app).post(url).set(headers).send({
+      query: ADVANCED_SEARCH_QUERY,
+      variables,
+    });
+    const response = res.body.data?._entities[0].advancedSearchByOffset;
+    const expected = {
+      entries: [
+        expect.objectContaining({
+          savedItem: { id: '12345' },
+        }),
+      ],
+      totalCount: 3,
+      limit: 4,
+      offset: 2,
+    };
+    expect(response).toEqual(expected);
+  });
+});

--- a/servers/user-list-search/src/premiumSearchByOffset.integration.ts
+++ b/servers/user-list-search/src/premiumSearchByOffset.integration.ts
@@ -11,6 +11,8 @@ import { Knex } from 'knex';
 import { loadItemExtended, loadList } from './searchIntegrationTestHelpers';
 import { SavedItemStatus } from './types';
 
+// These tests are lifted from premiumSearch.integration.ts
+
 const defaultDocProps = {
   resolved_id: 1,
   url: '',
@@ -69,7 +71,7 @@ async function loadUserItem(
   ]);
 }
 
-describe('premium search functional test', () => {
+describe('premium search functional test (offset pagination)', () => {
   const testEsClient = client;
   let app: Application;
   let server: ApolloServer<ContextManager>;
@@ -85,35 +87,28 @@ describe('premium search functional test', () => {
       $term: String!
       $filter: SearchFilterInput
       $sort: SearchSortInput
-      $pagination: PaginationInput
+      $pagination: OffsetPaginationInput
     ) {
       _entities(representations: { id: $id, __typename: "User" }) {
         ... on User {
-          searchSavedItems(
+          searchSavedItemsByOffset(
             term: $term
             filter: $filter
             sort: $sort
             pagination: $pagination
           ) {
-            edges {
-              cursor
-              node {
-                savedItem {
-                  id
-                }
-                searchHighlights {
-                  tags
-                  fullText
-                  title
-                }
+            entries {
+              savedItem {
+                id
+              }
+              searchHighlights {
+                tags
+                fullText
+                title
               }
             }
-            pageInfo {
-              startCursor
-              endCursor
-              hasNextPage
-              hasPreviousPage
-            }
+            limit
+            offset
             totalCount
           }
         }
@@ -226,9 +221,7 @@ describe('premium search functional test', () => {
         db,
       ),
     ];
-
     await Promise.all(items);
-
     // Takes a hot sec for the data to be available, otherwise test flakes
     await testEsClient.indices.refresh({
       index: config.aws.elasticsearch.index,
@@ -241,66 +234,10 @@ describe('premium search functional test', () => {
     testEsClient.close();
   });
 
-  it('should search for Items under User entity', async () => {
-    const SEARCH_QUERY = `
-      query search(
-        $id: ID!
-        $term: String!
-        $fields: [String]!
-        $highlightFields: [SearchHighlightField]
-      ) {
-        _entities(representations: { id: $id, __typename: "User" }) {
-          ... on User {
-            search(
-              params: {
-                term: $term
-                fields: $fields
-                highlightFields: $highlightFields
-              }
-            ) {
-              results {
-                itemId
-                highlights {
-                  title
-                  tags
-                }
-              }
-            }
-          }
-        }
-      }
-    `;
-    const variables = {
-      id: '1',
-      term: 'super',
-      fields: ['title', 'tags'],
-      highlightFields: [
-        { field: 'title', size: 8 },
-        { field: 'tags', size: 10 },
-      ],
-    };
-    const res = await request(app).post(url).set(headers).send({
-      query: SEARCH_QUERY,
-      variables,
-    });
-    const expected = [
-      {
-        itemId: '12345',
-        highlights: {
-          title: ['A <em>super</em> fun'],
-          tags: ['<em>super</em>'],
-        },
-      },
-    ];
-    expect(res.body.errors).toBeUndefined();
-    expect(res.body.data?._entities[0].search.results).toIncludeSameMembers(
-      expected,
-    );
-  });
   it('should handle response that returns hits with no highlights object', async () => {
     const variables = {
       id: '1',
-      pagination: { first: 1 },
+      pagination: { limit: 1 },
       term: ' ',
       sort: {
         sortBy: `CREATED_AT`,
@@ -316,20 +253,21 @@ describe('premium search functional test', () => {
       variables,
     });
     expect(res.body.errors).toBeUndefined();
-    const searchResult = res.body.data?._entities[0].searchSavedItems;
-    expect(searchResult).not.toBeNull();
-    expect(searchResult.edges.length).toEqual(1);
-    expect(searchResult.edges[0].node.savedItem.id).not.toBeNull();
-    expect(searchResult.edges[0].node.searchHighlights).toStrictEqual({
-      fullText: null,
-      tags: null,
-      title: null,
+    const searchResult = res.body.data?._entities[0].searchSavedItemsByOffset;
+    const expected = expect.objectContaining({
+      entries: [
+        {
+          savedItem: { id: expect.toBeString() },
+          searchHighlights: { fullText: null, tags: null, title: null },
+        },
+      ],
     });
+    expect(searchResult).toEqual(expected);
   });
   it('should handle response that returns no hits', async () => {
     const variables = {
       id: '1',
-      pagination: { first: 1 },
+      pagination: { limit: 1 },
       term: 'unangenehm',
       sort: {
         sortBy: `CREATED_AT`,
@@ -345,22 +283,20 @@ describe('premium search functional test', () => {
       variables,
     });
     expect(res.body.errors).toBeUndefined();
-    const searchResult = res.body.data?._entities[0].searchSavedItems;
-    expect(searchResult).not.toBeNull();
-    expect(searchResult.edges.length).toEqual(0);
-    expect(searchResult.totalCount).toEqual(0);
-    expect(searchResult.pageInfo).toStrictEqual({
-      endCursor: null,
-      hasNextPage: false,
-      hasPreviousPage: false,
-      startCursor: null,
-    });
+    const searchResult = res.body.data?._entities[0].searchSavedItemsByOffset;
+    const expected = {
+      entries: [],
+      limit: 1,
+      offset: 0,
+      totalCount: 0,
+    };
+    expect(searchResult).toEqual(expected);
   });
   it('should search query term with pagination, filters and sort', async () => {
     const variables = {
       id: '1',
       term: 'super fun article',
-      pagination: { after: `MA==`, first: 2 },
+      pagination: { offset: 1, limit: 2 },
       sort: {
         sortBy: `CREATED_AT`,
         sortOrder: `DESC`,
@@ -374,32 +310,38 @@ describe('premium search functional test', () => {
       query: SEARCH_SAVED_ITEM_QUERY,
       variables,
     });
-    const response = res.body.data?._entities[0].searchSavedItems;
-    expect(response).not.toBeNull();
-    expect(response.totalCount).toEqual(3);
-    expect(response.edges.length).toEqual(2);
-    expect(response.pageInfo.hasNextPage).toBeFalse();
-    expect(response.pageInfo.hasPreviousPage).toBeTrue();
-    expect(response.edges[0].node.savedItem.id).toEqual('456');
-    expect(response.edges[1].node.savedItem.id).toEqual('12345');
-    //fullText: not related to search
-    expect(response.edges[0].node.searchHighlights['fullText']).toBeNull();
-    expect(response.edges[0].node.searchHighlights['tags']).toStrictEqual([
-      `<em>article</em>`,
-    ]);
-    expect(response.edges[0].node.searchHighlights['title']).toStrictEqual([
-      `snowboarding <em>fun</em> <em>article</em>`,
-    ]);
-    expect(response.edges[1].node.searchHighlights['fullText']).toStrictEqual([
-      `some text that can be used for <em>article</em> highlights`,
-    ]);
+    const response = res.body.data?._entities[0].searchSavedItemsByOffset;
+    const expected = {
+      entries: [
+        {
+          savedItem: { id: '456' },
+          searchHighlights: {
+            fullText: null,
+            tags: [`<em>article</em>`],
+            title: [`snowboarding <em>fun</em> <em>article</em>`],
+          },
+        },
+        {
+          savedItem: { id: '12345' },
+          searchHighlights: expect.objectContaining({
+            fullText: [
+              `some text that can be used for <em>article</em> highlights`,
+            ],
+          }),
+        },
+      ],
+      limit: 2,
+      offset: 1,
+      totalCount: 3,
+    };
+    expect(response).toEqual(expected);
   });
 
   it('should search with domain as filter', async () => {
     const variables = {
       id: '1',
       term: 'fun',
-      pagination: { first: 2 },
+      pagination: { limit: 2 },
       sort: {
         sortBy: `CREATED_AT`,
         sortOrder: `DESC`,
@@ -413,16 +355,21 @@ describe('premium search functional test', () => {
       variables,
     });
 
-    const response = res.body.data?._entities[0].searchSavedItems;
-    expect(response).not.toBeNull();
-    expect(response.totalCount).toEqual(1);
-    expect(response.edges.length).toEqual(1);
-    expect(response.pageInfo.hasNextPage).toBeFalse();
-    expect(response.pageInfo.hasPreviousPage).toBeFalse();
-    expect(response.edges[0].node.savedItem.id).toEqual('789');
-    expect(response.edges[0].node.searchHighlights['title']).toStrictEqual([
-      `winter skating <em>fun</em> article`,
-    ]);
+    const response = res.body.data?._entities[0].searchSavedItemsByOffset;
+    const expected = {
+      entries: [
+        {
+          savedItem: { id: '789' },
+          searchHighlights: expect.objectContaining({
+            title: [`winter skating <em>fun</em> article`],
+          }),
+        },
+      ],
+      totalCount: 1,
+      limit: 2,
+      offset: 0,
+    };
+    expect(response).toEqual(expected);
   });
 
   it('should properly filter multi-word search tags', async () => {
@@ -434,11 +381,12 @@ describe('premium search functional test', () => {
       query: SEARCH_SAVED_ITEM_QUERY,
       variables,
     });
-    const response = res.body.data?._entities[0].searchSavedItems;
-    expect(response).not.toBeNull();
-    expect(response.totalCount).toEqual(1);
-    expect(response.edges.length).toEqual(1);
-    expect(response.edges[0].node.savedItem.id).toEqual('777');
+    const response = res.body.data?._entities[0].searchSavedItemsByOffset;
+    const expected = expect.objectContaining({
+      entries: [expect.objectContaining({ savedItem: { id: '777' } })],
+      totalCount: 1,
+    });
+    expect(response).toEqual(expected);
   });
 
   it('should properly filter by tag combinations', async () => {
@@ -450,88 +398,43 @@ describe('premium search functional test', () => {
       query: SEARCH_SAVED_ITEM_QUERY,
       variables,
     });
-    const response = res.body.data?._entities[0].searchSavedItems;
-    expect(response).not.toBeNull();
-    expect(response.totalCount).toEqual(1);
-    expect(response.edges.length).toEqual(1);
-    expect(response.edges[0].node.savedItem.id).toEqual('123');
+    const response = res.body.data?._entities[0].searchSavedItemsByOffset;
+    const expected = expect.objectContaining({
+      entries: [expect.objectContaining({ savedItem: { id: '123' } })],
+      totalCount: 1,
+    });
+    expect(response).toEqual(expected);
   });
 
-  it('should use titleOnly search when requested', async () => {
-    const variables = {
-      id: '1',
-      term: 'snowboard', // only 1 article has snowboarding in the title
-      filter: {
-        onlyTitleAndURL: true,
-      },
-    };
-    const res = await request(app).post(url).set(headers).send({
-      query: SEARCH_SAVED_ITEM_QUERY,
-      variables,
-    });
-    const response = res.body.data?._entities[0].searchSavedItems;
-    expect(response).not.toBeNull();
-    expect(response.totalCount).toEqual(1);
-    expect(response.edges.length).toEqual(1);
-    expect(response.edges[0].node.savedItem.id).toEqual('456');
-    expect(response.edges[0].node.searchHighlights).toBeNull();
-  });
-
-  it('should not use titleOnly search when told not to', async () => {
-    const variables = {
-      id: '1',
-      term: 'snowboard',
-      filter: {
-        onlyTitleAndURL: false,
-      },
-    };
-    const res = await request(app).post(url).set(headers).send({
-      query: SEARCH_SAVED_ITEM_QUERY,
-      variables,
-    });
-    const response = res.body.data?._entities[0].searchSavedItems;
-    expect(response).not.toBeNull();
-    expect(response.totalCount).toEqual(1);
-    expect(response.edges.length).toEqual(1);
-    expect(response.edges[0].node.savedItem.id).toEqual('456');
-    expect(response.edges[0].node.searchHighlights['fullText']).toBeNull();
-    expect(response.edges[0].node.searchHighlights['title']).toStrictEqual([
-      `<em>snowboarding</em> fun article`,
-    ]);
-  });
   describe('searchQuery', () => {
     const SEARCH_QUERY = `
-    query advancedSearch(
+    query advancedSearchByOffset(
       $id: ID!
       $queryString: String
       $filter: AdvancedSearchFilters
       $sort: SearchSortInput
-      $pagination: PaginationInput
+      $pagination: OffsetPaginationInput
     ) {
       _entities(representations: { id: $id, __typename: "User" }) {
         ... on User {
-          advancedSearch(
+          advancedSearchByOffset(
             queryString: $queryString
             filter: $filter
             sort: $sort
             pagination: $pagination
           ) {
-            edges {
-              cursor
-              node {
-                savedItem {
-                  id
-                }
-                searchHighlights {
-                  tags
-                  fullText
-                  title
-                }
+            entries {
+              savedItem {
+                id
+              }
+              searchHighlights {
+                tags
+                title
+                fullText
               }
             }
-            pageInfo {
-              startCursor
-            }
+            limit
+            offset
             totalCount
           }
         }
@@ -545,7 +448,7 @@ describe('premium search functional test', () => {
       const variables = {
         id: '1',
         queryString: 'fun',
-        pagination: { first: 2 },
+        pagination: { limit: 2 },
         sort: {
           sortBy: `CREATED_AT`,
           sortOrder: `DESC`,
@@ -559,42 +462,26 @@ describe('premium search functional test', () => {
         variables,
       });
 
-      const response = res.body.data?._entities[0].advancedSearch;
+      const response = res.body.data?._entities[0].advancedSearchByOffset;
       const expected = {
+        limit: 2,
+        offset: 0,
         totalCount: 1,
-        edges: expect.toIncludeSameMembers([
+        entries: [
           expect.objectContaining({
-            cursor: expect.toBeString(),
-            node: expect.objectContaining({
-              savedItem: {
-                id: '789',
-              },
-              searchHighlights: expect.objectContaining({
-                title: expect.toIncludeSameMembers([
-                  `winter skating <em>fun</em> article`,
-                ]),
-              }),
+            savedItem: {
+              id: '789',
+            },
+            searchHighlights: expect.objectContaining({
+              title: [`winter skating <em>fun</em> article`],
             }),
           }),
-        ]),
-        pageInfo: expect.objectContaining({
-          startCursor: expect.toBeString(),
-        }),
+        ],
       };
       expect(response).toEqual(expected);
     });
 
-    it.each([
-      {
-        name: 'before/last pagination',
-        overrides: { pagination: { before: 'abc', last: 2 } },
-        expectedMessage: 'Pagination by "before"/"last" are not supported',
-      },
-      {
-        name: 'last pagination',
-        overrides: { pagination: { last: 2 } },
-        expectedMessage: 'Pagination by "before"/"last" are not supported',
-      },
+    it.skip.each([
       {
         name: 'missing query string and no filters',
         overrides: { queryString: undefined, filter: undefined },

--- a/servers/user-list-search/src/searchIntegrationTestHelpers.ts
+++ b/servers/user-list-search/src/searchIntegrationTestHelpers.ts
@@ -1,16 +1,28 @@
 import { Knex } from 'knex';
 
-export async function loadItemExtended(
-  db,
-  itemId,
-  url,
-  title,
-  wordCount,
-  isArticle = 1,
-  isImage = 0,
-  isVideo = 0,
-  lang = `en`,
-) {
+export type SeedData = {
+  favorite: number;
+  itemId: number;
+  status: number;
+  title: string;
+  url: string;
+  date: Date;
+  wordCount: number;
+  isArticle?: number;
+  isImage?: number;
+  isVideo?: number;
+};
+
+export async function loadItemExtended(db, seedData: SeedData) {
+  const optionalDefaults = {
+    lang: 'en',
+    isArticle: 1,
+    isImage: 0,
+    isVideo: 0,
+  };
+  const seedWithDefaults = { ...optionalDefaults, ...seedData };
+  const { itemId, url, title, wordCount, lang, isArticle, isImage, isVideo } =
+    seedWithDefaults;
   await db('readitla_b.items_extended').insert({
     extended_item_id: itemId,
     resolved_url: url,
@@ -35,15 +47,8 @@ export async function loadItemExtended(
     used_fallback: 0,
   });
 }
-export async function loadList(
-  db: Knex,
-  favorite: number,
-  itemId: number,
-  status: number,
-  title: string,
-  url: string,
-  date: Date,
-) {
+export async function loadList(db: Knex, seedData: SeedData) {
+  const { itemId, favorite, status, url, title, date } = seedData;
   await db('readitla_ril-tmp.list').insert({
     item_id: itemId,
     status: status,

--- a/servers/user-list-search/src/server/serverUtils.ts
+++ b/servers/user-list-search/src/server/serverUtils.ts
@@ -3,9 +3,6 @@ import { Server, createServer } from 'http';
 import { config } from '../config';
 import { expressMiddleware } from '@apollo/server/express4';
 import { ApolloServer } from '@apollo/server';
-import { buildSubgraphSchema } from '@apollo/subgraph';
-import { typeDefs } from './typeDefs';
-import { resolvers } from '../resolvers';
 import { createApollo4QueryValidationPlugin } from 'graphql-constraint-directive/apollo4';
 import { schema } from './schema';
 import { ContextManager, getContextFactory } from './context';
@@ -41,7 +38,7 @@ export async function startServer(port: number): Promise<{
   });
 
   const server = new ApolloServer<any>({
-    schema: buildSubgraphSchema({ typeDefs, resolvers }),
+    schema,
     plugins: [
       ...defaultPlugins(httpServer),
       createApollo4QueryValidationPlugin({ schema }),

--- a/servers/user-list-search/src/types.ts
+++ b/servers/user-list-search/src/types.ts
@@ -4,11 +4,23 @@ export type User = {
   id: string;
 };
 
-export type SearchSavedItemParameters = {
+type SearchSavedItemParametersBase = {
   term: string;
   filter?: SavedItemsFilter;
   sort?: SearchSortInput;
+};
+
+export type SearchSavedItemParameters = SearchSavedItemParametersBase & {
   pagination?: Pagination;
+};
+
+export type SearchSavedItemOffsetParams = SearchSavedItemParametersBase & {
+  pagination?: OffsetPagination;
+};
+
+export type OffsetPagination = {
+  limit: number;
+  offset: number;
 };
 
 export type PageInfo = {
@@ -21,6 +33,13 @@ export type PageInfo = {
 export type SavedItemSearchResultConnection = {
   edges: SearchSavedItemEdge[];
   pageInfo: PageInfo;
+  totalCount: number;
+};
+
+export type SavedItemSearchResultPage = {
+  entries: SavedItemSearchResult[];
+  offset: number;
+  limit: number;
   totalCount: number;
 };
 
@@ -126,13 +145,18 @@ export type SearchSortInput = {
   sortOrder?: SortDirection;
 };
 
-export type AdvancedSearchParams = Partial<{
+type AdvancedSearchParamsBase = Partial<{
   queryString: string;
   filter: AdvancedSearchFilters;
   sort: SearchSortInput;
-  pagination: Pagination;
 }>;
 
+export type AdvancedSearchParams = AdvancedSearchParamsBase & {
+  pagination?: Pagination;
+};
+export type AdvancedSearchByOffsetParams = AdvancedSearchParamsBase & {
+  pagination?: OffsetPagination;
+};
 /**
  * The schema of the saved item in elasticsearch
  */


### PR DESCRIPTION
Some code reuse, some copying where it would be more annoying to refactor for reuse. Hopefully we'll be able to deprecate searchSavedItems in favor of consolidating on the advanced search, and remove the deprecated search api as well.

[POCKET-9630]