### PR TITLE
feat(search): add domain filter to free tier search

### DIFF
--- a/servers/user-list-search/src/datasource/SavedItemsDataSource.ts
+++ b/servers/user-list-search/src/datasource/SavedItemsDataSource.ts
@@ -13,6 +13,7 @@ import {
 import { IContext } from '../server/context';
 import { validatePagination as externalValidatePagination } from '@pocket-tools/apollo-utils';
 import { config } from '../config';
+import { getCleanedupDomainName } from './elasticsearch/elasticsearchSearch';
 
 export class SavedItemDataService {
   private db: Knex;
@@ -63,7 +64,18 @@ export class SavedItemDataService {
     if (filter.contentType != null) {
       SavedItemDataService.contentTypeFilter(baseQuery, filter.contentType);
     }
-
+    if (filter.domain != null) {
+      const cleanDomain = getCleanedupDomainName(filter.domain);
+      baseQuery.andWhere((builder) => {
+        builder
+          .where('readitla_ril-tmp.list.given_url', 'LIKE', `%${cleanDomain}%`)
+          .orWhere(
+            'readitla_b.items_extended.resolved_url',
+            'LIKE',
+            `%${cleanDomain}%`,
+          );
+      });
+    }
     return baseQuery;
   }
 

--- a/servers/user-list-search/src/freeSearch.integration.ts
+++ b/servers/user-list-search/src/freeSearch.integration.ts
@@ -47,6 +47,16 @@ async function seedDb(db: Knex) {
       date: new Date('2020-10-03 10:20:30'),
       wordCount: 10,
     },
+    {
+      favorite: 0,
+      itemId: 777,
+      status: SavedItemStatus.UNREAD,
+      title: 'sports ball',
+      url: 'http://differentdomain.com',
+      date: new Date('2021-5-03 10:20:30'),
+      wordCount: 100,
+      isVideo: 1,
+    },
   ];
   await Promise.all(
     data.flatMap((record) => [
@@ -262,6 +272,38 @@ describe('free search test', () => {
     expect(response.totalCount).toBe(2);
     expect(response.edges[0].node.savedItem.id).toBe('456');
     expect(response.edges[1].node.savedItem.id).toBe('789');
+  });
+
+  it('should only return results from a specific domain', async () => {
+    const SEARCH_SAVED_ITEM_QUERY = `
+      query searchSavedItem(
+        $id: ID!
+        $term: String!
+        $filter: SearchFilterInput
+      ) {
+        _entities(representations: { id: $id, __typename: "User" }) {
+          ... on User {
+            searchSavedItems(term: $term, filter: $filter) {
+              ${query}
+            }
+          }
+        }
+      }
+    `;
+    const variables = {
+      id: '1',
+      term: 'sports',
+      filter: {
+        domain: 'www.differentdomain.com',
+      },
+    };
+    const res = await request(app).post(url).set(headers).send({
+      query: SEARCH_SAVED_ITEM_QUERY,
+      variables,
+    });
+    const response = res.body.data?._entities[0].searchSavedItems;
+    expect(response.totalCount).toBe(1);
+    expect(response.edges[0].node.savedItem.id).toBe('777');
   });
 
   it('should return empty search result when term not found', async () => {


### PR DESCRIPTION
Add domain filter to free tier search. This aligns current behavior with /v3 free-tier search behavior.

[POCKET-9726]

[POCKET-9726]: https://mozilla-hub.atlassian.net/browse/POCKET-9726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ