### PR TITLE
feat(toplevel): adding in the toplevel v3 responses

### DIFF
--- a/servers/v3-proxy-api/src/graph/get/toRest.spec.ts
+++ b/servers/v3-proxy-api/src/graph/get/toRest.spec.ts
@@ -7,6 +7,7 @@ import {
   searchSavedItemSimpleToRest,
   searchSavedItemCompleteToRest,
   savedItemsFetchToRest,
+  savedItemsFetchSharesToRest,
 } from './toRest';
 import { GetResponseSimple } from '../types';
 import {
@@ -34,6 +35,7 @@ import {
   expectedFetch,
   mockGraphGetSimpleTitle,
   expectedGetSimpleTitle,
+  expectedSharesFetch,
 } from '../../test/fixtures';
 
 describe('GraphQL <> Rest convesion', () => {
@@ -115,6 +117,11 @@ describe('GraphQL <> Rest convesion', () => {
       } = seedDataRest;
       const restResponse: GetResponseSimple = {
         cachetype: 'db',
+        maxActions: 30,
+        status: 1,
+        complete: 1,
+        since: 1677818995,
+        error: null,
         list: {
           id1: {
             favorite,
@@ -189,12 +196,20 @@ describe('GraphQL <> Rest convesion', () => {
   });
 
   describe('convertSavedItemsFetch', () => {
-    it('should transform graphql savedItemsByOffset response to rest response', () => {
+    it('should transform graphql savedItemsByOffset response to fetch response', () => {
       const res = savedItemsFetchToRest(
         { chunk: '1', fetchChunkSize: '250', firstChunkSize: '25' },
         mockGraphGetComplete,
       );
       expect(res).toEqual(expectedFetch);
+    });
+
+    it('should transform graphql savedItemsByOffset response to fetch shared response', () => {
+      const res = savedItemsFetchSharesToRest(
+        { chunk: '1', fetchChunkSize: '250', firstChunkSize: '25' },
+        mockGraphGetComplete,
+      );
+      expect(res).toEqual(expectedSharesFetch);
     });
   });
 });

--- a/servers/v3-proxy-api/src/graph/types.ts
+++ b/servers/v3-proxy-api/src/graph/types.ts
@@ -23,8 +23,8 @@ export type GetResponseSimple = {
   //todo: add top level fields
   //e.g status, complete - as they are not mapped by developer portal docs
   list: { [key: string]: ListItemObject };
-  cachetype: string;
-};
+} & GetStaticResponse &
+  GetTopLevelDefaultResponse;
 
 export type SearchMeta = {
   search_meta: {
@@ -66,18 +66,41 @@ export type GetSearchResponseCompleteTotal = GetSearchResponseComplete & {
   total: string;
 };
 
-export type GetResponseComplete = {
-  //todo: add top level fields
-  //e.g status, complete - as they are not mapped by developer portal docs
-  // note that complete returns 1 for detailType=simple and
-  // detailType=complete when querying v3 API directly
-  // since: number;
-  // maxActions: number;
-  // error: ?;
-  // search_meta: {search_type: "normal"}
-  list: { [key: string]: ListItemObjectComplete };
+/**
+ * Represents a static response that we still need to return from Get with static
+ */
+export type GetStaticResponse = {
+  // Always return 30.
+  maxActions: number;
   cachetype: string;
 };
+
+/**
+ * Represents a static response that we still need to return from Get with empty values when a client requests `shares=1`
+ */
+export type GetSharesResponse = {
+  // empty data fields that used to have a use, but now are empty and Android will crash without.
+  recent_friends: [];
+  auto_complete_emails: [];
+  unconfirmed_shares: [];
+};
+
+/**
+ * Represents a set of fields that are always included in /v3/get responses
+ */
+export type GetTopLevelDefaultResponse = {
+  complete: number; // 0 if preg_match('/^[0-9]*$/', $since) && $since > 0, else 1
+  status: number; // 1 if no error & list > 0, 2 if no error & list == 0, 0 if error
+  since: number; // unix timestamp of the last updated at in the response of items
+  error: number; // maps to pocket error codes or null if no error
+};
+
+export type GetResponseComplete = {
+  // search_meta: { search_type: 'normal' };
+  list: { [key: string]: ListItemObjectComplete };
+} & GetStaticResponse &
+  GetTopLevelDefaultResponse;
+
 export type GetResponseSimpleTotal = GetResponseSimple & { total: string };
 export type GetResponseCompleteTotal = GetResponseComplete & {
   total: string;

--- a/servers/v3-proxy-api/src/test/fixtures/fetch.ts
+++ b/servers/v3-proxy-api/src/test/fixtures/fetch.ts
@@ -1,7 +1,11 @@
-import { FetchResponse } from '../../graph/types';
+import { FetchResponse, GetSharesResponse } from '../../graph/types';
 
 export const expectedFetch: FetchResponse = {
-  // TODO: Update additional top-level fields when implemented
+  complete: 1,
+  status: 1,
+  error: null,
+  since: 1706732550,
+  maxActions: 30,
   total: '10',
   passthrough: {
     chunk: '1',
@@ -145,4 +149,11 @@ export const expectedFetch: FetchResponse = {
       listen_duration_estimate: 0,
     },
   },
+};
+
+export const expectedSharesFetch: FetchResponse & GetSharesResponse = {
+  ...expectedFetch,
+  unconfirmed_shares: [],
+  recent_friends: [],
+  auto_complete_emails: [],
 };

--- a/servers/v3-proxy-api/src/test/fixtures/fixtures.ts
+++ b/servers/v3-proxy-api/src/test/fixtures/fixtures.ts
@@ -102,8 +102,6 @@ type MockListItemObject = Omit<ListItemObject, 'item_id' | 'resolved_id'> & {
 };
 /**
  * return REST v3 GET response for given Ids
- * //todo: need to include tags, images, videoes etc
- * //todo: map top level fields and sort_id
  * @param ids
  */
 export const testV3GetResponse = (
@@ -142,6 +140,11 @@ export const testV3GetResponse = (
   });
 
   return {
+    complete: 1,
+    status: 1,
+    error: null,
+    since: 1677818995,
+    maxActions: 30,
     cachetype: 'db',
     list: map,
   };

--- a/servers/v3-proxy-api/src/test/fixtures/get-search.ts
+++ b/servers/v3-proxy-api/src/test/fixtures/get-search.ts
@@ -12,8 +12,6 @@ import {
 } from '../../graph/types';
 
 export const expectedFreeTierResponseSimple: GetSearchResponseSimple = {
-  // status: 1,
-  // complete: 1,
   list: {
     '282381128': {
       item_id: '282381128',
@@ -74,20 +72,26 @@ export const expectedFreeTierResponseSimple: GetSearchResponseSimple = {
       highlights: null,
     },
   },
-  // error: null,
   search_meta: {
     total_result_count: 2,
     offset: 0,
     count: 30,
     has_more: false,
   },
+  complete: 1,
+  status: 1,
+  error: null,
+  since: 1709662321,
+  maxActions: 30,
   cachetype: 'db',
-  // maxActions: 30,
-  // since: 1709844782,
 };
 export const expectedFreeTierResponseComplete: GetSearchResponseComplete = {
-  // status: 1,
-  // complete: 1,
+  complete: 1,
+  status: 1,
+  error: null,
+  since: 1709662321,
+  maxActions: 30,
+  cachetype: 'db',
   list: {
     '282381128': {
       item_id: '282381128',
@@ -164,32 +168,28 @@ export const expectedFreeTierResponseComplete: GetSearchResponseComplete = {
       highlights: null,
     },
   },
-  // error: null,
   search_meta: {
     offset: 0,
     count: 30,
     total_result_count: 2,
     has_more: false,
   },
-  cachetype: 'db',
-  // maxActions: 30,
-  // since: 1709663533,
 };
 
 export const expectedFreeTierSearchNoResults: GetSearchResponseSimple = {
-  // status: 2,
-  // complete: 1,
+  complete: 1,
+  status: 2,
+  error: null,
+  since: 0,
+  maxActions: 30,
+  cachetype: 'db',
   list: [],
-  // error: null,
   search_meta: {
     offset: 0,
     count: 30,
     total_result_count: 0,
     has_more: false,
   },
-  cachetype: 'db',
-  // maxActions: 30,
-  // since: 1709844694,
 };
 
 export const graphSearchNoResults = {
@@ -386,8 +386,12 @@ export const freeTierSearchGraphComplete = {
 };
 
 export const expectedPremiumTierResponseSimple: GetSearchResponseSimple = {
-  // status: 1,
-  // complete: 1,
+  complete: 1,
+  status: 1,
+  error: null,
+  since: 1659049987,
+  maxActions: 30,
+  cachetype: 'db',
   list: {
     '3670270497': {
       item_id: '3670270497',
@@ -504,21 +508,21 @@ export const expectedPremiumTierResponseSimple: GetSearchResponseSimple = {
       listen_duration_estimate: 0, // 886,
     },
   },
-  // error: null,
   search_meta: {
     total_result_count: 22,
     count: 3,
     offset: 0,
     has_more: true,
   },
-  cachetype: 'db',
-  // maxActions: 30,
-  // since: 1709845037,
 };
 
 export const expectedPremiumTierResponseComplete: GetSearchResponseComplete = {
-  // status: 1,
-  // complete: 1,
+  complete: 1,
+  status: 1,
+  error: null,
+  since: 1659049987,
+  maxActions: 30,
+  cachetype: 'db',
   list: {
     '3670270497': {
       item_id: '3670270497',
@@ -853,16 +857,12 @@ export const expectedPremiumTierResponseComplete: GetSearchResponseComplete = {
       listen_duration_estimate: 0, // 886,
     },
   },
-  // error: null,
   search_meta: {
     total_result_count: 22,
     count: 3,
     offset: 0,
     has_more: true,
   },
-  cachetype: 'db',
-  // maxActions: 30,
-  // since: 1709845096,
 };
 
 export const premiumSearchGraphComplete: SearchSavedItemsByOffsetCompleteQuery =

--- a/servers/v3-proxy-api/src/test/fixtures/get.ts
+++ b/servers/v3-proxy-api/src/test/fixtures/get.ts
@@ -231,7 +231,11 @@ export const mockGraphGetSimple: GetSavedItemsByOffsetSimpleQuery = {
 };
 
 export const expectedGetComplete: GetResponseComplete = {
-  // TODO: Update additional top-level fields when implemented
+  complete: 1,
+  status: 1,
+  error: null,
+  since: 1706732550,
+  maxActions: 30,
   cachetype: 'db',
   list: {
     '11231399273': {
@@ -377,7 +381,11 @@ export const expectedGetCompleteTotal: GetResponseCompleteTotal = {
 };
 
 export const expectedGetSimple: GetResponseSimple = {
-  // TODO: Update additional top-level fields when implemented
+  complete: 1,
+  status: 1,
+  error: null,
+  since: 1706732550,
+  maxActions: 30,
   cachetype: 'db',
   list: {
     '11231399273': {
@@ -468,9 +476,14 @@ export const mockGraphGetSimpleTitle: GetSavedItemsByOffsetSimpleQuery = {
 };
 
 export const expectedGetSimpleTitle: GetResponseSimple = {
+  complete: 1,
+  status: 1,
+  error: null,
+  since: 1706732550,
+  maxActions: 30,
+  cachetype: 'db',
   // First one, title falls back to resolved_title
   // Second one, have a title
-  cachetype: 'db',
   list: {
     '11231399273': {
       ...expectedGetSimple.list['11231399273'],


### PR DESCRIPTION
## Goal

Add the top level response fields into the v3 rest response like:
* status
* complete
* error
* maxActions
* since

https://mozilla-hub.atlassian.net/browse/POCKET-9725

## Not Implemented

This does not implement `error` codes or `complete` fully. we will followup with those