### PR TITLE
fix(v3proxy): fix filters and total+complete response

### DIFF
--- a/servers/v3-proxy-api/src/graph/get/toGraphQL.spec.ts
+++ b/servers/v3-proxy-api/src/graph/get/toGraphQL.spec.ts
@@ -19,7 +19,6 @@ describe('toGraphQL', () => {
           sortBy: SavedItemsSortBy.CreatedAt,
           sortOrder: SavedItemsSortOrder.Desc,
         },
-        filter: {},
       };
       expect(setSavedItemsVariables(defaultQuery)).toEqual(expected);
     });
@@ -31,7 +30,7 @@ describe('toGraphQL', () => {
         },
         {
           params: { state: 'all' as const },
-          expected: { filter: {} },
+          expected: {},
         },
         {
           params: { favorite: true, tag: 'recipe' },
@@ -146,7 +145,6 @@ describe('toGraphQL', () => {
           sortBy: SearchItemsSortBy.Relevance,
           sortOrder: SavedItemsSortOrder.Desc,
         },
-        filter: {},
         term: 'abc',
       };
       expect(setSearchVariables(defaultSearchQuery)).toEqual(expected);
@@ -229,7 +227,7 @@ describe('toGraphQL', () => {
         },
         {
           params: { state: 'all' as const },
-          expected: { filter: {} },
+          expected: {},
         },
       ])(
         'maps filter as expected, including combos and unused',

--- a/servers/v3-proxy-api/src/graph/get/toGraphQL.ts
+++ b/servers/v3-proxy-api/src/graph/get/toGraphQL.ts
@@ -195,14 +195,18 @@ export function setSavedItemsVariables(
 ): UserSavedItemsByOffsetArgs {
   const filter = SavedItemsFilterFactory(requestParams);
   const sort = SavedItemsSortFactory(requestParams);
-  return {
+  const variables = {
     pagination: {
       limit: requestParams.count,
       offset: requestParams.offset,
     },
     sort,
-    filter,
   };
+  // Attach filter only if not empty
+  if (Object.keys(filter).length) {
+    variables['filter'] = filter;
+  }
+  return variables;
 }
 
 export function setSearchVariables(
@@ -210,13 +214,18 @@ export function setSearchVariables(
 ): UserSearchSavedItemsByOffsetArgs {
   const sort = SearchSortFactory(requestParams);
   const filter = SearchFilterFactory(requestParams);
-  return {
+
+  const variables = {
     term: requestParams.search,
     pagination: {
       limit: requestParams.count,
       offset: requestParams.offset,
     },
     sort,
-    filter,
   };
+  // Attach filter only if not empty
+  if (Object.keys(filter).length) {
+    variables['filter'] = filter;
+  }
+  return variables;
 }

--- a/servers/v3-proxy-api/src/routes/v3Get.ts
+++ b/servers/v3-proxy-api/src/routes/v3Get.ts
@@ -15,6 +15,7 @@ import {
   savedItemsSimpleTotalToRest,
   searchSavedItemCompleteToRest,
   searchSavedItemCompleteTotalToRest,
+  savedItemsCompleteTotalToRest,
   searchSavedItemSimpleTotalToRest,
   searchSavedItemSimpleToRest,
 } from '../graph/get/toRest';
@@ -120,7 +121,7 @@ export async function processV3call(
         variables,
       );
       if (data.total) {
-        return savedItemsSimpleTotalToRest(response);
+        return savedItemsCompleteTotalToRest(response);
       } else {
         return savedItemsCompleteToRest(response);
       }


### PR DESCRIPTION
Do not pass an empty filters object (graphql is rejecting it), instead only add filters to the variables if they are relevant.

Fix a bug where the Simple transformer was being called when it should have been the Complete transformer.