### PR TITLE
fix(jq-aws): fixing a jq & aws update

### DIFF
--- a/.circleci/common.yml
+++ b/.circleci/common.yml
@@ -408,7 +408,6 @@ jobs:
     steps:
       - exit-early-if-irrelevant:
           for: << parameters.for >>
-      - jq/install
       - run:
           name: Deploy Lambda
           command: |

--- a/.circleci/common.yml
+++ b/.circleci/common.yml
@@ -4,7 +4,6 @@ orbs:
   aws-cli: circleci/aws-cli@2.0.6
   aws-ecr: circleci/aws-ecr@7.3.0
   aws-code-deploy: circleci/aws-code-deploy@3.0.0
-  jq: circleci/jq@3.0.0
 
 # This is an enum that is used within all our jobs and our exit early job.
 # As a new "service/deployment" is added you should add to the enum.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,25 +47,25 @@ jobs:
           config-path: /tmp/generated-config.yml
           output-path: /tmp/pipeline-parameters.json
           mapping: |
-            ((servers|infrastructure)/image-api/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile) image_api true
-            ((servers|infrastructure|lambdas)/annotations-api.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile) annotations_api true
-            ((servers|infrastructure)/shared-snowplow-consumer/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile) shared_snowplow_consumer true
-            ((servers|infrastructure)/parser-graphql-wrapper/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile) parser_graphql_wrapper true
-            ((lambdas|infrastructure)/transactional-emails.*)|(packages/.*)|(pnpm-lock\.yaml) transactional_emails true
-            ((lambdas|infrastructure)/fxa-webhook-proxy-.*)|(packages/.*)|(pnpm-lock\.yaml) fxa_webhook_proxy true
-            ((servers|infrastructure)/user-api/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile) user_api true
-            ((servers|infrastructure)/list-api/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile) list_api true
-            ((servers|infrastructure)/client-api/.*) client_api true
-            ((servers|infrastructure)/feature-flags/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile) feature_flags true
-            ((lambdas|infrastructure)/sendgrid-data/.*) sendgrid_data true
-            ((lambdas|infrastructure|servers)/account-data-deleter/.*)|(packages/.*)|(pnpm-lock\.yaml)|(.circleci/account-data-deleter.yml) account_data_deleter true
-            ((lambdas|infrastructure)/account-delete-monitor/.*)|(packages/.*)|(pnpm-lock\.yaml)|(.circleci/account-delete-monitor.yml) account_delete_monitor true
-            ((servers|infrastructure|lambdas)/shareable-lists-api/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile) shareable_lists_api true
-            ((infrastructure)/pocket-event-bridge/.*)|(packages/.*)|(pnpm-lock\.yaml)|(.circleci/pocket-event-bridge.yml) pocket_event_bridge true
-            ((servers|infrastructure|lambdas)/user-list-search.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile)|(.circleci/user-list-search.yml) user_list_search true
-            ((infrastructure)/braze/.*)|(packages/.*)|(pnpm-lock\.yaml)|(.circleci/braze.yml) braze true
-            ((servers|infrastructure)/v3-proxy-api/.*)|(packages/.*)|(pnpm-lock\.yaml)|(.circleci/v3-proxy-api.yml) v3_proxy_api true
-            ((servers|infrastructure)/push-server/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile)|(.circleci/push-server.yml) push_server true
+            ((servers|infrastructure)/image-api/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile)|(.circleci/common.yml) image_api true
+            ((servers|infrastructure|lambdas)/annotations-api.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile)|(.circleci/common.yml) annotations_api true
+            ((servers|infrastructure)/shared-snowplow-consumer/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile)|(.circleci/common.yml) shared_snowplow_consumer true
+            ((servers|infrastructure)/parser-graphql-wrapper/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile)|(.circleci/common.yml) parser_graphql_wrapper true
+            ((lambdas|infrastructure)/transactional-emails.*)|(packages/.*)|(pnpm-lock\.yaml)|(.circleci/common.yml) transactional_emails true
+            ((lambdas|infrastructure)/fxa-webhook-proxy-.*)|(packages/.*)|(pnpm-lock\.yaml)|(.circleci/common.yml) fxa_webhook_proxy true
+            ((servers|infrastructure)/user-api/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile)|(.circleci/common.yml) user_api true
+            ((servers|infrastructure)/list-api/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile)|(.circleci/common.yml) list_api true
+            ((servers|infrastructure)/client-api/.*)|(.circleci/common.yml) client_api true
+            ((servers|infrastructure)/feature-flags/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile)|(.circleci/common.yml) feature_flags true
+            ((lambdas|infrastructure)/sendgrid-data/.*)|(.circleci/common.yml) sendgrid_data true
+            ((lambdas|infrastructure|servers)/account-data-deleter/.*)|(packages/.*)|(pnpm-lock\.yaml)|(.circleci/account-data-deleter.yml)|(.circleci/common.yml) account_data_deleter true
+            ((lambdas|infrastructure)/account-delete-monitor/.*)|(packages/.*)|(pnpm-lock\.yaml)|(.circleci/account-delete-monitor.yml)|(.circleci/common.yml) account_delete_monitor true
+            ((servers|infrastructure|lambdas)/shareable-lists-api/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile)|(.circleci/common.yml) shareable_lists_api true
+            ((infrastructure)/pocket-event-bridge/.*)|(packages/.*)|(pnpm-lock\.yaml)|(.circleci/pocket-event-bridge.yml)|(.circleci/common.yml) pocket_event_bridge true
+            ((servers|infrastructure|lambdas)/user-list-search.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile)|(.circleci/user-list-search.yml)|(.circleci/common.yml) user_list_search true
+            ((infrastructure)/braze/.*)|(packages/.*)|(pnpm-lock\.yaml)|(.circleci/braze.yml)|(.circleci/common.yml) braze true
+            ((servers|infrastructure)/v3-proxy-api/.*)|(packages/.*)|(pnpm-lock\.yaml)|(.circleci/v3-proxy-api.yml)|(.circleci/common.yml) v3_proxy_api true
+            ((servers|infrastructure)/push-server/.*)|(packages/.*)|(pnpm-lock\.yaml)|(Dockerfile)|(.circleci/push-server.yml)|(.circleci/common.yml) push_server true
 
       - continuation/continue:
           configuration_path: /tmp/generated-config.yml

--- a/package.json
+++ b/package.json
@@ -28,5 +28,10 @@
   "name": "pocket-monorepo",
   "engines": {
     "node": "^20.11"
+  },
+  "pnpm": {
+    "overrides": {
+      "@smithy/util-endpoints": "1.1.2"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@smithy/util-endpoints': 1.1.2
+
 importers:
 
   .:
@@ -2590,7 +2593,7 @@ packages:
       '@smithy/util-body-length-node': 2.3.0
       '@smithy/util-defaults-mode-browser': 2.2.0
       '@smithy/util-defaults-mode-node': 2.3.0
-      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-endpoints': 1.1.2
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
@@ -2640,7 +2643,7 @@ packages:
       '@smithy/util-body-length-node': 2.3.0
       '@smithy/util-defaults-mode-browser': 2.2.0
       '@smithy/util-defaults-mode-node': 2.3.0
-      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-endpoints': 1.1.2
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
@@ -2691,7 +2694,7 @@ packages:
       '@smithy/util-body-length-node': 2.3.0
       '@smithy/util-defaults-mode-browser': 2.2.0
       '@smithy/util-defaults-mode-node': 2.3.0
-      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-endpoints': 1.1.2
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
@@ -2738,7 +2741,7 @@ packages:
       '@smithy/util-body-length-node': 2.3.0
       '@smithy/util-defaults-mode-browser': 2.2.0
       '@smithy/util-defaults-mode-node': 2.3.0
-      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-endpoints': 1.1.2
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
@@ -2789,7 +2792,7 @@ packages:
       '@smithy/util-body-length-node': 2.3.0
       '@smithy/util-defaults-mode-browser': 2.2.0
       '@smithy/util-defaults-mode-node': 2.3.0
-      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-endpoints': 1.1.2
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
@@ -2841,7 +2844,7 @@ packages:
       '@smithy/util-body-length-node': 2.3.0
       '@smithy/util-defaults-mode-browser': 2.2.0
       '@smithy/util-defaults-mode-node': 2.3.0
-      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-endpoints': 1.1.2
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-stream': 2.2.0
@@ -2891,7 +2894,7 @@ packages:
       '@smithy/util-body-length-node': 2.3.0
       '@smithy/util-defaults-mode-browser': 2.2.0
       '@smithy/util-defaults-mode-node': 2.3.0
-      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-endpoints': 1.1.2
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
@@ -2942,7 +2945,7 @@ packages:
       '@smithy/util-body-length-node': 2.3.0
       '@smithy/util-defaults-mode-browser': 2.2.0
       '@smithy/util-defaults-mode-node': 2.3.0
-      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-endpoints': 1.1.2
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
@@ -2990,7 +2993,7 @@ packages:
       '@smithy/util-body-length-node': 2.3.0
       '@smithy/util-defaults-mode-browser': 2.2.0
       '@smithy/util-defaults-mode-node': 2.3.0
-      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-endpoints': 1.1.2
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
@@ -3042,7 +3045,7 @@ packages:
       '@smithy/util-body-length-node': 2.3.0
       '@smithy/util-defaults-mode-browser': 2.2.0
       '@smithy/util-defaults-mode-node': 2.3.0
-      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-endpoints': 1.1.2
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
@@ -3088,7 +3091,7 @@ packages:
       '@smithy/util-body-length-node': 2.3.0
       '@smithy/util-defaults-mode-browser': 2.2.0
       '@smithy/util-defaults-mode-node': 2.3.0
-      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-endpoints': 1.1.2
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
@@ -3137,7 +3140,7 @@ packages:
       '@smithy/util-body-length-node': 2.3.0
       '@smithy/util-defaults-mode-browser': 2.2.0
       '@smithy/util-defaults-mode-node': 2.3.0
-      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-endpoints': 1.1.2
       '@smithy/util-middleware': 2.2.0
       '@smithy/util-retry': 2.2.0
       '@smithy/util-utf8': 2.3.0
@@ -3448,7 +3451,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.535.0
       '@smithy/types': 2.12.0
-      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-endpoints': 1.1.2
       tslib: 2.6.2
     dev: false
 
@@ -7761,8 +7764,8 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-endpoints@1.2.0:
-    resolution: {integrity: sha512-BuDHv8zRjsE5zXd3PxFXFknzBG3owCpjq8G3FcsXW3CykYXuEqM3nTSsmLzw5q+T12ZYuDlVUZKBdpNbhVtlrQ==}
+  /@smithy/util-endpoints@1.1.2:
+    resolution: {integrity: sha512-2/REfdcJ20y9iF+9kSBRBsaoGzjT5dZ3E6/TA45GHJuJAb/vZTj76VLTcrl2iN3fWXiDK1B8RxchaLGbr7RxxA==}
     engines: {node: '>= 14.0.0'}
     dependencies:
       '@smithy/node-config-provider': 2.3.0


### PR DESCRIPTION
## Goal

**JQ**
When updating the JQ circleci plugin it looks like the install step changes how the subsequent steps run. e now include JQ in our build image, so we can just remove this instead.

**aws**
Looks like the latest aws update changes some things with smithy. See https://github.com/aws/aws-sdk-js-v3/issues/5435 

https://pocket.sentry.io/issues/5070670422/?project=6410738&query=is:unresolved&statsPeriod=14d&stream_index=0

**ci**
also ensuring that the CI always runs if we change common ci files