### PR TITLE
fix(sentry): ensuring that we do not truncate sentry

### DIFF
--- a/servers/v3-proxy-api/src/main.ts
+++ b/servers/v3-proxy-api/src/main.ts
@@ -11,15 +11,28 @@ import v3GetRouter from './routes/v3Get';
 import v3AddRouter from './routes/v3Add';
 import v3FetchRouter from './routes/v3Fetch';
 
-Sentry.init({
-  ...config.sentry,
-  debug: config.sentry.environment == 'development',
-});
-
 //todo: set telemetry -
 // would it make sense to add them here or directly export/add to this package
 
 export const app: Application = express();
+
+Sentry.init({
+  ...config.sentry,
+  includeLocalVariables: true,
+  maxValueLength: 2000,
+  integrations: [
+    // Autoload will pull in mysql, apollo and graphql
+    // https://github.com/getsentry/sentry-javascript/blob/1f3a796e904e2f84148db80304cb5bdb83a04cb1/packages/tracing-internal/src/node/integrations/lazy.ts#L13
+    ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
+    // enable HTTP calls tracing
+    new Sentry.Integrations.Http({ tracing: true }),
+    // enable Express.js middleware tracing
+    new Sentry.Integrations.Express({
+      // to trace all requests to the default router
+      app,
+    }),
+  ],
+});
 
 app.use(json());
 app.set('query parser', 'simple');


### PR DESCRIPTION
## Goal

Make sentry not truncate errors.

## Implementation details
This is a copy paste of the sentry init from apollo-utils, but i didnt want to use that just yet because then that would make v3 proxy include apollo stuff which is not needed atm.