### PR TITLE
feat(search): add searchType to graph

### DIFF
--- a/servers/user-list-search/schema.graphql
+++ b/servers/user-list-search/schema.graphql
@@ -23,6 +23,17 @@ enum SearchStatus {
 }
 
 """
+What search method was used -- elasticsearch cluster (premium)
+or searching on the database directly (free tier).
+"""
+enum SearchType {
+  """Corresponds to premium search"""
+  ELASTICSEARCH
+  """Corresponds to free tier search"""
+  DATABASE
+}
+
+"""
 Sort direction of the returned items.
 """
 enum SearchSortDirection {
@@ -183,6 +194,7 @@ A page of SavedItemSearchResult, retrieved by offset-based pagination.
 """
 type SavedItemSearchResultPage @tag(name: "internal") {
   entries: [SavedItemSearchResult!]!
+  searchType: SearchType!
   totalCount: Int!
   offset: Int!
   limit: Int!
@@ -218,6 +230,10 @@ type SavedItemSearchResultConnection {
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
+  """
+  What search method was used
+  """
+  searchType: SearchType!
 }
 
 """

--- a/servers/user-list-search/src/datasource/SavedItemsDataSource.ts
+++ b/servers/user-list-search/src/datasource/SavedItemsDataSource.ts
@@ -9,6 +9,7 @@ import {
   SearchSavedItemParameters,
   SavedItemSearchResultPage,
   SearchSavedItemOffsetParams,
+  SearchType,
 } from '../types';
 import { IContext } from '../server/context';
 import { validatePagination as externalValidatePagination } from '@pocket-tools/apollo-utils';
@@ -169,6 +170,7 @@ export class SavedItemDataService {
     return {
       entries,
       totalCount: totalcount,
+      searchType: SearchType.DATABASE,
       ...pageInput,
     };
   }
@@ -206,7 +208,7 @@ export class SavedItemDataService {
     // item_id sort is to resolve ties with stable sort (e.g. null sort field)
     baseQuery.orderBy(sortColumn, sortOrder.toLowerCase(), 'item_id', 'asc');
 
-    return paginate(
+    const searchResult = await paginate(
       // Need to use a subquery in order to order by derived fields ('archivedAt')
       this.db.select('*').from(baseQuery.as('page_query')),
       {
@@ -230,5 +232,7 @@ export class SavedItemDataService {
         }),
       },
     );
+    searchResult['searchType'] = SearchType.DATABASE;
+    return searchResult;
   }
 }

--- a/servers/user-list-search/src/datasource/elasticsearch/Paginator.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/Paginator.ts
@@ -5,6 +5,7 @@ import {
   SavedItemSearchResultConnection,
   SavedItemSearchResultPage,
   SearchSavedItemEdge,
+  SearchType,
 } from '../../types';
 
 /**
@@ -79,6 +80,7 @@ export class Paginator {
       ? input.hits.total
       : (input.hits.total as any).value;
     return {
+      searchType: SearchType.ELASTICSEARCH,
       edges,
       totalCount,
       pageInfo,

--- a/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.ts
@@ -12,6 +12,7 @@ import {
   SavedItemSearchResultPage,
   SavedItemSearchResult,
   AdvancedSearchByOffsetParams,
+  SearchType,
 } from '../../types';
 import { UserInputError, validatePagination } from '@pocket-tools/apollo-utils';
 import { SearchQueryBuilder } from './searchQueryBuilder';
@@ -622,6 +623,7 @@ export async function advancedSearchByOffset(
   const result = await advancedSearchBase(params, userId);
   const entries = Paginator.resultToPage(result);
   return {
+    searchType: SearchType.ELASTICSEARCH,
     ...entries,
     limit: params.pagination?.limit ?? config.pagination.defaultPageSize,
     offset: params.pagination?.offset ?? 0,
@@ -642,6 +644,7 @@ export async function searchSavedItemsByOffset(
   }));
   return {
     entries,
+    searchType: SearchType.ELASTICSEARCH,
     limit: searchParams.size,
     offset: searchParams.from,
     totalCount: result.hits.total['value'],
@@ -699,6 +702,7 @@ export async function searchSavedItems(
     (searchParams.from + searchResultsEdges.length - 1).toString(),
   ).toString('base64');
   const response = {
+    searchType: SearchType.ELASTICSEARCH,
     edges: searchResultsEdges,
     pageInfo: {
       endCursor: searchResultsEdges.length == 0 ? null : endCursor,

--- a/servers/user-list-search/src/freeSearch.integration.ts
+++ b/servers/user-list-search/src/freeSearch.integration.ts
@@ -107,6 +107,7 @@ describe('free search test', () => {
       hasNextPage
       hasPreviousPage
     }
+    searchType
     totalCount`;
 
   it('should search paginated search with after and first', async () => {
@@ -143,6 +144,7 @@ describe('free search test', () => {
     expect(response.totalCount).toBe(3);
     expect(response.pageInfo.hasNextPage).toBeFalse();
     expect(response.pageInfo.hasPreviousPage).toBeTrue();
+    expect(response.searchType).toBe('DATABASE');
     expect(response.edges[0].node.savedItem.id).toBe('456');
     expect(response.edges[1].node.savedItem.id).toBe('12345');
   });
@@ -480,6 +482,7 @@ describe('free search test', () => {
     expect(response.totalCount).toBe(3);
     expect(response.pageInfo.hasNextPage).toBeFalse();
     expect(response.pageInfo.hasPreviousPage).toBeTrue();
+    expect(response.searchType).toBe('DATABASE');
     expect(response.edges[0].node.savedItem.id).toBe('456');
     expect(response.edges[1].node.savedItem.id).toBe('12345');
   });

--- a/servers/user-list-search/src/freeSearchByOffset.integration.ts
+++ b/servers/user-list-search/src/freeSearchByOffset.integration.ts
@@ -106,6 +106,7 @@ describe('free-tier search (offset pagination)', () => {
     offset
     limit
     totalCount
+    searchType
   }`;
 
   it('should search paginated search with limit and offset', async () => {
@@ -147,6 +148,7 @@ describe('free-tier search (offset pagination)', () => {
       totalCount: 3,
       limit: 4,
       offset: 2,
+      searchType: 'DATABASE',
     };
     expect(response).toEqual(expected);
   });
@@ -220,6 +222,7 @@ describe('free-tier search (offset pagination)', () => {
       totalCount: 1,
       limit: 2,
       offset: 0,
+      searchType: 'DATABASE',
     };
     expect(response).toEqual(expected);
   });
@@ -258,6 +261,7 @@ describe('free-tier search (offset pagination)', () => {
       totalCount: 0,
       limit: 4,
       offset: 0,
+      searchType: 'DATABASE',
     };
     expect(response).toEqual(expected);
   });
@@ -300,6 +304,7 @@ describe('free-tier search (offset pagination)', () => {
       totalCount: 1,
       limit: 2,
       offset: 0,
+      searchType: 'DATABASE',
     };
     expect(response).toEqual(expected);
   });
@@ -423,6 +428,7 @@ describe('free-tier search (offset pagination)', () => {
       totalCount: 3,
       limit: 4,
       offset: 2,
+      searchType: 'DATABASE',
     };
     expect(response).toEqual(expected);
   });

--- a/servers/user-list-search/src/premiumSearch.integration.ts
+++ b/servers/user-list-search/src/premiumSearch.integration.ts
@@ -114,6 +114,7 @@ describe('premium search functional test', () => {
               hasNextPage
               hasPreviousPage
             }
+            searchType
             totalCount
           }
         }
@@ -377,6 +378,7 @@ describe('premium search functional test', () => {
     const response = res.body.data?._entities[0].searchSavedItems;
     expect(response).not.toBeNull();
     expect(response.totalCount).toEqual(3);
+    expect(response.searchType).toEqual('ELASTICSEARCH');
     expect(response.edges.length).toEqual(2);
     expect(response.pageInfo.hasNextPage).toBeFalse();
     expect(response.pageInfo.hasPreviousPage).toBeTrue();

--- a/servers/user-list-search/src/premiumSearchByOffset.integration.ts
+++ b/servers/user-list-search/src/premiumSearchByOffset.integration.ts
@@ -107,6 +107,7 @@ describe('premium search functional test (offset pagination)', () => {
                 title
               }
             }
+            searchType
             limit
             offset
             totalCount
@@ -286,6 +287,7 @@ describe('premium search functional test (offset pagination)', () => {
     const searchResult = res.body.data?._entities[0].searchSavedItemsByOffset;
     const expected = {
       entries: [],
+      searchType: 'ELASTICSEARCH',
       limit: 1,
       offset: 0,
       totalCount: 0,
@@ -330,6 +332,7 @@ describe('premium search functional test (offset pagination)', () => {
           }),
         },
       ],
+      searchType: 'ELASTICSEARCH',
       limit: 2,
       offset: 1,
       totalCount: 3,
@@ -365,6 +368,7 @@ describe('premium search functional test (offset pagination)', () => {
           }),
         },
       ],
+      searchType: 'ELASTICSEARCH',
       totalCount: 1,
       limit: 2,
       offset: 0,

--- a/servers/user-list-search/src/types.ts
+++ b/servers/user-list-search/src/types.ts
@@ -1,5 +1,10 @@
 import { PaginationInput } from '@pocket-tools/apollo-utils';
 
+export enum SearchType {
+  ELASTICSEARCH = 'ELASTICSEARCH',
+  DATABASE = 'DATABASE',
+}
+
 export type User = {
   id: string;
 };
@@ -32,6 +37,7 @@ export type PageInfo = {
 
 export type SavedItemSearchResultConnection = {
   edges: SearchSavedItemEdge[];
+  searchType: SearchType;
   pageInfo: PageInfo;
   totalCount: number;
 };
@@ -40,6 +46,7 @@ export type SavedItemSearchResultPage = {
   entries: SavedItemSearchResult[];
   offset: number;
   limit: number;
+  searchType: SearchType;
   totalCount: number;
 };
 


### PR DESCRIPTION
Supports v3 proxy response which includes what kind of search was performed.

Alternative considered: request the user's premium status as part of the response and infer what kind of search was done based on that.

Didn't do this because 
* it would add a dependency for another subgraph (User), making this search API less robust
* avoid coding derivative business logic in multiple places; better to stay close to the source

[POCKET-9630]

[POCKET-9630]: https://mozilla-hub.atlassian.net/browse/POCKET-9630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ