### PR TITLE
Revert "feat(search): add searchType to graph (#264)"

### DIFF
--- a/servers/user-list-search/schema.graphql
+++ b/servers/user-list-search/schema.graphql
@@ -23,17 +23,6 @@ enum SearchStatus {
 }
 
 """
-What search method was used -- elasticsearch cluster (premium)
-or searching on the database directly (free tier).
-"""
-enum SearchType {
-  """Corresponds to premium search"""
-  ELASTICSEARCH
-  """Corresponds to free tier search"""
-  DATABASE
-}
-
-"""
 Sort direction of the returned items.
 """
 enum SearchSortDirection {
@@ -194,7 +183,6 @@ A page of SavedItemSearchResult, retrieved by offset-based pagination.
 """
 type SavedItemSearchResultPage @tag(name: "internal") {
   entries: [SavedItemSearchResult!]!
-  searchType: SearchType!
   totalCount: Int!
   offset: Int!
   limit: Int!
@@ -230,10 +218,6 @@ type SavedItemSearchResultConnection {
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
-  """
-  What search method was used
-  """
-  searchType: SearchType!
 }
 
 """

--- a/servers/user-list-search/src/datasource/SavedItemsDataSource.ts
+++ b/servers/user-list-search/src/datasource/SavedItemsDataSource.ts
@@ -9,7 +9,6 @@ import {
   SearchSavedItemParameters,
   SavedItemSearchResultPage,
   SearchSavedItemOffsetParams,
-  SearchType,
 } from '../types';
 import { IContext } from '../server/context';
 import { validatePagination as externalValidatePagination } from '@pocket-tools/apollo-utils';
@@ -170,7 +169,6 @@ export class SavedItemDataService {
     return {
       entries,
       totalCount: totalcount,
-      searchType: SearchType.DATABASE,
       ...pageInput,
     };
   }
@@ -208,7 +206,7 @@ export class SavedItemDataService {
     // item_id sort is to resolve ties with stable sort (e.g. null sort field)
     baseQuery.orderBy(sortColumn, sortOrder.toLowerCase(), 'item_id', 'asc');
 
-    const searchResult = await paginate(
+    return paginate(
       // Need to use a subquery in order to order by derived fields ('archivedAt')
       this.db.select('*').from(baseQuery.as('page_query')),
       {
@@ -232,7 +230,5 @@ export class SavedItemDataService {
         }),
       },
     );
-    searchResult['searchType'] = SearchType.DATABASE;
-    return searchResult;
   }
 }

--- a/servers/user-list-search/src/datasource/elasticsearch/Paginator.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/Paginator.ts
@@ -5,7 +5,6 @@ import {
   SavedItemSearchResultConnection,
   SavedItemSearchResultPage,
   SearchSavedItemEdge,
-  SearchType,
 } from '../../types';
 
 /**
@@ -80,7 +79,6 @@ export class Paginator {
       ? input.hits.total
       : (input.hits.total as any).value;
     return {
-      searchType: SearchType.ELASTICSEARCH,
       edges,
       totalCount,
       pageInfo,

--- a/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.ts
@@ -12,7 +12,6 @@ import {
   SavedItemSearchResultPage,
   SavedItemSearchResult,
   AdvancedSearchByOffsetParams,
-  SearchType,
 } from '../../types';
 import { UserInputError, validatePagination } from '@pocket-tools/apollo-utils';
 import { SearchQueryBuilder } from './searchQueryBuilder';
@@ -623,7 +622,6 @@ export async function advancedSearchByOffset(
   const result = await advancedSearchBase(params, userId);
   const entries = Paginator.resultToPage(result);
   return {
-    searchType: SearchType.ELASTICSEARCH,
     ...entries,
     limit: params.pagination?.limit ?? config.pagination.defaultPageSize,
     offset: params.pagination?.offset ?? 0,
@@ -644,7 +642,6 @@ export async function searchSavedItemsByOffset(
   }));
   return {
     entries,
-    searchType: SearchType.ELASTICSEARCH,
     limit: searchParams.size,
     offset: searchParams.from,
     totalCount: result.hits.total['value'],
@@ -702,7 +699,6 @@ export async function searchSavedItems(
     (searchParams.from + searchResultsEdges.length - 1).toString(),
   ).toString('base64');
   const response = {
-    searchType: SearchType.ELASTICSEARCH,
     edges: searchResultsEdges,
     pageInfo: {
       endCursor: searchResultsEdges.length == 0 ? null : endCursor,

--- a/servers/user-list-search/src/freeSearch.integration.ts
+++ b/servers/user-list-search/src/freeSearch.integration.ts
@@ -107,7 +107,6 @@ describe('free search test', () => {
       hasNextPage
       hasPreviousPage
     }
-    searchType
     totalCount`;
 
   it('should search paginated search with after and first', async () => {
@@ -144,7 +143,6 @@ describe('free search test', () => {
     expect(response.totalCount).toBe(3);
     expect(response.pageInfo.hasNextPage).toBeFalse();
     expect(response.pageInfo.hasPreviousPage).toBeTrue();
-    expect(response.searchType).toBe('DATABASE');
     expect(response.edges[0].node.savedItem.id).toBe('456');
     expect(response.edges[1].node.savedItem.id).toBe('12345');
   });
@@ -482,7 +480,6 @@ describe('free search test', () => {
     expect(response.totalCount).toBe(3);
     expect(response.pageInfo.hasNextPage).toBeFalse();
     expect(response.pageInfo.hasPreviousPage).toBeTrue();
-    expect(response.searchType).toBe('DATABASE');
     expect(response.edges[0].node.savedItem.id).toBe('456');
     expect(response.edges[1].node.savedItem.id).toBe('12345');
   });

--- a/servers/user-list-search/src/freeSearchByOffset.integration.ts
+++ b/servers/user-list-search/src/freeSearchByOffset.integration.ts
@@ -106,7 +106,6 @@ describe('free-tier search (offset pagination)', () => {
     offset
     limit
     totalCount
-    searchType
   }`;
 
   it('should search paginated search with limit and offset', async () => {
@@ -148,7 +147,6 @@ describe('free-tier search (offset pagination)', () => {
       totalCount: 3,
       limit: 4,
       offset: 2,
-      searchType: 'DATABASE',
     };
     expect(response).toEqual(expected);
   });
@@ -222,7 +220,6 @@ describe('free-tier search (offset pagination)', () => {
       totalCount: 1,
       limit: 2,
       offset: 0,
-      searchType: 'DATABASE',
     };
     expect(response).toEqual(expected);
   });
@@ -261,7 +258,6 @@ describe('free-tier search (offset pagination)', () => {
       totalCount: 0,
       limit: 4,
       offset: 0,
-      searchType: 'DATABASE',
     };
     expect(response).toEqual(expected);
   });
@@ -304,7 +300,6 @@ describe('free-tier search (offset pagination)', () => {
       totalCount: 1,
       limit: 2,
       offset: 0,
-      searchType: 'DATABASE',
     };
     expect(response).toEqual(expected);
   });
@@ -428,7 +423,6 @@ describe('free-tier search (offset pagination)', () => {
       totalCount: 3,
       limit: 4,
       offset: 2,
-      searchType: 'DATABASE',
     };
     expect(response).toEqual(expected);
   });

--- a/servers/user-list-search/src/premiumSearch.integration.ts
+++ b/servers/user-list-search/src/premiumSearch.integration.ts
@@ -114,7 +114,6 @@ describe('premium search functional test', () => {
               hasNextPage
               hasPreviousPage
             }
-            searchType
             totalCount
           }
         }
@@ -378,7 +377,6 @@ describe('premium search functional test', () => {
     const response = res.body.data?._entities[0].searchSavedItems;
     expect(response).not.toBeNull();
     expect(response.totalCount).toEqual(3);
-    expect(response.searchType).toEqual('ELASTICSEARCH');
     expect(response.edges.length).toEqual(2);
     expect(response.pageInfo.hasNextPage).toBeFalse();
     expect(response.pageInfo.hasPreviousPage).toBeTrue();

--- a/servers/user-list-search/src/premiumSearchByOffset.integration.ts
+++ b/servers/user-list-search/src/premiumSearchByOffset.integration.ts
@@ -107,7 +107,6 @@ describe('premium search functional test (offset pagination)', () => {
                 title
               }
             }
-            searchType
             limit
             offset
             totalCount
@@ -287,7 +286,6 @@ describe('premium search functional test (offset pagination)', () => {
     const searchResult = res.body.data?._entities[0].searchSavedItemsByOffset;
     const expected = {
       entries: [],
-      searchType: 'ELASTICSEARCH',
       limit: 1,
       offset: 0,
       totalCount: 0,
@@ -332,7 +330,6 @@ describe('premium search functional test (offset pagination)', () => {
           }),
         },
       ],
-      searchType: 'ELASTICSEARCH',
       limit: 2,
       offset: 1,
       totalCount: 3,
@@ -368,7 +365,6 @@ describe('premium search functional test (offset pagination)', () => {
           }),
         },
       ],
-      searchType: 'ELASTICSEARCH',
       totalCount: 1,
       limit: 2,
       offset: 0,

--- a/servers/user-list-search/src/types.ts
+++ b/servers/user-list-search/src/types.ts
@@ -1,10 +1,5 @@
 import { PaginationInput } from '@pocket-tools/apollo-utils';
 
-export enum SearchType {
-  ELASTICSEARCH = 'ELASTICSEARCH',
-  DATABASE = 'DATABASE',
-}
-
 export type User = {
   id: string;
 };
@@ -37,7 +32,6 @@ export type PageInfo = {
 
 export type SavedItemSearchResultConnection = {
   edges: SearchSavedItemEdge[];
-  searchType: SearchType;
   pageInfo: PageInfo;
   totalCount: number;
 };
@@ -46,7 +40,6 @@ export type SavedItemSearchResultPage = {
   entries: SavedItemSearchResult[];
   offset: number;
   limit: number;
-  searchType: SearchType;
   totalCount: number;
 };
 


### PR DESCRIPTION
This reverts commit bffde026e23c7a05c9c058de0d7082cc3c8b5f27.

Turns out this supports an undocumented and unused response in /v3/get, so let's not clutter our graph.