### PR TITLE
fix(search): case-insensitive search for fallback title

### DIFF
--- a/servers/user-list-search/src/datasource/SavedItemsDataSource.ts
+++ b/servers/user-list-search/src/datasource/SavedItemsDataSource.ts
@@ -118,7 +118,9 @@ export class SavedItemDataService {
             'like',
             `%${term}%`,
           )
-          .orWhere('readitla_b.items_extended.title', 'like', `%${term}%`);
+          .orWhereRaw(`LOWER(readitla_b.items_extended.title) LIKE ?`, [
+            `%${term}%`,
+          ]);
       });
   }
 
@@ -145,7 +147,8 @@ export class SavedItemDataService {
     const sortOrder = params.sort ? params.sort.sortOrder : 'DESC';
     const sortColumn =
       params.sort?.sortBy == `TIME_TO_READ` ? `word_count` : 'time_added';
-    let baseQuery = this.buildQuery(params.term).andWhere(
+    const term = params.term.toLowerCase();
+    let baseQuery = this.buildQuery(term).andWhere(
       'readitla_ril-tmp.list.user_id',
       this.userId,
     );
@@ -190,7 +193,8 @@ export class SavedItemDataService {
     const sortOrder = params.sort ? params.sort.sortOrder : 'DESC';
     const sortColumn =
       params.sort?.sortBy == `TIME_TO_READ` ? `word_count` : 'time_added';
-    let baseQuery = this.buildQuery(params.term).andWhere(
+    const term = params.term.toLowerCase();
+    let baseQuery = this.buildQuery(term).andWhere(
       'readitla_ril-tmp.list.user_id',
       this.userId,
     );


### PR DESCRIPTION
The resolved_title (items_extended.title) field is not case-insensitive in the database. Lowercase it for searching, and also lowercase the search term just in case. in case.

[POCKET-9723]

[POCKET-9723]: https://mozilla-hub.atlassian.net/browse/POCKET-9723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ