### PR TITLE
fix(imports): updating all cdktf imports to use the right syntax

### DIFF
--- a/infrastructure/account-data-deleter/src/dataDeleterApp.ts
+++ b/infrastructure/account-data-deleter/src/dataDeleterApp.ts
@@ -1,11 +1,13 @@
 import { config } from './config';
 
-import { CloudwatchLogGroup } from '@cdktf/provider-aws/lib/cloudwatch-log-group';
-import { DataAwsCallerIdentity } from '@cdktf/provider-aws/lib/data-aws-caller-identity';
-import { DataAwsKmsAlias } from '@cdktf/provider-aws/lib/data-aws-kms-alias';
-import { DataAwsRegion } from '@cdktf/provider-aws/lib/data-aws-region';
-import { DataAwsSnsTopic } from '@cdktf/provider-aws/lib/data-aws-sns-topic';
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
+import {
+  cloudwatchLogGroup,
+  dataAwsCallerIdentity,
+  dataAwsKmsAlias,
+  dataAwsRegion,
+  sqsQueue,
+  dataAwsSnsTopic,
+} from '@cdktf/provider-aws';
 
 import {
   PocketALBApplication,
@@ -16,12 +18,12 @@ import { Construct } from 'constructs';
 
 export type DataDeleterAppConfig = {
   pagerDuty: PocketPagerDuty;
-  region: DataAwsRegion;
-  caller: DataAwsCallerIdentity;
-  secretsManagerKmsAlias: DataAwsKmsAlias;
-  snsTopic: DataAwsSnsTopic;
-  batchDeleteQueue: SqsQueue;
-  batchDeleteDLQ: SqsQueue;
+  region: dataAwsRegion.DataAwsRegion;
+  caller: dataAwsCallerIdentity.DataAwsCallerIdentity;
+  secretsManagerKmsAlias: dataAwsKmsAlias.DataAwsKmsAlias;
+  snsTopic: dataAwsSnsTopic.DataAwsSnsTopic;
+  batchDeleteQueue: sqsQueue.SqsQueue;
+  batchDeleteDLQ: sqsQueue.SqsQueue;
 };
 
 export class DataDeleterApp extends Construct {
@@ -243,7 +245,7 @@ export class DataDeleterApp extends Construct {
    * @private
    */
   private createCustomLogGroup(containerName: string) {
-    const logGroup = new CloudwatchLogGroup(
+    const logGroup = new cloudwatchLogGroup.CloudwatchLogGroup(
       this,
       `${containerName}-log-group`,
       {

--- a/infrastructure/account-data-deleter/src/lambda/base/sqsLambda.ts
+++ b/infrastructure/account-data-deleter/src/lambda/base/sqsLambda.ts
@@ -1,11 +1,13 @@
 import { config as stackConfig } from '../../config';
 
-import { DataAwsSsmParameter } from '@cdktf/provider-aws/lib/data-aws-ssm-parameter';
-import { LAMBDA_RUNTIMES } from '@pocket-tools/terraform-modules';
-import { PocketPagerDuty } from '@pocket-tools/terraform-modules';
-import { PocketSQSWithLambdaTarget } from '@pocket-tools/terraform-modules';
-import { PocketVersionedLambdaProps } from '@pocket-tools/terraform-modules';
-import { PocketVPC } from '@pocket-tools/terraform-modules';
+import { dataAwsSsmParameter } from '@cdktf/provider-aws';
+import {
+  LAMBDA_RUNTIMES,
+  PocketPagerDuty,
+  PocketSQSWithLambdaTarget,
+  PocketVersionedLambdaProps,
+  PocketVPC,
+} from '@pocket-tools/terraform-modules';
 
 import { Construct } from 'constructs';
 
@@ -67,13 +69,21 @@ export class SqsLambda extends Construct {
   }
 
   private getEnvVariableValues() {
-    const sentryDsn = new DataAwsSsmParameter(this, 'sentry-dsn', {
-      name: `/${stackConfig.name}/${stackConfig.environment}/SENTRY_DSN`,
-    });
+    const sentryDsn = new dataAwsSsmParameter.DataAwsSsmParameter(
+      this,
+      'sentry-dsn',
+      {
+        name: `/${stackConfig.name}/${stackConfig.environment}/SENTRY_DSN`,
+      },
+    );
 
-    const serviceHash = new DataAwsSsmParameter(this, 'service-hash', {
-      name: `${stackConfig.circleCIPrefix}/SERVICE_HASH`,
-    });
+    const serviceHash = new dataAwsSsmParameter.DataAwsSsmParameter(
+      this,
+      'service-hash',
+      {
+        name: `${stackConfig.circleCIPrefix}/SERVICE_HASH`,
+      },
+    );
 
     return { sentryDsn: sentryDsn.value, gitSha: serviceHash.value };
   }

--- a/infrastructure/account-data-deleter/src/lambda/batchDeleteLambdaResources.ts
+++ b/infrastructure/account-data-deleter/src/lambda/batchDeleteLambdaResources.ts
@@ -1,12 +1,14 @@
 import { config, config as stackConfig } from '../config';
 
-import { DataAwsSsmParameter } from '@cdktf/provider-aws/lib/data-aws-ssm-parameter';
-import { DataAwsIamPolicyDocument } from '@cdktf/provider-aws/lib/data-aws-iam-policy-document';
-import { DynamodbTable } from '@cdktf/provider-aws/lib/dynamodb-table';
-import { IamPolicy } from '@cdktf/provider-aws/lib/iam-policy';
-import { IamRolePolicyAttachment } from '@cdktf/provider-aws/lib/iam-role-policy-attachment';
-import { IamRole } from '@cdktf/provider-aws/lib/iam-role';
-import { LambdaPermission } from '@cdktf/provider-aws/lib/lambda-permission';
+import {
+  dataAwsSsmParameter,
+  dataAwsIamPolicyDocument,
+  dynamodbTable,
+  iamPolicy,
+  iamRolePolicyAttachment,
+  iamRole,
+  lambdaPermission,
+} from '@cdktf/provider-aws';
 import {
   ApplicationDynamoDBTable,
   ApplicationDynamoDBTableCapacityMode,
@@ -117,7 +119,7 @@ export class BatchDeleteLambdaResources extends Construct {
     );
 
     //permission for scheduledEvent to invoke the batchDeleteLambda
-    new LambdaPermission(this, `${config.prefix}-batchLambda-permission`, {
+    new lambdaPermission.LambdaPermission(this, `${config.prefix}-batchLambda-permission`, {
       principal: 'events.amazonaws.com',
       action: 'lambda:InvokeFunction',
       functionName: this.batchDeleteLambda.lambda.defaultLambda.arn,
@@ -126,11 +128,11 @@ export class BatchDeleteLambdaResources extends Construct {
   }
 
   private getEnvVariableValues() {
-    const sentryDsn = new DataAwsSsmParameter(this, 'sentry-dsn', {
+    const sentryDsn = new dataAwsSsmParameter.DataAwsSsmParameter(this, 'sentry-dsn', {
       name: `/${stackConfig.name}/${stackConfig.environment}/SENTRY_DSN`,
     });
 
-    const serviceHash = new DataAwsSsmParameter(this, 'service-hash', {
+    const serviceHash = new dataAwsSsmParameter.DataAwsSsmParameter(this, 'service-hash', {
       name: `${stackConfig.circleCIPrefix}/SERVICE_HASH`,
     });
 
@@ -199,14 +201,14 @@ export class BatchDeleteLambdaResources extends Construct {
    */
   private addDynamoPermissions(
     name: string,
-    lambdaExecutionRole: IamRole,
-    dynamoTables: DynamodbTable[],
+    lambdaExecutionRole: iamRole.IamRole,
+    dynamoTables: dynamodbTable.DynamodbTable[],
     actions: string[],
   ) {
     const resources = dynamoTables.map((_) => _.arn);
-    const policy = new IamPolicy(this, `${name}-lambda-dynamo-policy`, {
+    const policy = new iamPolicy.IamPolicy(this, `${name}-lambda-dynamo-policy`, {
       name: `${this.name}-${name}-DynamoLambdaPolicy`,
-      policy: new DataAwsIamPolicyDocument(
+      policy: new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
         this,
         `${name}-lambda-dynamo-policy-doc`,
         {
@@ -221,7 +223,7 @@ export class BatchDeleteLambdaResources extends Construct {
       ).json,
       dependsOn: [lambdaExecutionRole],
     });
-    return new IamRolePolicyAttachment(
+    return new iamRolePolicyAttachment.IamRolePolicyAttachment(
       this,
       `${name}-execution-role-policy-attachment`,
       {

--- a/infrastructure/account-data-deleter/src/lambda/eventLambda.ts
+++ b/infrastructure/account-data-deleter/src/lambda/eventLambda.ts
@@ -1,7 +1,7 @@
 import { SqsLambda, SqsLambdaProps } from './base/sqsLambda';
 import { config as stackConfig } from '../config';
 
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
+import { sqsQueue } from '@cdktf/provider-aws';
 import { ApplicationSqsSnsTopicSubscription } from '@pocket-tools/terraform-modules/';
 
 import { Construct } from 'constructs';
@@ -28,7 +28,7 @@ export class EventLambda extends Construct {
         snsTopicArn: `arn:aws:sns:${config.vpc.region}:${config.vpc.accountId}:${stackConfig.lambda.snsTopicName.userEvents}`,
         sqsQueue: lambda.sqsQueueResource,
         tags: stackConfig.tags,
-        dependsOn: [lambda.sqsQueueResource as SqsQueue],
+        dependsOn: [lambda.sqsQueueResource as sqsQueue.SqsQueue],
       },
     );
   }

--- a/infrastructure/account-data-deleter/src/main.ts
+++ b/infrastructure/account-data-deleter/src/main.ts
@@ -3,15 +3,17 @@ import { DataDeleterApp, DataDeleterAppConfig } from './dataDeleterApp';
 import { BatchDeleteLambdaResources } from './lambda/batchDeleteLambdaResources';
 import { EventLambda } from './lambda/eventLambda';
 
-import { ArchiveProvider } from '@cdktf/provider-archive/lib/provider';
-import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
-import { DataAwsCallerIdentity } from '@cdktf/provider-aws/lib/data-aws-caller-identity';
-import { DataAwsKmsAlias } from '@cdktf/provider-aws/lib/data-aws-kms-alias';
-import { DataAwsRegion } from '@cdktf/provider-aws/lib/data-aws-region';
-import { DataAwsSnsTopic } from '@cdktf/provider-aws/lib/data-aws-sns-topic';
-import { LocalProvider } from '@cdktf/provider-local/lib/provider';
-import { NullProvider } from '@cdktf/provider-null/lib/provider';
-import { PagerdutyProvider } from '@cdktf/provider-pagerduty/lib/provider';
+import { provider as archiveProvider } from '@cdktf/provider-archive';
+import {
+  provider as awsProvider,
+  dataAwsCallerIdentity,
+  dataAwsKmsAlias,
+  dataAwsRegion,
+  dataAwsSnsTopic,
+} from '@cdktf/provider-aws';
+import { provider as localProvider } from '@cdktf/provider-local';
+import { provider as nullProvider } from '@cdktf/provider-null';
+import { provider as pagerdutyProvider } from '@cdktf/provider-pagerduty';
 import {
   ApplicationSQSQueue,
   PocketPagerDuty,
@@ -30,11 +32,13 @@ class AccountDataDeleter extends TerraformStack {
   constructor(scope: Construct, name: string) {
     super(scope, name);
 
-    new ArchiveProvider(this, 'archive-provider');
-    new AwsProvider(this, 'aws', { region: 'us-east-1' });
-    new LocalProvider(this, 'local-provider');
-    new NullProvider(this, 'null-provider');
-    new PagerdutyProvider(this, 'pagerduty-provider', { token: undefined });
+    new archiveProvider.ArchiveProvider(this, 'archive-provider');
+    new awsProvider.AwsProvider(this, 'aws', { region: 'us-east-1' });
+    new localProvider.LocalProvider(this, 'local-provider');
+    new nullProvider.NullProvider(this, 'null-provider');
+    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty-provider', {
+      token: undefined,
+    });
 
     new S3Backend(this, {
       bucket: `mozilla-pocket-team-${config.environment.toLowerCase()}-terraform-state`,
@@ -43,8 +47,11 @@ class AccountDataDeleter extends TerraformStack {
       region: 'us-east-1',
     });
 
-    const caller = new DataAwsCallerIdentity(this, 'caller');
-    const region = new DataAwsRegion(this, 'region');
+    const caller = new dataAwsCallerIdentity.DataAwsCallerIdentity(
+      this,
+      'caller',
+    );
+    const region = new dataAwsRegion.DataAwsRegion(this, 'region');
     const pagerDuty = this.createPagerDuty();
     const pocketVpc = new PocketVPC(this, 'pocket-vpc');
 
@@ -84,7 +91,7 @@ class AccountDataDeleter extends TerraformStack {
    * @private
    */
   private getSecretsManagerKmsAlias() {
-    return new DataAwsKmsAlias(this, 'kms_alias', {
+    return new dataAwsKmsAlias.DataAwsKmsAlias(this, 'kms_alias', {
       name: 'alias/aws/secretsmanager',
     });
   }
@@ -94,7 +101,7 @@ class AccountDataDeleter extends TerraformStack {
    * @private
    */
   private getCodeDeploySnsTopic() {
-    return new DataAwsSnsTopic(this, 'backend_notifications', {
+    return new dataAwsSnsTopic.DataAwsSnsTopic(this, 'backend_notifications', {
       name: `Backend-${config.environment}-ChatBot`,
     });
   }

--- a/infrastructure/account-delete-monitor/src/main.ts
+++ b/infrastructure/account-delete-monitor/src/main.ts
@@ -2,21 +2,24 @@ import { config } from './config';
 import { DynamoDB } from './dynamodb';
 import { SQSEventLambda } from './sqsEventLambda';
 
-import { ArchiveProvider } from '@cdktf/provider-archive/lib/provider';
-import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
-import { DataAwsCallerIdentity } from '@cdktf/provider-aws/lib/data-aws-caller-identity';
-import { DataAwsIamPolicyDocument } from '@cdktf/provider-aws/lib/data-aws-iam-policy-document';
-import { DataAwsRegion } from '@cdktf/provider-aws/lib/data-aws-region';
-import { DynamodbTable } from '@cdktf/provider-aws/lib/dynamodb-table';
-import { IamPolicy } from '@cdktf/provider-aws/lib/iam-policy';
-import { IamRole } from '@cdktf/provider-aws/lib/iam-role';
-import { IamRolePolicyAttachment } from '@cdktf/provider-aws/lib/iam-role-policy-attachment';
-import { SnsTopicSubscription } from '@cdktf/provider-aws/lib/sns-topic-subscription';
-import { SqsQueuePolicy } from '@cdktf/provider-aws/lib/sqs-queue-policy';
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
-import { LocalProvider } from '@cdktf/provider-local/lib/provider';
-import { NullProvider } from '@cdktf/provider-null/lib/provider';
-import { PagerdutyProvider } from '@cdktf/provider-pagerduty/lib/provider';
+import { provider as archiveProvider } from '@cdktf/provider-archive';
+import {
+  provider as awsProvider,
+  dataAwsCallerIdentity,
+  dataAwsIamPolicyDocument,
+  dataAwsRegion,
+  dynamodbTable,
+  iamRole,
+  iamPolicy,
+  iamRolePolicyAttachment,
+  snsTopicSubscription,
+  sqsQueue,
+  sqsQueuePolicy,
+} from '@cdktf/provider-aws';
+
+import { provider as localProvider } from '@cdktf/provider-local';
+import { provider as nullProvider } from '@cdktf/provider-null';
+import { provider as pagerdutyProvider } from '@cdktf/provider-pagerduty';
 import { PocketPagerDuty, PocketVPC } from '@pocket-tools/terraform-modules';
 import {
   App,
@@ -33,11 +36,13 @@ class AccountDeleteMonitor extends TerraformStack {
   ) {
     super(scope, name);
 
-    new ArchiveProvider(this, 'archive_provider');
-    new AwsProvider(this, 'aws', { region: 'us-east-1' });
-    new LocalProvider(this, 'local_provider');
-    new NullProvider(this, 'null_provider');
-    new PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
+    new archiveProvider.ArchiveProvider(this, 'archive_provider');
+    new awsProvider.AwsProvider(this, 'aws', { region: 'us-east-1' });
+    new localProvider.LocalProvider(this, 'local_provider');
+    new nullProvider.NullProvider(this, 'null_provider');
+    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', {
+      token: undefined,
+    });
 
     new S3Backend(this, {
       bucket: `mozilla-pocket-team-${config.environment.toLowerCase()}-terraform-state`,
@@ -46,9 +51,12 @@ class AccountDeleteMonitor extends TerraformStack {
       region: 'us-east-1',
     });
 
-    const caller = new DataAwsCallerIdentity(this, 'caller');
+    const caller = new dataAwsCallerIdentity.DataAwsCallerIdentity(
+      this,
+      'caller',
+    );
     const pocketVPC = new PocketVPC(this, 'pocket-vpc');
-    const region = new DataAwsRegion(this, 'region');
+    const region = new dataAwsRegion.DataAwsRegion(this, 'region');
 
     const pagerDuty = this.createPagerDuty();
     // Create data store
@@ -70,7 +78,7 @@ class AccountDeleteMonitor extends TerraformStack {
     );
 
     //dlq for sqs-sns subscription
-    const snsTopicDlq = new SqsQueue(this, 'sns-topic-dql', {
+    const snsTopicDlq = new sqsQueue.SqsQueue(this, 'sns-topic-dql', {
       name: `${config.prefix}-SNS-Topics-DLQ`,
       tags: config.tags,
     });
@@ -110,28 +118,32 @@ class AccountDeleteMonitor extends TerraformStack {
    */
   private addDynamoPermissions(
     name: string,
-    lambdaExecutionRole: IamRole,
-    dynamoTable: DynamodbTable,
+    lambdaExecutionRole: iamRole.IamRole,
+    dynamoTable: dynamodbTable.DynamodbTable,
     actions: string[],
   ) {
-    const policy = new IamPolicy(this, `${name}-lambda-dynamo-policy`, {
-      name: `${this.name}-${name}-DynamoLambdaPolicy`,
-      policy: new DataAwsIamPolicyDocument(
-        this,
-        `${name}-lambda-dynamo-policy-doc`,
-        {
-          statement: [
-            {
-              effect: 'Allow',
-              actions,
-              resources: [dynamoTable.arn],
-            },
-          ],
-        },
-      ).json,
-      dependsOn: [lambdaExecutionRole],
-    });
-    return new IamRolePolicyAttachment(
+    const policy = new iamPolicy.IamPolicy(
+      this,
+      `${name}-lambda-dynamo-policy`,
+      {
+        name: `${this.name}-${name}-DynamoLambdaPolicy`,
+        policy: new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
+          this,
+          `${name}-lambda-dynamo-policy-doc`,
+          {
+            statement: [
+              {
+                effect: 'Allow',
+                actions,
+                resources: [dynamoTable.arn],
+              },
+            ],
+          },
+        ).json,
+        dependsOn: [lambdaExecutionRole],
+      },
+    );
+    return new iamRolePolicyAttachment.IamRolePolicyAttachment(
       this,
       `${name}-execution-role-policy-attachment`,
       {
@@ -152,18 +164,22 @@ class AccountDeleteMonitor extends TerraformStack {
    */
   private subscribeSqsToSnsTopic(
     sqsLambda: SQSEventLambda,
-    snsTopicDlq: SqsQueue,
+    snsTopicDlq: sqsQueue.SqsQueue,
     snsTopicArn: string,
     topicName: string,
   ) {
-    return new SnsTopicSubscription(this, `${topicName}-sns-subscription`, {
-      topicArn: snsTopicArn,
-      protocol: 'sqs',
-      endpoint: sqsLambda.construct.applicationSqsQueue.sqsQueue.arn,
-      redrivePolicy: JSON.stringify({
-        deadLetterTargetArn: snsTopicDlq.arn,
-      }),
-    });
+    return new snsTopicSubscription.SnsTopicSubscription(
+      this,
+      `${topicName}-sns-subscription`,
+      {
+        topicArn: snsTopicArn,
+        protocol: 'sqs',
+        endpoint: sqsLambda.construct.applicationSqsQueue.sqsQueue.arn,
+        redrivePolicy: JSON.stringify({
+          deadLetterTargetArn: snsTopicDlq.arn,
+        }),
+      },
+    );
   }
 
   /**
@@ -202,8 +218,8 @@ class AccountDeleteMonitor extends TerraformStack {
    * @private
    */
   private createPoliciesForAccountDeletionMonitoringSqs(
-    snsTopicQueue: SqsQueue,
-    snsTopicDlq: SqsQueue,
+    snsTopicQueue: sqsQueue.SqsQueue,
+    snsTopicDlq: sqsQueue.SqsQueue,
     userEventTopicArn: string,
     userMergeEventTopicArn: string,
   ): void {
@@ -212,7 +228,7 @@ class AccountDeleteMonitor extends TerraformStack {
       { name: 'adm-sns-dlq', resource: snsTopicDlq },
     ].forEach((queue) => {
       console.log(queue.resource.policy);
-      const policy = new DataAwsIamPolicyDocument(
+      const policy = new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
         this,
         `${queue.name}-policy-document`,
         {
@@ -241,7 +257,7 @@ class AccountDeleteMonitor extends TerraformStack {
         },
       ).json;
 
-      new SqsQueuePolicy(this, `${queue.name}-policy`, {
+      new sqsQueuePolicy.SqsQueuePolicy(this, `${queue.name}-policy`, {
         queueUrl: queue.resource.url,
         policy: policy,
       });

--- a/infrastructure/account-delete-monitor/src/sqsEventLambda.ts
+++ b/infrastructure/account-delete-monitor/src/sqsEventLambda.ts
@@ -1,11 +1,9 @@
 import { config as stackConfig } from './config';
 
-import { DataAwsSsmParameter } from '@cdktf/provider-aws/lib/data-aws-ssm-parameter';
+import { dataAwsSsmParameter } from '@cdktf/provider-aws';
 import {
   ApplicationDynamoDBTable,
   PocketSQSWithLambdaTarget,
-} from '@pocket-tools/terraform-modules';
-import {
   LAMBDA_RUNTIMES,
   PocketPagerDuty,
   PocketVersionedLambdaProps,
@@ -65,13 +63,21 @@ export class SQSEventLambda extends Construct {
   }
 
   private getEnvVariableValues() {
-    const sentryDsn = new DataAwsSsmParameter(this, 'sentry-dsn', {
-      name: `/${stackConfig.name}/${stackConfig.environment}/SENTRY_DSN`,
-    });
+    const sentryDsn = new dataAwsSsmParameter.DataAwsSsmParameter(
+      this,
+      'sentry-dsn',
+      {
+        name: `/${stackConfig.name}/${stackConfig.environment}/SENTRY_DSN`,
+      },
+    );
 
-    const serviceHash = new DataAwsSsmParameter(this, 'service-hash', {
-      name: `${stackConfig.circleCIPrefix}/SERVICE_HASH`,
-    });
+    const serviceHash = new dataAwsSsmParameter.DataAwsSsmParameter(
+      this,
+      'service-hash',
+      {
+        name: `${stackConfig.circleCIPrefix}/SERVICE_HASH`,
+      },
+    );
 
     return { sentryDsn: sentryDsn.value, gitSha: serviceHash.value };
   }

--- a/infrastructure/annotations-api/src/SqsLambda.ts
+++ b/infrastructure/annotations-api/src/SqsLambda.ts
@@ -6,8 +6,7 @@ import {
   PocketSQSWithLambdaTarget,
   PocketVPC,
 } from '@pocket-tools/terraform-modules';
-import { DataAwsRegion } from '@cdktf/provider-aws/lib/data-aws-region';
-import { DataAwsCallerIdentity } from '@cdktf/provider-aws/lib/data-aws-caller-identity';
+import { dataAwsRegion, dataAwsCallerIdentity } from '@cdktf/provider-aws';
 
 export class SqsLambda extends Construct {
   public readonly lambda: PocketSQSWithLambdaTarget;
@@ -16,8 +15,8 @@ export class SqsLambda extends Construct {
     scope: Construct,
     private name: string,
     vpc: PocketVPC,
-    region: DataAwsRegion,
-    caller: DataAwsCallerIdentity,
+    region: dataAwsRegion.DataAwsRegion,
+    caller: dataAwsCallerIdentity.DataAwsCallerIdentity,
     pagerDuty?: PocketPagerDuty,
   ) {
     super(scope, name);

--- a/infrastructure/annotations-api/src/dynamodb.ts
+++ b/infrastructure/annotations-api/src/dynamodb.ts
@@ -1,4 +1,3 @@
-import { Resource } from 'cdktf';
 import { Construct } from 'constructs';
 import { config } from './config';
 import {
@@ -6,7 +5,7 @@ import {
   ApplicationDynamoDBTableCapacityMode,
 } from '@pocket-tools/terraform-modules';
 
-export class DynamoDB extends Resource {
+export class DynamoDB extends Construct {
   public readonly highlightNotesTable: ApplicationDynamoDBTable;
 
   constructor(scope: Construct, name: string) {

--- a/infrastructure/annotations-api/src/main.ts
+++ b/infrastructure/annotations-api/src/main.ts
@@ -5,16 +5,19 @@ import {
   S3Backend,
   TerraformStack,
 } from 'cdktf';
-import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
-import { DataAwsCallerIdentity } from '@cdktf/provider-aws/lib/data-aws-caller-identity';
-import { DataAwsKmsAlias } from '@cdktf/provider-aws/lib/data-aws-kms-alias';
-import { DataAwsRegion } from '@cdktf/provider-aws/lib/data-aws-region';
-import { DataAwsSnsTopic } from '@cdktf/provider-aws/lib/data-aws-sns-topic';
-import { LocalProvider } from '@cdktf/provider-local/lib/provider';
-import { NullProvider } from '@cdktf/provider-null/lib/provider';
-import { ArchiveProvider } from '@cdktf/provider-archive/lib/provider';
-import { PagerdutyProvider } from '@cdktf/provider-pagerduty/lib/provider';
+import {
+  provider as awsProvider,
+  sqsQueue,
+  dataAwsCallerIdentity,
+  dataAwsKmsAlias,
+  dataAwsRegion,
+  dataAwsSnsTopic,
+  cloudwatchLogGroup
+} from '@cdktf/provider-aws';
+import { provider as localProvider } from '@cdktf/provider-local';
+import { provider as nullProvider } from '@cdktf/provider-null';
+import { provider as archiveProvider } from '@cdktf/provider-archive';
+import { provider as pagerdutyProvider } from '@cdktf/provider-pagerduty';
 import { config } from './config';
 import {
   ApplicationSQSQueue,
@@ -26,17 +29,18 @@ import {
 } from '@pocket-tools/terraform-modules';
 import { DynamoDB } from './dynamodb';
 import { SqsLambda } from './SqsLambda';
-import { CloudwatchLogGroup } from '@cdktf/provider-aws/lib/cloudwatch-log-group';
 
 class AnnotationsAPI extends TerraformStack {
   constructor(scope: Construct, name: string) {
     super(scope, name);
 
-    new AwsProvider(this, 'aws', { region: 'us-east-1' });
-    new PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
-    new LocalProvider(this, 'local_provider');
-    new NullProvider(this, 'null_provider');
-    new ArchiveProvider(this, 'archive-provider');
+    new awsProvider.AwsProvider(this, 'aws', { region: 'us-east-1' });
+    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', {
+      token: undefined,
+    });
+    new localProvider.LocalProvider(this, 'local_provider');
+    new nullProvider.NullProvider(this, 'null_provider');
+    new archiveProvider.ArchiveProvider(this, 'archive-provider');
 
     new S3Backend(this, {
       bucket: `mozilla-pocket-team-${config.environment.toLowerCase()}-terraform-state`,
@@ -45,8 +49,11 @@ class AnnotationsAPI extends TerraformStack {
       region: 'us-east-1',
     });
 
-    const region = new DataAwsRegion(this, 'region');
-    const caller = new DataAwsCallerIdentity(this, 'caller');
+    const region = new dataAwsRegion.DataAwsRegion(this, 'region');
+    const caller = new dataAwsCallerIdentity.DataAwsCallerIdentity(
+      this,
+      'caller',
+    );
     const pocketVPC = new PocketVPC(this, 'pocket-vpc');
     const dynamodb = new DynamoDB(this, 'dynamodb');
 
@@ -68,7 +75,7 @@ class AnnotationsAPI extends TerraformStack {
         snsTopicArn: `arn:aws:sns:${pocketVPC.region}:${pocketVPC.accountId}:${config.lambda.snsTopicName.userEvents}`,
         sqsQueue: lambda.sqsQueueResource,
         tags: config.tags,
-        dependsOn: [lambda.sqsQueueResource as SqsQueue],
+        dependsOn: [lambda.sqsQueueResource as sqsQueue.SqsQueue],
       },
     );
 
@@ -125,7 +132,7 @@ class AnnotationsAPI extends TerraformStack {
    * @private
    */
   private getCodeDeploySnsTopic() {
-    return new DataAwsSnsTopic(this, 'backend_notifications', {
+    return new dataAwsSnsTopic.DataAwsSnsTopic(this, 'backend_notifications', {
       name: `Backend-${config.environment}-ChatBot`,
     });
   }
@@ -135,7 +142,7 @@ class AnnotationsAPI extends TerraformStack {
    * @private
    */
   private getSecretsManagerKmsAlias() {
-    return new DataAwsKmsAlias(this, 'kms_alias', {
+    return new dataAwsKmsAlias.DataAwsKmsAlias(this, 'kms_alias', {
       name: 'alias/aws/secretsmanager',
     });
   }
@@ -177,10 +184,10 @@ class AnnotationsAPI extends TerraformStack {
 
   private createPocketAlbApplication(dependencies: {
     pagerDuty: PocketPagerDuty;
-    region: DataAwsRegion;
-    caller: DataAwsCallerIdentity;
-    secretsManagerKmsAlias: DataAwsKmsAlias;
-    snsTopic: DataAwsSnsTopic;
+    region: dataAwsRegion.DataAwsRegion;
+    caller: dataAwsCallerIdentity.DataAwsCallerIdentity;
+    secretsManagerKmsAlias: dataAwsKmsAlias.DataAwsKmsAlias;
+    snsTopic: dataAwsSnsTopic.DataAwsSnsTopic;
     dynamodb: DynamoDB;
   }): PocketALBApplication {
     const { region, caller, secretsManagerKmsAlias, snsTopic, dynamodb } =
@@ -425,7 +432,7 @@ class AnnotationsAPI extends TerraformStack {
    * @private
    */
   private createCustomLogGroup(containerName: string) {
-    const logGroup = new CloudwatchLogGroup(
+    const logGroup = new cloudwatchLogGroup.CloudwatchLogGroup(
       this,
       `${containerName}-log-group`,
       {

--- a/infrastructure/braze/src/dataExport.ts
+++ b/infrastructure/braze/src/dataExport.ts
@@ -1,12 +1,14 @@
 import { Construct } from 'constructs';
-import { S3Bucket } from '@cdktf/provider-aws/lib/s3-bucket';
-import { S3BucketAcl } from '@cdktf/provider-aws/lib/s3-bucket-acl';
-import { S3BucketLifecycleConfiguration } from '@cdktf/provider-aws/lib/s3-bucket-lifecycle-configuration';
-import { S3BucketPublicAccessBlock } from '@cdktf/provider-aws/lib/s3-bucket-public-access-block';
-import { IamPolicy } from '@cdktf/provider-aws/lib/iam-policy';
-import { DataAwsIamPolicyDocument } from '@cdktf/provider-aws/lib/data-aws-iam-policy-document';
-import { IamRolePolicyAttachment } from '@cdktf/provider-aws/lib/iam-role-policy-attachment';
-import { IamRole } from '@cdktf/provider-aws/lib/iam-role';
+import {
+  s3Bucket,
+  s3BucketAcl,
+  s3BucketLifecycleConfiguration,
+  s3BucketPublicAccessBlock,
+  iamPolicy,
+  dataAwsIamPolicyDocument,
+  iamRolePolicyAttachment,
+  iamRole,
+} from '@cdktf/provider-aws';
 
 export interface DataExportBucketConfig {
   brazeExternalId: string;
@@ -33,39 +35,51 @@ export class DataExportBucket extends Construct {
   private createS3Bucket(
     scope: Construct,
     config: DataExportBucketConfig,
-  ): S3Bucket {
-    const s3Bucket = new S3Bucket(scope, 'data-export-bucket', {
-      bucket: config.bucket,
-      tags: config.tags,
-    });
+  ): s3Bucket.S3Bucket {
+    const s3BucketResource = new s3Bucket.S3Bucket(
+      scope,
+      'data-export-bucket',
+      {
+        bucket: config.bucket,
+        tags: config.tags,
+      },
+    );
 
-    new S3BucketAcl(scope, 'data-export-bucket-acl', {
+    new s3BucketAcl.S3BucketAcl(scope, 'data-export-bucket-acl', {
       acl: 'private',
-      bucket: s3Bucket.bucket,
+      bucket: s3BucketResource.bucket,
     });
 
-    new S3BucketLifecycleConfiguration(scope, 'data-export-bucket-lifecycle', {
-      bucket: s3Bucket.bucket,
-      rule: [
-        {
-          id: 'expiration-rule',
-          status: 'Enabled',
-          //expire any data after 90 days
-          expiration: {
-            days: 90,
+    new s3BucketLifecycleConfiguration.S3BucketLifecycleConfiguration(
+      scope,
+      'data-export-bucket-lifecycle',
+      {
+        bucket: s3BucketResource.bucket,
+        rule: [
+          {
+            id: 'expiration-rule',
+            status: 'Enabled',
+            //expire any data after 90 days
+            expiration: {
+              days: 90,
+            },
           },
-        },
-      ],
-    });
+        ],
+      },
+    );
 
-    new S3BucketPublicAccessBlock(scope, 'data-export-bucket-public-block', {
-      bucket: s3Bucket.id,
-      blockPublicPolicy: true,
-      ignorePublicAcls: true,
-      restrictPublicBuckets: true,
-    });
+    new s3BucketPublicAccessBlock.S3BucketPublicAccessBlock(
+      scope,
+      'data-export-bucket-public-block',
+      {
+        bucket: s3BucketResource.id,
+        blockPublicPolicy: true,
+        ignorePublicAcls: true,
+        restrictPublicBuckets: true,
+      },
+    );
 
-    return s3Bucket;
+    return s3BucketResource;
   }
 
   /**
@@ -76,24 +90,28 @@ export class DataExportBucket extends Construct {
    */
   private createBrazeIAMPolicy(
     scope: Construct,
-    s3Bucket: S3Bucket,
-  ): IamPolicy {
-    return new IamPolicy(scope, 'braze-s3-data-access-policy', {
+    s3Bucket: s3Bucket.S3Bucket,
+  ): iamPolicy.IamPolicy {
+    return new iamPolicy.IamPolicy(scope, 'braze-s3-data-access-policy', {
       namePrefix: 'braze-s3-data-export',
-      policy: new DataAwsIamPolicyDocument(scope, 'braze-s3-sdk', {
-        statement: [
-          {
-            actions: ['s3:ListBucket', 's3:GetBucketLocation'],
-            resources: [`arn:aws:s3:::${s3Bucket.bucket}`],
-            effect: 'Allow',
-          },
-          {
-            actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
-            resources: [`arn:aws:s3:::${s3Bucket.bucket}/*`],
-            effect: 'Allow',
-          },
-        ],
-      }).json,
+      policy: new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
+        scope,
+        'braze-s3-sdk',
+        {
+          statement: [
+            {
+              actions: ['s3:ListBucket', 's3:GetBucketLocation'],
+              resources: [`arn:aws:s3:::${s3Bucket.bucket}`],
+              effect: 'Allow',
+            },
+            {
+              actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+              resources: [`arn:aws:s3:::${s3Bucket.bucket}/*`],
+              effect: 'Allow',
+            },
+          ],
+        },
+      ).json,
     });
   }
 
@@ -106,43 +124,51 @@ export class DataExportBucket extends Construct {
    */
   private createBrazeIAMRole(
     scope: Construct,
-    s3Bucket: S3Bucket,
-    brazeIAMPolicy: IamPolicy,
+    s3Bucket: s3Bucket.S3Bucket,
+    brazeIAMPolicy: iamPolicy.IamPolicy,
     config: DataExportBucketConfig,
   ) {
-    const brazeIAMRole = new IamRole(scope, 'braze-s3-data-access-role', {
-      namePrefix: `${config.prefix}`,
-      tags: config.tags,
+    const brazeIAMRole = new iamRole.IamRole(
+      scope,
+      'braze-s3-data-access-role',
+      {
+        namePrefix: `${config.prefix}`,
+        tags: config.tags,
 
-      assumeRolePolicy: new DataAwsIamPolicyDocument(
-        this,
-        'braze-s3-data-export-assume-role-policy',
-        {
-          statement: [
-            {
-              actions: ['sts:AssumeRole'],
-              principals: [
-                {
-                  type: 'AWS',
-                  identifiers: [config.brazeAccountId],
-                },
-              ],
-              condition: [
-                {
-                  variable: 'sts:ExternalId',
-                  test: 'StringEquals',
-                  values: [config.brazeExternalId],
-                },
-              ],
-            },
-          ],
-        },
-      ).json,
-    });
+        assumeRolePolicy: new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
+          this,
+          'braze-s3-data-export-assume-role-policy',
+          {
+            statement: [
+              {
+                actions: ['sts:AssumeRole'],
+                principals: [
+                  {
+                    type: 'AWS',
+                    identifiers: [config.brazeAccountId],
+                  },
+                ],
+                condition: [
+                  {
+                    variable: 'sts:ExternalId',
+                    test: 'StringEquals',
+                    values: [config.brazeExternalId],
+                  },
+                ],
+              },
+            ],
+          },
+        ).json,
+      },
+    );
 
-    new IamRolePolicyAttachment(scope, 'braze-s3-data-access-role-policy', {
-      policyArn: brazeIAMPolicy.arn,
-      role: brazeIAMRole.name,
-    });
+    new iamRolePolicyAttachment.IamRolePolicyAttachment(
+      scope,
+      'braze-s3-data-access-role-policy',
+      {
+        policyArn: brazeIAMPolicy.arn,
+        role: brazeIAMRole.name,
+      },
+    );
   }
 }

--- a/infrastructure/braze/src/emailSendDomain.ts
+++ b/infrastructure/braze/src/emailSendDomain.ts
@@ -1,6 +1,5 @@
 import { Construct } from 'constructs';
-import { DataAwsRoute53Zone } from '@cdktf/provider-aws/lib/data-aws-route53-zone';
-import { Route53Record } from '@cdktf/provider-aws/lib/route53-record';
+import { dataAwsRoute53Zone, route53Record } from '@cdktf/provider-aws';
 import { getRootDomain } from '@pocket-tools/terraform-modules';
 
 export interface EmailSendDomainConfig {
@@ -23,25 +22,25 @@ interface RootZoneConfig {
 }
 
 interface TextRecordsConfig {
-  baseDNS: DataAwsRoute53Zone;
+  baseDNS: dataAwsRoute53Zone.DataAwsRoute53Zone;
   subdomain: string;
   textRecords: { [key: string]: string[] };
 }
 
 interface ARecordsConfig {
-  baseDNS: DataAwsRoute53Zone;
+  baseDNS: dataAwsRoute53Zone.DataAwsRoute53Zone;
   subdomain: string;
   aRecords: { [key: string]: string };
 }
 
 interface CNAMEConfig {
-  baseDNS: DataAwsRoute53Zone;
+  baseDNS: dataAwsRoute53Zone.DataAwsRoute53Zone;
   subdomain: string;
   cname: string;
 }
 
 interface MXConfig {
-  baseDNS: DataAwsRoute53Zone;
+  baseDNS: dataAwsRoute53Zone.DataAwsRoute53Zone;
   subdomain: string;
   mx: string;
 }
@@ -91,10 +90,12 @@ export class EmailSendDomain extends Construct {
    * @param zone
    * @private
    */
-  private getRootZone(zone: RootZoneConfig): DataAwsRoute53Zone {
+  private getRootZone(
+    zone: RootZoneConfig,
+  ): dataAwsRoute53Zone.DataAwsRoute53Zone {
     //Get the root zone for our subdomain
     //We can't make a sub hosted zone like we usually do because we need to CNAME the root record
-    return new DataAwsRoute53Zone(this, `base_dns`, {
+    return new dataAwsRoute53Zone.DataAwsRoute53Zone(this, `base_dns`, {
       name: getRootDomain(zone.domain),
     });
   }
@@ -105,7 +106,7 @@ export class EmailSendDomain extends Construct {
    * @private
    */
   private createMainCNAMERecord(config: CNAMEConfig) {
-    return new Route53Record(this, `cname_record`, {
+    return new route53Record.Route53Record(this, `cname_record`, {
       zoneId: config.baseDNS.zoneId,
       name: config.subdomain,
       type: 'CNAME',
@@ -120,7 +121,7 @@ export class EmailSendDomain extends Construct {
    * @private
    */
   private createMXRecord(config: MXConfig) {
-    return new Route53Record(this, `mx_record`, {
+    return new route53Record.Route53Record(this, `mx_record`, {
       zoneId: config.baseDNS.zoneId,
       name: config.subdomain,
       type: 'MX',
@@ -135,18 +136,22 @@ export class EmailSendDomain extends Construct {
    * @private
    */
   private createTextVerificationRecords(config: TextRecordsConfig) {
-    const records: Route53Record[] = [];
+    const records: route53Record.Route53Record[] = [];
     for (const [name, value] of Object.entries(config.textRecords)) {
       const recordName =
         name == '' ? config.subdomain : `${name}.${config.subdomain}`;
       records.push(
-        new Route53Record(this, `${records.length}_text_records`, {
-          zoneId: config.baseDNS.zoneId,
-          name: recordName,
-          type: 'TXT',
-          records: value,
-          ttl: 300,
-        }),
+        new route53Record.Route53Record(
+          this,
+          `${records.length}_text_records`,
+          {
+            zoneId: config.baseDNS.zoneId,
+            name: recordName,
+            type: 'TXT',
+            records: value,
+            ttl: 300,
+          },
+        ),
       );
     }
 
@@ -159,12 +164,12 @@ export class EmailSendDomain extends Construct {
    * @private
    */
   private createARecords(config: ARecordsConfig) {
-    const records: Route53Record[] = [];
+    const records: route53Record.Route53Record[] = [];
     for (const [name, value] of Object.entries(config.aRecords)) {
       const recordName =
         name == '' ? config.subdomain : `${name}.${config.subdomain}`;
       records.push(
-        new Route53Record(this, `${records.length}_a_records`, {
+        new route53Record.Route53Record(this, `${records.length}_a_records`, {
           zoneId: config.baseDNS.zoneId,
           name: recordName,
           type: 'A',

--- a/infrastructure/braze/src/main.ts
+++ b/infrastructure/braze/src/main.ts
@@ -1,10 +1,10 @@
 import { Construct } from 'constructs';
 import { App, S3Backend, TerraformStack, Aspects, MigrateIds } from 'cdktf';
-import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
+import { provider as awsProvider } from '@cdktf/provider-aws';
 import { config } from './config';
-import { PagerdutyProvider } from '@cdktf/provider-pagerduty/lib/provider';
-import { LocalProvider } from '@cdktf/provider-local/lib/provider';
-import { NullProvider } from '@cdktf/provider-null/lib/provider';
+import { provider as pagerdutyProvider } from '@cdktf/provider-pagerduty';
+import { provider as localProvider } from '@cdktf/provider-local';
+import { provider as nullProvider } from '@cdktf/provider-null';
 import { EmailSendDomain } from './emailSendDomain';
 import * as fs from 'fs';
 import { ClickTrackingDomain } from './clickTrackingDomain';
@@ -14,10 +14,12 @@ class Braze extends TerraformStack {
   constructor(scope: Construct, name: string) {
     super(scope, name);
 
-    new AwsProvider(this, 'aws', { region: 'us-east-1' });
-    new PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
-    new LocalProvider(this, 'local_provider');
-    new NullProvider(this, 'null_provider');
+    new awsProvider.AwsProvider(this, 'aws', { region: 'us-east-1' });
+    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', {
+      token: undefined,
+    });
+    new localProvider.LocalProvider(this, 'local_provider');
+    new nullProvider.NullProvider(this, 'null_provider');
 
     new S3Backend(this, {
       bucket: `mozilla-pocket-team-${config.environment.toLowerCase()}-terraform-state`,

--- a/infrastructure/client-api/src/main.ts
+++ b/infrastructure/client-api/src/main.ts
@@ -1,16 +1,20 @@
 import { config } from './config';
 
-import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
-import { CloudwatchLogGroup } from '@cdktf/provider-aws/lib/cloudwatch-log-group';
-import { DataAwsCallerIdentity } from '@cdktf/provider-aws/lib/data-aws-caller-identity';
-import { DataAwsKmsAlias } from '@cdktf/provider-aws/lib/data-aws-kms-alias';
-import { DataAwsRegion } from '@cdktf/provider-aws/lib/data-aws-region';
-import { DataAwsSnsTopic } from '@cdktf/provider-aws/lib/data-aws-sns-topic';
-import { DataAwsSubnets } from '@cdktf/provider-aws/lib/data-aws-subnets';
-import { LocalProvider } from '@cdktf/provider-local/lib/provider';
-import { NullProvider } from '@cdktf/provider-null/lib/provider';
-import { PagerdutyProvider } from '@cdktf/provider-pagerduty/lib/provider';
-import { DataPagerdutyEscalationPolicy } from '@cdktf/provider-pagerduty/lib/data-pagerduty-escalation-policy';
+import {
+  provider as awsProvider,
+  cloudwatchLogGroup,
+  dataAwsCallerIdentity,
+  dataAwsRegion,
+  dataAwsKmsAlias,
+  dataAwsSnsTopic,
+  dataAwsSubnets,
+} from '@cdktf/provider-aws';
+import { provider as localProvider } from '@cdktf/provider-local';
+import { provider as nullProvider } from '@cdktf/provider-null';
+import {
+  provider as pagerdutyProvider,
+  dataPagerdutyEscalationPolicy,
+} from '@cdktf/provider-pagerduty';
 import {
   PocketALBApplication,
   PocketPagerDuty,
@@ -27,10 +31,12 @@ class ClientAPI extends TerraformStack {
   constructor(scope: Construct, name: string) {
     super(scope, name);
 
-    new AwsProvider(this, 'aws', { region: 'us-east-1' });
-    new LocalProvider(this, 'local_provider');
-    new NullProvider(this, 'null_provider');
-    new PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
+    new awsProvider.AwsProvider(this, 'aws', { region: 'us-east-1' });
+    new localProvider.LocalProvider(this, 'local_provider');
+    new nullProvider.NullProvider(this, 'null_provider');
+    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', {
+      token: undefined,
+    });
     new S3Backend(this, {
       bucket: `mozilla-pocket-team-${config.environment.toLowerCase()}-terraform-state`,
       dynamodbTable: `mozilla-pocket-team-${config.environment.toLowerCase()}-terraform-state`,
@@ -38,8 +44,11 @@ class ClientAPI extends TerraformStack {
       region: 'us-east-1',
     });
 
-    const caller = new DataAwsCallerIdentity(this, 'caller');
-    const region = new DataAwsRegion(this, 'region');
+    const caller = new dataAwsCallerIdentity.DataAwsCallerIdentity(
+      this,
+      'caller',
+    );
+    const region = new dataAwsRegion.DataAwsRegion(this, 'region');
 
     const clientApiPagerduty = this.createPagerDuty();
     const pocketVPC = new PocketVPC(this, 'pocket-vpc');
@@ -78,7 +87,7 @@ class ClientAPI extends TerraformStack {
    * @private
    */
   private getCodeDeploySnsTopic() {
-    return new DataAwsSnsTopic(this, 'backend_notifications', {
+    return new dataAwsSnsTopic.DataAwsSnsTopic(this, 'backend_notifications', {
       name: `Backend-${config.environment}-ChatBot`,
     });
   }
@@ -88,7 +97,7 @@ class ClientAPI extends TerraformStack {
    * @private
    */
   private getSecretsManagerKmsAlias() {
-    return new DataAwsKmsAlias(this, 'kms_alias', {
+    return new dataAwsKmsAlias.DataAwsKmsAlias(this, 'kms_alias', {
       name: 'alias/aws/secretsmanager',
     });
   }
@@ -103,13 +112,14 @@ class ClientAPI extends TerraformStack {
       return null;
     }
 
-    const mozillaEscalation = new DataPagerdutyEscalationPolicy(
-      this,
-      'mozilla_sre_escalation_policy',
-      {
-        name: 'IT SRE: Escalation Policy',
-      },
-    );
+    const mozillaEscalation =
+      new dataPagerdutyEscalationPolicy.DataPagerdutyEscalationPolicy(
+        this,
+        'mozilla_sre_escalation_policy',
+        {
+          name: 'IT SRE: Escalation Policy',
+        },
+      );
 
     return new PocketPagerDuty(this, 'pagerduty', {
       prefix: config.prefix,
@@ -122,10 +132,10 @@ class ClientAPI extends TerraformStack {
 
   private createPocketAlbApplication(dependencies: {
     pagerDuty?: PocketPagerDuty;
-    region: DataAwsRegion;
-    caller: DataAwsCallerIdentity;
-    secretsManagerKmsAlias: DataAwsKmsAlias;
-    snsTopic: DataAwsSnsTopic;
+    region: dataAwsRegion.DataAwsRegion;
+    caller: dataAwsCallerIdentity.DataAwsCallerIdentity;
+    secretsManagerKmsAlias: dataAwsKmsAlias.DataAwsKmsAlias;
+    snsTopic: dataAwsSnsTopic.DataAwsSnsTopic;
     cache: string;
   }): PocketALBApplication {
     const {
@@ -332,7 +342,7 @@ class ClientAPI extends TerraformStack {
    */
   private createElasticache(scope: Construct, pocketVPC: PocketVPC): string {
     // Serverless elasticache doesn't support the `e` availablity zone in us-east-1... so we need to filter it out..
-    const privateSubnets = new DataAwsSubnets(
+    const privateSubnets = new dataAwsSubnets.DataAwsSubnets(
       this,
       `cache_private_subnet_ids`,
       {
@@ -375,7 +385,7 @@ class ClientAPI extends TerraformStack {
    * @private
    */
   private createCustomLogGroup(containerName: string) {
-    const logGroup = new CloudwatchLogGroup(
+    const logGroup = new cloudwatchLogGroup.CloudwatchLogGroup(
       this,
       `${containerName}-log-group`,
       {

--- a/infrastructure/feature-flags/src/main.ts
+++ b/infrastructure/feature-flags/src/main.ts
@@ -1,11 +1,13 @@
-import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
-import { DataAwsCallerIdentity } from '@cdktf/provider-aws/lib/data-aws-caller-identity';
-import { DataAwsRegion } from '@cdktf/provider-aws/lib/data-aws-region';
-import { DataAwsKmsAlias } from '@cdktf/provider-aws/lib/data-aws-kms-alias';
-import { DataAwsSnsTopic } from '@cdktf/provider-aws/lib/data-aws-sns-topic';
-import { LocalProvider } from '@cdktf/provider-local/lib/provider';
-import { NullProvider } from '@cdktf/provider-null/lib/provider';
-import { PagerdutyProvider } from '@cdktf/provider-pagerduty/lib/provider';
+import {
+  provider as awsProvider,
+  dataAwsCallerIdentity,
+  dataAwsRegion,
+  dataAwsKmsAlias,
+  dataAwsSnsTopic,
+} from '@cdktf/provider-aws';
+import { provider as localProvider } from '@cdktf/provider-local';
+import { provider as nullProvider } from '@cdktf/provider-null';
+import { provider as pagerdutyProvider } from '@cdktf/provider-pagerduty';
 import {
   ApplicationRDSCluster,
   PocketALBApplication,
@@ -21,12 +23,14 @@ class FeatureFlags extends TerraformStack {
   constructor(scope: Construct, name: string) {
     super(scope, name);
 
-    new AwsProvider(this, 'aws', { region: 'us-east-1' });
+    new awsProvider.AwsProvider(this, 'aws', { region: 'us-east-1' });
 
-    new PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
+    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', {
+      token: undefined,
+    });
 
-    new LocalProvider(this, 'local_provider');
-    new NullProvider(this, 'null_provider');
+    new localProvider.LocalProvider(this, 'local_provider');
+    new nullProvider.NullProvider(this, 'null_provider');
 
     new S3Backend(this, {
       bucket: `mozilla-pocket-team-${config.environment.toLowerCase()}-terraform-state`,
@@ -36,8 +40,11 @@ class FeatureFlags extends TerraformStack {
     });
 
     const pocketVpc = new PocketVPC(this, 'pocket-vpc');
-    const region = new DataAwsRegion(this, 'region');
-    const caller = new DataAwsCallerIdentity(this, 'caller');
+    const region = new dataAwsRegion.DataAwsRegion(this, 'region');
+    const caller = new dataAwsCallerIdentity.DataAwsCallerIdentity(
+      this,
+      'caller',
+    );
 
     this.createPocketAlbApplication({
       rds: this.createRds(pocketVpc),
@@ -54,7 +61,7 @@ class FeatureFlags extends TerraformStack {
    * @private
    */
   private getCodeDeploySnsTopic() {
-    return new DataAwsSnsTopic(this, 'backend_notifications', {
+    return new dataAwsSnsTopic.DataAwsSnsTopic(this, 'backend_notifications', {
       name: `Backend-${config.environment}-ChatBot`,
     });
   }
@@ -64,7 +71,7 @@ class FeatureFlags extends TerraformStack {
    * @private
    */
   private getSecretsManagerKmsAlias() {
-    return new DataAwsKmsAlias(this, 'kms_alias', {
+    return new dataAwsKmsAlias.DataAwsKmsAlias(this, 'kms_alias', {
       name: 'alias/aws/secretsmanager',
     });
   }
@@ -131,10 +138,10 @@ class FeatureFlags extends TerraformStack {
   private createPocketAlbApplication(dependencies: {
     rds: ApplicationRDSCluster;
     pagerDuty: PocketPagerDuty;
-    region: DataAwsRegion;
-    caller: DataAwsCallerIdentity;
-    secretsManagerKmsAlias: DataAwsKmsAlias;
-    snsTopic: DataAwsSnsTopic;
+    region: dataAwsRegion.DataAwsRegion;
+    caller: dataAwsCallerIdentity.DataAwsCallerIdentity;
+    secretsManagerKmsAlias: dataAwsKmsAlias.DataAwsKmsAlias;
+    snsTopic: dataAwsSnsTopic.DataAwsSnsTopic;
   }): PocketALBApplication {
     const { rds, region, caller, secretsManagerKmsAlias, snsTopic } =
       dependencies;

--- a/infrastructure/fxa-webhook-proxy/src/apiGateway.ts
+++ b/infrastructure/fxa-webhook-proxy/src/apiGateway.ts
@@ -9,14 +9,14 @@ import {
 import { config } from './config';
 import { getEnvVariableValues } from './utilities';
 import { Construct } from 'constructs';
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
+import { sqsQueue } from '@cdktf/provider-aws';
 
 export class ApiGateway extends Construct {
   constructor(
     scope: Construct,
     private name: string,
     private vpc: PocketVPC,
-    private sqsQueue: SqsQueue,
+    private sqsQueue: sqsQueue.SqsQueue,
     pagerDuty?: PocketPagerDuty,
   ) {
     super(scope, name);

--- a/infrastructure/fxa-webhook-proxy/src/main.ts
+++ b/infrastructure/fxa-webhook-proxy/src/main.ts
@@ -11,23 +11,23 @@ import {
   PocketPagerDuty,
   PocketVPC,
 } from '@pocket-tools/terraform-modules';
-import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
-import { PagerdutyProvider } from '@cdktf/provider-pagerduty/lib/provider';
+import { provider as awsProvider } from '@cdktf/provider-aws';
+import { provider as pagerdutyProvider } from '@cdktf/provider-pagerduty';
 import { SqsLambda } from './sqsLambda';
-import { ArchiveProvider } from '@cdktf/provider-archive/lib/provider';
-import { NullProvider } from '@cdktf/provider-null/lib/provider';
-import { LocalProvider } from '@cdktf/provider-local/lib/provider';
+import { provider as archiveProvider } from '@cdktf/provider-archive';
+import { provider as nullProvider } from '@cdktf/provider-null';
+import { provider as localProvider } from '@cdktf/provider-local';
 import { ApiGateway } from './apiGateway';
 
 class FxAWebhookProxy extends TerraformStack {
   constructor(scope: Construct, name: string) {
     super(scope, name);
 
-    new AwsProvider(this, 'aws', { region: 'us-east-1' });
-    new PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
-    new ArchiveProvider(this, 'archive-provider');
-    new NullProvider(this, 'null-provider');
-    new LocalProvider(this, 'local-provider');
+    new awsProvider.AwsProvider(this, 'aws', { region: 'us-east-1' });
+    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
+    new archiveProvider.ArchiveProvider(this, 'archive-provider');
+    new nullProvider.NullProvider(this, 'null-provider');
+    new localProvider.LocalProvider(this, 'local-provider');
 
     new S3Backend(this, {
       bucket: `mozilla-pocket-team-${config.environment.toLowerCase()}-terraform-state`,

--- a/infrastructure/fxa-webhook-proxy/src/sqsLambda.ts
+++ b/infrastructure/fxa-webhook-proxy/src/sqsLambda.ts
@@ -7,14 +7,14 @@ import {
   PocketVPC,
 } from '@pocket-tools/terraform-modules';
 import { getEnvVariableValues } from './utilities';
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
+import { sqsQueue } from '@cdktf/provider-aws';
 
 export class SqsLambda extends Construct {
   constructor(
     scope: Construct,
     private name: string,
     private vpc: PocketVPC,
-    private sqsQueue: SqsQueue,
+    private sqsQueue: sqsQueue.SqsQueue,
     pagerDuty?: PocketPagerDuty,
   ) {
     super(scope, name);

--- a/infrastructure/fxa-webhook-proxy/src/utilities.ts
+++ b/infrastructure/fxa-webhook-proxy/src/utilities.ts
@@ -1,15 +1,23 @@
-import { DataAwsSsmParameter } from '@cdktf/provider-aws/lib/data-aws-ssm-parameter';
+import { dataAwsSsmParameter } from '@cdktf/provider-aws';
 import { config } from './config';
 import { Construct } from 'constructs';
 
 export function getEnvVariableValues(scope: Construct) {
-  const sentryDsn = new DataAwsSsmParameter(scope, 'sentry-dsn', {
-    name: `/${config.name}/${config.environment}/SENTRY_DSN`,
-  });
+  const sentryDsn = new dataAwsSsmParameter.DataAwsSsmParameter(
+    scope,
+    'sentry-dsn',
+    {
+      name: `/${config.name}/${config.environment}/SENTRY_DSN`,
+    },
+  );
 
-  const serviceHash = new DataAwsSsmParameter(scope, 'service-hash', {
-    name: `${config.circleCIPrefix}/SERVICE_HASH`,
-  });
+  const serviceHash = new dataAwsSsmParameter.DataAwsSsmParameter(
+    scope,
+    'service-hash',
+    {
+      name: `${config.circleCIPrefix}/SERVICE_HASH`,
+    },
+  );
 
   return { sentryDsn: sentryDsn.value, gitSha: serviceHash.value };
 }

--- a/infrastructure/image-api/src/main.ts
+++ b/infrastructure/image-api/src/main.ts
@@ -14,27 +14,31 @@ import {
 } from '@pocket-tools/terraform-modules';
 import * as fs from 'fs';
 
-import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
-import { DataAwsRegion } from '@cdktf/provider-aws/lib/data-aws-region';
-import { DataAwsCallerIdentity } from '@cdktf/provider-aws/lib/data-aws-caller-identity';
-import { CloudwatchLogGroup } from '@cdktf/provider-aws/lib/cloudwatch-log-group';
-import { DataAwsKmsAlias } from '@cdktf/provider-aws/lib/data-aws-kms-alias';
-import { DataAwsSnsTopic } from '@cdktf/provider-aws/lib/data-aws-sns-topic';
-import { DataAwsSubnets } from '@cdktf/provider-aws/lib/data-aws-subnets';
-import { PagerdutyProvider } from '@cdktf/provider-pagerduty/lib/provider';
-import { NullProvider } from '@cdktf/provider-null/lib/provider';
-import { LocalProvider } from '@cdktf/provider-local/lib/provider';
-import { ArchiveProvider } from '@cdktf/provider-archive/lib/provider';
+import {
+  provider as awsProvider,
+  dataAwsRegion,
+  dataAwsCallerIdentity,
+  dataAwsKmsAlias,
+  cloudwatchLogGroup,
+  dataAwsSnsTopic,
+  dataAwsSubnets,
+} from '@cdktf/provider-aws';
+import { provider as pagerdutyProvider } from '@cdktf/provider-pagerduty';
+import { provider as nullProvider } from '@cdktf/provider-null';
+import { provider as localProvider } from '@cdktf/provider-local';
+import { provider as archiveProvider } from '@cdktf/provider-archive';
 
 class ImageAPI extends TerraformStack {
   constructor(scope: Construct, name: string) {
     super(scope, name);
 
-    new AwsProvider(this, 'aws', { region: 'us-east-1' });
-    new PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
-    new NullProvider(this, 'null-provider');
-    new LocalProvider(this, 'local-provider');
-    new ArchiveProvider(this, 'archive-provider');
+    new awsProvider.AwsProvider(this, 'aws', { region: 'us-east-1' });
+    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', {
+      token: undefined,
+    });
+    new nullProvider.NullProvider(this, 'null-provider');
+    new localProvider.LocalProvider(this, 'local-provider');
+    new archiveProvider.ArchiveProvider(this, 'archive-provider');
 
     new S3Backend(this, {
       bucket: `mozilla-pocket-team-${config.environment.toLowerCase()}-terraform-state`,
@@ -44,8 +48,11 @@ class ImageAPI extends TerraformStack {
     });
 
     const pocketVPC = new PocketVPC(this, 'pocket-vpc');
-    const region = new DataAwsRegion(this, 'region');
-    const caller = new DataAwsCallerIdentity(this, 'caller');
+    const region = new dataAwsRegion.DataAwsRegion(this, 'region');
+    const caller = new dataAwsCallerIdentity.DataAwsCallerIdentity(
+      this,
+      'caller',
+    );
 
     const { primaryEndpoint, readerEndpoint } = this.createElasticache(
       this,
@@ -68,7 +75,7 @@ class ImageAPI extends TerraformStack {
    * @private
    */
   private getCodeDeploySnsTopic() {
-    return new DataAwsSnsTopic(this, 'backend_notifications', {
+    return new dataAwsSnsTopic.DataAwsSnsTopic(this, 'backend_notifications', {
       name: `Backend-${config.environment}-ChatBot`,
     });
   }
@@ -78,7 +85,7 @@ class ImageAPI extends TerraformStack {
    * @private
    */
   private getSecretsManagerKmsAlias() {
-    return new DataAwsKmsAlias(this, 'kms_alias', {
+    return new dataAwsKmsAlias.DataAwsKmsAlias(this, 'kms_alias', {
       name: 'alias/aws/secretsmanager',
     });
   }
@@ -119,10 +126,10 @@ class ImageAPI extends TerraformStack {
 
   private createPocketAlbApplication(dependencies: {
     pagerDuty: PocketPagerDuty;
-    region: DataAwsRegion;
-    caller: DataAwsCallerIdentity;
-    secretsManagerKmsAlias: DataAwsKmsAlias;
-    snsTopic: DataAwsSnsTopic;
+    region: dataAwsRegion.DataAwsRegion;
+    caller: dataAwsCallerIdentity.DataAwsCallerIdentity;
+    secretsManagerKmsAlias: dataAwsKmsAlias.DataAwsKmsAlias;
+    snsTopic: dataAwsSnsTopic.DataAwsSnsTopic;
     primaryEndpoint: string;
     readerEndpoint: string;
   }): PocketALBApplication {
@@ -324,7 +331,7 @@ class ImageAPI extends TerraformStack {
     readerEndpoint: string;
   } {
     // Serverless elasticache doesn't support the `e` availablity zone in us-east-1... so we need to filter it out..
-    const privateSubnets = new DataAwsSubnets(
+    const privateSubnets = new dataAwsSubnets.DataAwsSubnets(
       this,
       `cache_private_subnet_ids`,
       {
@@ -370,7 +377,7 @@ class ImageAPI extends TerraformStack {
    * @private
    */
   private createCustomLogGroup(containerName: string) {
-    const logGroup = new CloudwatchLogGroup(
+    const logGroup = new cloudwatchLogGroup.CloudwatchLogGroup(
       this,
       `${containerName}-log-group`,
       {

--- a/infrastructure/list-api/src/main.ts
+++ b/infrastructure/list-api/src/main.ts
@@ -1,13 +1,15 @@
-import { ArchiveProvider } from '@cdktf/provider-archive/lib/provider';
-import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
-import { DataAwsCallerIdentity } from '@cdktf/provider-aws/lib/data-aws-caller-identity';
-import { DataAwsRegion } from '@cdktf/provider-aws/lib/data-aws-region';
-import { DataAwsKmsAlias } from '@cdktf/provider-aws/lib/data-aws-kms-alias';
-import { DataAwsSnsTopic } from '@cdktf/provider-aws/lib/data-aws-sns-topic';
-import { CloudwatchLogGroup } from '@cdktf/provider-aws/lib/cloudwatch-log-group';
-import { LocalProvider } from '@cdktf/provider-local/lib/provider';
-import { NullProvider } from '@cdktf/provider-null/lib/provider';
-import { PagerdutyProvider } from '@cdktf/provider-pagerduty/lib/provider';
+import { provider as archiveProvider } from '@cdktf/provider-archive';
+import {
+  provider as awsProvider,
+  dataAwsCallerIdentity,
+  dataAwsRegion,
+  dataAwsKmsAlias,
+  dataAwsSnsTopic,
+  cloudwatchLogGroup,
+} from '@cdktf/provider-aws';
+import { provider as localProvider } from '@cdktf/provider-local';
+import { provider as nullProvider } from '@cdktf/provider-null';
+import { provider as pagerdutyProvider } from '@cdktf/provider-pagerduty';
 import {
   ApplicationRDSCluster,
   PocketALBApplication,
@@ -27,11 +29,13 @@ class ListAPI extends TerraformStack {
   constructor(scope: Construct, name: string) {
     super(scope, name);
 
-    new AwsProvider(this, 'aws', { region: 'us-east-1' });
-    new PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
-    new NullProvider(this, 'null-provider');
-    new LocalProvider(this, 'local-provider');
-    new ArchiveProvider(this, 'archive-provider');
+    new awsProvider.AwsProvider(this, 'aws', { region: 'us-east-1' });
+    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', {
+      token: undefined,
+    });
+    new nullProvider.NullProvider(this, 'null-provider');
+    new localProvider.LocalProvider(this, 'local-provider');
+    new archiveProvider.ArchiveProvider(this, 'archive-provider');
 
     new S3Backend(this, {
       bucket: `mozilla-pocket-team-${config.environment.toLowerCase()}-terraform-state`,
@@ -41,8 +45,11 @@ class ListAPI extends TerraformStack {
     });
 
     const pocketVPC = new PocketVPC(this, 'pocket-vpc');
-    const region = new DataAwsRegion(this, 'region');
-    const caller = new DataAwsCallerIdentity(this, 'caller');
+    const region = new dataAwsRegion.DataAwsRegion(this, 'region');
+    const caller = new dataAwsCallerIdentity.DataAwsCallerIdentity(
+      this,
+      'caller',
+    );
     this.createPocketAlbApplication({
       pagerDuty: this.createPagerDuty(),
       secretsManagerKmsAlias: this.getSecretsManagerKmsAlias(),
@@ -58,7 +65,7 @@ class ListAPI extends TerraformStack {
    * @private
    */
   private getCodeDeploySnsTopic() {
-    return new DataAwsSnsTopic(this, 'backend_notifications', {
+    return new dataAwsSnsTopic.DataAwsSnsTopic(this, 'backend_notifications', {
       name: `Backend-${config.environment}-ChatBot`,
     });
   }
@@ -68,7 +75,7 @@ class ListAPI extends TerraformStack {
    * @private
    */
   private getSecretsManagerKmsAlias() {
-    return new DataAwsKmsAlias(this, 'kms_alias', {
+    return new dataAwsKmsAlias.DataAwsKmsAlias(this, 'kms_alias', {
       name: 'alias/aws/secretsmanager',
     });
   }
@@ -132,10 +139,10 @@ class ListAPI extends TerraformStack {
 
   private createPocketAlbApplication(dependencies: {
     pagerDuty: PocketPagerDuty;
-    region: DataAwsRegion;
-    caller: DataAwsCallerIdentity;
-    secretsManagerKmsAlias: DataAwsKmsAlias;
-    snsTopic: DataAwsSnsTopic;
+    region: dataAwsRegion.DataAwsRegion;
+    caller: dataAwsCallerIdentity.DataAwsCallerIdentity;
+    secretsManagerKmsAlias: dataAwsKmsAlias.DataAwsKmsAlias;
+    snsTopic: dataAwsSnsTopic.DataAwsSnsTopic;
     vpc: PocketVPC;
   }): PocketALBApplication {
     const { pagerDuty, region, caller, secretsManagerKmsAlias, snsTopic, vpc } =
@@ -445,7 +452,7 @@ class ListAPI extends TerraformStack {
    * @private
    */
   private createCustomLogGroup(containerName: string) {
-    const logGroup = new CloudwatchLogGroup(
+    const logGroup = new cloudwatchLogGroup.CloudwatchLogGroup(
       this,
       `${containerName}-log-group`,
       {

--- a/infrastructure/pocket-event-bridge/src/event-rules/forgot-password-request/index.ts
+++ b/infrastructure/pocket-event-bridge/src/event-rules/forgot-password-request/index.ts
@@ -5,17 +5,19 @@ import {
   PocketPagerDuty,
 } from '@pocket-tools/terraform-modules';
 import { config } from '../../config';
-import { SnsTopic } from '@cdktf/provider-aws/lib/sns-topic';
-import { DataAwsIamPolicyDocument } from '@cdktf/provider-aws/lib/data-aws-iam-policy-document';
-import { SnsTopicPolicy } from '@cdktf/provider-aws/lib/sns-topic-policy';
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
-import { Resource } from '@cdktf/provider-null/lib/resource';
+import {
+  snsTopic,
+  dataAwsIamPolicyDocument,
+  snsTopicPolicy,
+  sqsQueue,
+} from '@cdktf/provider-aws';
+import { resource } from '@cdktf/provider-null';
 import { eventConfig } from './eventConfig';
 import { createDeadLetterQueueAlarm } from '../utils';
 
 export class ForgotPassword extends Construct {
-  public readonly snsTopic: SnsTopic;
-  public readonly snsTopicDlq: SqsQueue;
+  public readonly snsTopic: snsTopic.SnsTopic;
+  public readonly snsTopicDlq: sqsQueue.SqsQueue;
 
   constructor(
     scope: Construct,
@@ -24,7 +26,7 @@ export class ForgotPassword extends Construct {
   ) {
     super(scope, name);
 
-    this.snsTopic = new SnsTopic(this, 'forgot-password-topic', {
+    this.snsTopic = new snsTopic.SnsTopic(this, 'forgot-password-topic', {
       name: `${config.prefix}-${eventConfig.name}-Topic`,
       lifecycle: {
         preventDestroy: true,
@@ -32,7 +34,7 @@ export class ForgotPassword extends Construct {
       tags: config.tags,
     });
 
-    this.snsTopicDlq = new SqsQueue(this, 'sns-topic-dlq', {
+    this.snsTopicDlq = new sqsQueue.SqsQueue(this, 'sns-topic-dlq', {
       name: `${config.prefix}-${eventConfig.name}-SNS-Topic-Event-Rule-DLQ`,
       tags: config.tags,
     });
@@ -47,7 +49,7 @@ export class ForgotPassword extends Construct {
       `${eventConfig.name}-rule-dlq-alarm`,
     );
 
-    new Resource(this, 'null-resource', {
+    new resource.Resource(this, 'null-resource', {
       dependsOn: [forgotPasswordRule.getEventBridge().rule, this.snsTopic],
     });
   }
@@ -87,29 +89,34 @@ export class ForgotPassword extends Construct {
   }
 
   private createPolicyForEventBridgeToSns() {
-    const eventBridgeSnsPolicy = new DataAwsIamPolicyDocument(
-      this,
-      `${config.prefix}-EventBridge-SNS-Policy`,
-      {
-        statement: [
-          {
-            effect: 'Allow',
-            actions: ['sns:Publish'],
-            resources: [this.snsTopic.arn],
-            principals: [
-              {
-                identifiers: ['events.amazonaws.com'],
-                type: 'Service',
-              },
-            ],
-          },
-        ],
-      },
-    ).json;
+    const eventBridgeSnsPolicy =
+      new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
+        this,
+        `${config.prefix}-EventBridge-SNS-Policy`,
+        {
+          statement: [
+            {
+              effect: 'Allow',
+              actions: ['sns:Publish'],
+              resources: [this.snsTopic.arn],
+              principals: [
+                {
+                  identifiers: ['events.amazonaws.com'],
+                  type: 'Service',
+                },
+              ],
+            },
+          ],
+        },
+      ).json;
 
-    return new SnsTopicPolicy(this, 'forgot-password-sns-topic-policy', {
-      arn: this.snsTopic.arn,
-      policy: eventBridgeSnsPolicy,
-    });
+    return new snsTopicPolicy.SnsTopicPolicy(
+      this,
+      'forgot-password-sns-topic-policy',
+      {
+        arn: this.snsTopic.arn,
+        policy: eventBridgeSnsPolicy,
+      },
+    );
   }
 }

--- a/infrastructure/pocket-event-bridge/src/event-rules/shareable-lists-api-events/shareableListEventRules.ts
+++ b/infrastructure/pocket-event-bridge/src/event-rules/shareable-lists-api-events/shareableListEventRules.ts
@@ -6,17 +6,19 @@ import {
   PocketPagerDuty,
 } from '@pocket-tools/terraform-modules';
 import { config } from '../../config';
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
-import { SnsTopic } from '@cdktf/provider-aws/lib/sns-topic';
-import { DataAwsIamPolicyDocument } from '@cdktf/provider-aws/lib/data-aws-iam-policy-document';
-import { SnsTopicPolicy } from '@cdktf/provider-aws/lib/sns-topic-policy';
-import { Resource } from '@cdktf/provider-null/lib/resource';
+import {
+  sqsQueue,
+  snsTopic,
+  dataAwsIamPolicyDocument,
+  snsTopicPolicy,
+} from '@cdktf/provider-aws';
+import { resource } from '@cdktf/provider-null';
 import { eventConfig } from './eventConfig';
 import { createDeadLetterQueueAlarm } from '../utils';
 
 export class ShareableListEvents extends Construct {
-  public readonly snsTopic: SnsTopic;
-  public readonly snsTopicDlq: SqsQueue;
+  public readonly snsTopic: snsTopic.SnsTopic;
+  public readonly snsTopicDlq: sqsQueue.SqsQueue;
 
   constructor(
     scope: Construct,
@@ -26,14 +28,14 @@ export class ShareableListEvents extends Construct {
   ) {
     super(scope, name);
 
-    this.snsTopic = new SnsTopic(this, 'shareable-list-event-topic', {
+    this.snsTopic = new snsTopic.SnsTopic(this, 'shareable-list-event-topic', {
       name: `${config.prefix}-ShareableListEventTopic`,
       lifecycle: {
         preventDestroy: true,
       },
     });
 
-    this.snsTopicDlq = new SqsQueue(this, 'sns-topic-dql', {
+    this.snsTopicDlq = new sqsQueue.SqsQueue(this, 'sns-topic-dql', {
       name: `${config.prefix}-SNS-${eventConfig.shareableList.name}-Topic-DLQ`,
       tags: config.tags,
     });
@@ -59,7 +61,7 @@ export class ShareableListEvents extends Construct {
     //to prevent resource deletion in-addition to preventDestroy
     //e.g removing any of the dependsOn resource and running npm build would
     //throw error
-    new Resource(this, 'null-resource', {
+    new resource.Resource(this, 'null-resource', {
       dependsOn: [shareableListEvent.getEventBridge().rule, this.snsTopic],
     });
   }
@@ -97,29 +99,34 @@ export class ShareableListEvents extends Construct {
   }
 
   private createPolicyForEventBridgeToSns() {
-    const eventBridgeSnsPolicy = new DataAwsIamPolicyDocument(
-      this,
-      `${config.prefix}-EventBridge-SNS-Policy`,
-      {
-        statement: [
-          {
-            effect: 'Allow',
-            actions: ['sns:Publish'],
-            resources: [this.snsTopic.arn],
-            principals: [
-              {
-                identifiers: ['events.amazonaws.com'],
-                type: 'Service',
-              },
-            ],
-          },
-        ],
-      },
-    ).json;
+    const eventBridgeSnsPolicy =
+      new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
+        this,
+        `${config.prefix}-EventBridge-SNS-Policy`,
+        {
+          statement: [
+            {
+              effect: 'Allow',
+              actions: ['sns:Publish'],
+              resources: [this.snsTopic.arn],
+              principals: [
+                {
+                  identifiers: ['events.amazonaws.com'],
+                  type: 'Service',
+                },
+              ],
+            },
+          ],
+        },
+      ).json;
 
-    return new SnsTopicPolicy(this, 'shareable-list-events-sns-topic-policy', {
-      arn: this.snsTopic.arn,
-      policy: eventBridgeSnsPolicy,
-    });
+    return new snsTopicPolicy.SnsTopicPolicy(
+      this,
+      'shareable-list-events-sns-topic-policy',
+      {
+        arn: this.snsTopic.arn,
+        policy: eventBridgeSnsPolicy,
+      },
+    );
   }
 }

--- a/infrastructure/pocket-event-bridge/src/event-rules/user-api-events/userApiEventRules.ts
+++ b/infrastructure/pocket-event-bridge/src/event-rules/user-api-events/userApiEventRules.ts
@@ -6,17 +6,19 @@ import {
   PocketPagerDuty,
 } from '@pocket-tools/terraform-modules';
 import { config } from '../../config';
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
-import { SnsTopic } from '@cdktf/provider-aws/lib/sns-topic';
-import { DataAwsIamPolicyDocument } from '@cdktf/provider-aws/lib/data-aws-iam-policy-document';
-import { SnsTopicPolicy } from '@cdktf/provider-aws/lib/sns-topic-policy';
-import { Resource } from '@cdktf/provider-null/lib/resource';
+import {
+  sqsQueue,
+  snsTopic,
+  dataAwsIamPolicyDocument,
+  snsTopicPolicy,
+} from '@cdktf/provider-aws';
+import { resource } from '@cdktf/provider-null';
 import { eventConfig } from './eventConfig';
 import { createDeadLetterQueueAlarm } from '../utils';
 
-export class UserApiEvents extends Resource {
-  public readonly snsTopic: SnsTopic;
-  public readonly snsTopicDlq: SqsQueue;
+export class UserApiEvents extends Construct {
+  public readonly snsTopic: snsTopic.SnsTopic;
+  public readonly snsTopicDlq: sqsQueue.SqsQueue;
 
   constructor(
     scope: Construct,
@@ -26,14 +28,14 @@ export class UserApiEvents extends Resource {
   ) {
     super(scope, name);
 
-    this.snsTopic = new SnsTopic(this, 'user-event-topic', {
+    this.snsTopic = new snsTopic.SnsTopic(this, 'user-event-topic', {
       name: `${config.prefix}-UserEventTopic`,
       lifecycle: {
         preventDestroy: true,
       },
     });
 
-    this.snsTopicDlq = new SqsQueue(this, 'sns-topic-dql', {
+    this.snsTopicDlq = new sqsQueue.SqsQueue(this, 'sns-topic-dql', {
       name: `${config.prefix}-${eventConfig.name}-Topic-Rule-DLQ`,
       tags: config.tags,
     });
@@ -59,7 +61,7 @@ export class UserApiEvents extends Resource {
     //to prevent resource deletion in-addition to preventDestroy
     //e.g removing any of the dependsOn resource and running npm build would
     //throw error
-    new Resource(this, 'null-resource', {
+    new resource.Resource(this, 'null-resource', {
       dependsOn: [userEvent.getEventBridge().rule, this.snsTopic],
     });
   }
@@ -97,29 +99,34 @@ export class UserApiEvents extends Resource {
   }
 
   private createPolicyForEventBridgeToSns() {
-    const eventBridgeSnsPolicy = new DataAwsIamPolicyDocument(
-      this,
-      `${config.prefix}-EventBridge-SNS-Policy`,
-      {
-        statement: [
-          {
-            effect: 'Allow',
-            actions: ['sns:Publish'],
-            resources: [this.snsTopic.arn],
-            principals: [
-              {
-                identifiers: ['events.amazonaws.com'],
-                type: 'Service',
-              },
-            ],
-          },
-        ],
-      },
-    ).json;
+    const eventBridgeSnsPolicy =
+      new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
+        this,
+        `${config.prefix}-EventBridge-SNS-Policy`,
+        {
+          statement: [
+            {
+              effect: 'Allow',
+              actions: ['sns:Publish'],
+              resources: [this.snsTopic.arn],
+              principals: [
+                {
+                  identifiers: ['events.amazonaws.com'],
+                  type: 'Service',
+                },
+              ],
+            },
+          ],
+        },
+      ).json;
 
-    return new SnsTopicPolicy(this, 'user-events-sns-topic-policy', {
-      arn: this.snsTopic.arn,
-      policy: eventBridgeSnsPolicy,
-    });
+    return new snsTopicPolicy.SnsTopicPolicy(
+      this,
+      'user-events-sns-topic-policy',
+      {
+        arn: this.snsTopic.arn,
+        policy: eventBridgeSnsPolicy,
+      },
+    );
   }
 }

--- a/infrastructure/pocket-event-bridge/src/event-rules/user-registration/userRegistrationEventRule.ts
+++ b/infrastructure/pocket-event-bridge/src/event-rules/user-registration/userRegistrationEventRule.ts
@@ -5,16 +5,18 @@ import {
   PocketPagerDuty,
 } from '@pocket-tools/terraform-modules';
 import { config } from '../../config';
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
-import { SnsTopic } from '@cdktf/provider-aws/lib/sns-topic';
-import { DataAwsIamPolicyDocument } from '@cdktf/provider-aws/lib/data-aws-iam-policy-document';
-import { SnsTopicPolicy } from '@cdktf/provider-aws/lib/sns-topic-policy';
-import { Resource } from '@cdktf/provider-null/lib/resource';
+import {
+  sqsQueue,
+  snsTopic,
+  dataAwsIamPolicyDocument,
+  snsTopicPolicy,
+} from '@cdktf/provider-aws';
+import { resource } from '@cdktf/provider-null';
 import { eventConfig } from './eventConfig';
 
-export class UserRegistrationEventRule extends Resource {
-  public readonly snsTopic: SnsTopic;
-  public readonly snsTopicDlq: SqsQueue;
+export class UserRegistrationEventRule extends Construct {
+  public readonly snsTopic: snsTopic.SnsTopic;
+  public readonly snsTopicDlq: sqsQueue.SqsQueue;
 
   constructor(
     scope: Construct,
@@ -23,14 +25,14 @@ export class UserRegistrationEventRule extends Resource {
   ) {
     super(scope, name);
 
-    this.snsTopic = new SnsTopic(this, 'user-registration-topic', {
+    this.snsTopic = new snsTopic.SnsTopic(this, 'user-registration-topic', {
       name: `${config.prefix}-UserRegistrationTopic`,
       lifecycle: {
         preventDestroy: true,
       },
     });
 
-    this.snsTopicDlq = new SqsQueue(this, 'sns-topic-dql', {
+    this.snsTopicDlq = new sqsQueue.SqsQueue(this, 'sns-topic-dql', {
       name: `${config.prefix}-SNS-${eventConfig.name}-Topic--DLQ`,
       tags: config.tags,
     });
@@ -46,7 +48,7 @@ export class UserRegistrationEventRule extends Resource {
     //to prevent resource deletion in-addition to preventDestroy
     //e.g removing any of the dependsOn resource and running npm build would
     //throw error
-    new Resource(this, 'null-resource', {
+    new resource.Resource(this, 'null-resource', {
       dependsOn: [userRegistrationEvent.getEventBridge().rule, this.snsTopic],
     });
   }
@@ -84,27 +86,28 @@ export class UserRegistrationEventRule extends Resource {
   }
 
   private createPolicyForEventBridgeToSns() {
-    const eventBridgeSnsPolicy = new DataAwsIamPolicyDocument(
-      this,
-      `${config.prefix}-EventBridge-SNS-Policy`,
-      {
-        statement: [
-          {
-            effect: 'Allow',
-            actions: ['sns:Publish'],
-            resources: [this.snsTopic.arn],
-            principals: [
-              {
-                identifiers: ['events.amazonaws.com'],
-                type: 'Service',
-              },
-            ],
-          },
-        ],
-      },
-    ).json;
+    const eventBridgeSnsPolicy =
+      new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
+        this,
+        `${config.prefix}-EventBridge-SNS-Policy`,
+        {
+          statement: [
+            {
+              effect: 'Allow',
+              actions: ['sns:Publish'],
+              resources: [this.snsTopic.arn],
+              principals: [
+                {
+                  identifiers: ['events.amazonaws.com'],
+                  type: 'Service',
+                },
+              ],
+            },
+          ],
+        },
+      ).json;
 
-    return new SnsTopicPolicy(
+    return new snsTopicPolicy.SnsTopicPolicy(
       this,
       'user-registration-events-sns-topic-policy',
       {

--- a/infrastructure/pocket-event-bridge/src/event-rules/utils.ts
+++ b/infrastructure/pocket-event-bridge/src/event-rules/utils.ts
@@ -1,6 +1,6 @@
 import { config } from '../config';
 import { PocketPagerDuty } from '@pocket-tools/terraform-modules';
-import { CloudwatchMetricAlarm } from '@cdktf/provider-aws/lib/cloudwatch-metric-alarm';
+import { cloudwatchMetricAlarm } from '@cdktf/provider-aws';
 
 /**
  * Function to create alarms for Dead-letter queues
@@ -27,19 +27,25 @@ export function createDeadLetterQueueAlarm(
   periodInSeconds = 900,
   threshold = 15,
 ) {
-  new CloudwatchMetricAlarm(stack, alarmName.toLowerCase(), {
-    alarmName: `${config.prefix}-${alarmName}`,
-    alarmDescription: `Number of messages >= ${threshold}`,
-    namespace: 'AWS/SQS',
-    metricName: 'ApproximateNumberOfMessagesVisible',
-    dimensions: { QueueName: queueName },
-    comparisonOperator: 'GreaterThanOrEqualToThreshold',
-    evaluationPeriods: evaluationPeriods,
-    period: periodInSeconds,
-    threshold: threshold,
-    statistic: 'Sum',
-    alarmActions: config.isDev ? [] : [pagerDuty.snsNonCriticalAlarmTopic.arn],
-    okActions: config.isDev ? [] : [pagerDuty.snsNonCriticalAlarmTopic.arn],
-    actionsEnabled: enabled,
-  });
+  new cloudwatchMetricAlarm.CloudwatchMetricAlarm(
+    stack,
+    alarmName.toLowerCase(),
+    {
+      alarmName: `${config.prefix}-${alarmName}`,
+      alarmDescription: `Number of messages >= ${threshold}`,
+      namespace: 'AWS/SQS',
+      metricName: 'ApproximateNumberOfMessagesVisible',
+      dimensions: { QueueName: queueName },
+      comparisonOperator: 'GreaterThanOrEqualToThreshold',
+      evaluationPeriods: evaluationPeriods,
+      period: periodInSeconds,
+      threshold: threshold,
+      statistic: 'Sum',
+      alarmActions: config.isDev
+        ? []
+        : [pagerDuty.snsNonCriticalAlarmTopic.arn],
+      okActions: config.isDev ? [] : [pagerDuty.snsNonCriticalAlarmTopic.arn],
+      actionsEnabled: enabled,
+    },
+  );
 }

--- a/infrastructure/pocket-event-bridge/src/events-schema/ForgotPasswordRequestEvent.ts
+++ b/infrastructure/pocket-event-bridge/src/events-schema/ForgotPasswordRequestEvent.ts
@@ -3,10 +3,7 @@
  * user initiates a password recovery
  */
 import { Construct } from 'constructs';
-import {
-  SchemasSchema,
-  SchemasSchemaConfig,
-} from '@cdktf/provider-aws/lib/schemas-schema';
+import { schemasSchema } from '@cdktf/provider-aws';
 import { SCHEMA_REGISTRY, SCHEMA_TYPE } from './types';
 
 export class ForgotPasswordRequestEvent extends Construct {
@@ -21,14 +18,14 @@ export class ForgotPasswordRequestEvent extends Construct {
   }
 
   private createForgotPasswordRequestEvent() {
-    const schemaProps: SchemasSchemaConfig = {
+    const schemaProps: schemasSchema.SchemasSchemaConfig = {
       name: this.forgotPasswordRequest,
       description: `emitted when pocket user initiates a password recovery`,
       type: SCHEMA_TYPE,
       registryName: SCHEMA_REGISTRY,
       content: JSON.stringify(this.getForgotPasswordRequestPayload()),
     };
-    const schema = new SchemasSchema(
+    const schema = new schemasSchema.SchemasSchema(
       this,
       `${this.forgotPasswordRequest}-Schema`,
       schemaProps,

--- a/infrastructure/pocket-event-bridge/src/events-schema/premiumPurchaseEvent.ts
+++ b/infrastructure/pocket-event-bridge/src/events-schema/premiumPurchaseEvent.ts
@@ -3,10 +3,7 @@
  * Both events share the same payload type
  */
 import { Construct } from 'constructs';
-import {
-  SchemasSchema,
-  SchemasSchemaConfig,
-} from '@cdktf/provider-aws/lib/schemas-schema';
+import { schemasSchema } from '@cdktf/provider-aws';
 import { SCHEMA_REGISTRY, SCHEMA_TYPE } from './types';
 
 export class PremiumPurchaseEvent extends Construct {
@@ -24,14 +21,14 @@ export class PremiumPurchaseEvent extends Construct {
   }
 
   private createPremiumPurchaseEvent() {
-    const schemaProps: SchemasSchemaConfig = {
+    const schemaProps: schemasSchema.SchemasSchemaConfig = {
       name: this.premiumPurchaseEvent,
       description: `emitted when pocket user subscribes for premium account`,
       type: SCHEMA_TYPE,
       registryName: SCHEMA_REGISTRY,
       content: JSON.stringify(this.getPremiumPurchaseEventSchema()),
     };
-    const schema = new SchemasSchema(
+    const schema = new schemasSchema.SchemasSchema(
       this,
       `${this.premiumPurchaseEvent}-Schema`,
       schemaProps,
@@ -41,14 +38,14 @@ export class PremiumPurchaseEvent extends Construct {
   }
 
   private createPremiumRenewalUpcomingEvent() {
-    const schemaProps: SchemasSchemaConfig = {
+    const schemaProps: schemasSchema.SchemasSchemaConfig = {
       name: this.premiumRenewalUpcomingEvent,
       description: `emitted when pocket user premium subscription is renewed`,
       type: SCHEMA_TYPE,
       registryName: SCHEMA_REGISTRY,
       content: JSON.stringify(this.getPremiumPurchaseEventSchema()),
     };
-    const schema = new SchemasSchema(
+    const schema = new schemasSchema.SchemasSchema(
       this,
       `${this.premiumRenewalUpcomingEvent}-Schema`,
       schemaProps,

--- a/infrastructure/pocket-event-bridge/src/events-schema/queueCheckDelete.ts
+++ b/infrastructure/pocket-event-bridge/src/events-schema/queueCheckDelete.ts
@@ -5,10 +5,7 @@
  */
 import { Fn } from 'cdktf';
 import { Construct } from 'constructs';
-import {
-  SchemasSchema,
-  SchemasSchemaConfig,
-} from '@cdktf/provider-aws/lib/schemas-schema';
+import { schemasSchema } from '@cdktf/provider-aws';
 import { SCHEMA_REGISTRY, SCHEMA_TYPE } from './types';
 import { config } from '../event-rules/account-delete-monitor/config';
 
@@ -22,14 +19,14 @@ export class QueueCheckDeleteSchema extends Construct {
   }
 
   private createQueueCheckDeleteSchema() {
-    const schemaProps: SchemasSchemaConfig = {
+    const schemaProps: schemasSchema.SchemasSchemaConfig = {
       name: config.queueCheckDelete.schema,
       description: `scheduled event to start "check delete" cascade, for determining if a user's data has been removed after deleting their account`,
       type: SCHEMA_TYPE,
       registryName: SCHEMA_REGISTRY,
       content: Fn.jsonencode(this.getScheduleCheckDeleteSchema()),
     };
-    const schema = new SchemasSchema(
+    const schema = new schemasSchema.SchemasSchema(
       this,
       `${config.queueCheckDelete.scheduleExpression}-schema`,
       schemaProps,

--- a/infrastructure/pocket-event-bridge/src/events-schema/userEvents.ts
+++ b/infrastructure/pocket-event-bridge/src/events-schema/userEvents.ts
@@ -1,9 +1,6 @@
 import { Fn } from 'cdktf';
 import { Construct } from 'constructs';
-import {
-  SchemasSchema,
-  SchemasSchemaConfig,
-} from '@cdktf/provider-aws/lib/schemas-schema';
+import { schemasSchema } from '@cdktf/provider-aws';
 import { SCHEMA_REGISTRY, SCHEMA_TYPE } from './types';
 
 export class UserEventsSchema extends Construct {
@@ -16,14 +13,18 @@ export class UserEventsSchema extends Construct {
   }
 
   private createUserEventsSchema() {
-    const schemaProps: SchemasSchemaConfig = {
+    const schemaProps: schemasSchema.SchemasSchemaConfig = {
       name: 'user-events',
       description: 'events emitted by user-api',
       type: SCHEMA_TYPE,
       registryName: SCHEMA_REGISTRY,
       content: Fn.jsonencode(this.getUserEventsSchema()),
     };
-    const schema = new SchemasSchema(this, 'user-events-schema', schemaProps);
+    const schema = new schemasSchema.SchemasSchema(
+      this,
+      'user-events-schema',
+      schemaProps,
+    );
     return schema;
   }
 

--- a/infrastructure/pocket-event-bridge/src/events-schema/userMergeEvent.ts
+++ b/infrastructure/pocket-event-bridge/src/events-schema/userMergeEvent.ts
@@ -4,10 +4,7 @@
  */
 import { Fn } from 'cdktf';
 import { Construct } from 'constructs';
-import {
-  SchemasSchema,
-  SchemasSchemaConfig,
-} from '@cdktf/provider-aws/lib/schemas-schema';
+import { schemasSchema } from '@cdktf/provider-aws';
 import { SCHEMA_REGISTRY, SCHEMA_TYPE } from './types';
 
 export class UserMergeEventSchema extends Construct {
@@ -21,14 +18,14 @@ export class UserMergeEventSchema extends Construct {
   }
 
   private createUserMergeEvent() {
-    const schemaProps: SchemasSchemaConfig = {
+    const schemaProps: schemasSchema.SchemasSchemaConfig = {
       name: this.eventName,
       description: `user merge event is emitted when sourceUserId's account data is merged to the destinationUserId's account`,
       type: SCHEMA_TYPE,
       registryName: SCHEMA_REGISTRY,
       content: Fn.jsonencode(this.getUserMergeEventSchema()),
     };
-    const schema = new SchemasSchema(
+    const schema = new schemasSchema.SchemasSchema(
       this,
       `${this.eventName}-schema`,
       schemaProps,

--- a/infrastructure/pocket-event-bridge/src/events-schema/userRegistrationEventSchema.ts
+++ b/infrastructure/pocket-event-bridge/src/events-schema/userRegistrationEventSchema.ts
@@ -3,10 +3,7 @@
  * user initiates a password recovery
  */
 import { Construct } from 'constructs';
-import {
-  SchemasSchema,
-  SchemasSchemaConfig,
-} from '@cdktf/provider-aws/lib/schemas-schema';
+import { schemasSchema } from '@cdktf/provider-aws';
 import { SCHEMA_REGISTRY, SCHEMA_TYPE } from './types';
 
 export class UserRegistrationEventSchema extends Construct {
@@ -21,14 +18,14 @@ export class UserRegistrationEventSchema extends Construct {
   }
 
   private createUserRegistrationEventSchema() {
-    const schemaProps: SchemasSchemaConfig = {
+    const schemaProps: schemasSchema.SchemasSchemaConfig = {
       name: this.userRegistrationEvent,
       description: `emitted when pocket user is registered (e.g signup)`,
       type: SCHEMA_TYPE,
       registryName: SCHEMA_REGISTRY,
       content: JSON.stringify(this.getUserRegistrationPayload()),
     };
-    const schema = new SchemasSchema(
+    const schema = new schemasSchema.SchemasSchema(
       this,
       `${this.userRegistrationEvent}-Schema`,
       schemaProps,

--- a/infrastructure/pocket-event-bridge/src/main.ts
+++ b/infrastructure/pocket-event-bridge/src/main.ts
@@ -5,10 +5,10 @@ import {
   TerraformStack,
   DataTerraformRemoteState,
 } from 'cdktf';
-import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
-import { PagerdutyProvider } from '@cdktf/provider-pagerduty/lib/provider';
-import { LocalProvider } from '@cdktf/provider-local/lib/provider';
-import { NullProvider } from '@cdktf/provider-null/lib/provider';
+import { provider as awsProvider } from '@cdktf/provider-aws';
+import { provider as pagerdutyProvider } from '@cdktf/provider-pagerduty';
+import { provider as localProvider } from '@cdktf/provider-local';
+import { provider as nullProvider } from '@cdktf/provider-null';
 import {
   ApplicationEventBus,
   ApplicationEventBusProps,
@@ -20,7 +20,7 @@ import { ShareableListEvents } from './event-rules/shareable-lists-api-events/sh
 import { ShareableListItemEvents } from './event-rules/shareable-lists-api-events/shareableListItemEventRules';
 import { ListApiEvents } from './event-rules/list-api-events/listApiEventRules';
 import { PocketPagerDuty } from '@pocket-tools/terraform-modules';
-import { ArchiveProvider } from '@cdktf/provider-archive/lib/provider';
+import { provider as archiveProvider } from '@cdktf/provider-archive';
 import { config } from './config';
 import { UserEventsSchema } from './events-schema/userEvents';
 import { AccountDeleteMonitorEvents } from './event-rules/account-delete-monitor';
@@ -38,14 +38,14 @@ class PocketEventBus extends TerraformStack {
   constructor(scope: Construct, name: string) {
     super(scope, name);
 
-    new AwsProvider(this, 'aws', {
+    new awsProvider.AwsProvider(this, 'aws', {
       region: 'us-east-1',
       defaultTags: [{ tags: config.tags }],
     });
-    new PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
-    new LocalProvider(this, 'local_provider');
-    new NullProvider(this, 'null_provider');
-    new ArchiveProvider(this, 'archive_provider');
+    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
+    new localProvider.LocalProvider(this, 'local_provider');
+    new nullProvider.NullProvider(this, 'null_provider');
+    new archiveProvider.ArchiveProvider(this, 'archive_provider');
 
     new S3Backend(this, {
       bucket: `mozilla-pocket-team-${config.environment.toLowerCase()}-terraform-state`,

--- a/infrastructure/sendgrid-data/src/main.ts
+++ b/infrastructure/sendgrid-data/src/main.ts
@@ -7,22 +7,22 @@ import {
 } from 'cdktf';
 import { config } from './config';
 import { PocketPagerDuty, PocketVPC } from '@pocket-tools/terraform-modules';
-import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
-import { PagerdutyProvider } from '@cdktf/provider-pagerduty/lib/provider';
-import { ArchiveProvider } from '@cdktf/provider-archive/lib/provider';
-import { NullProvider } from '@cdktf/provider-null/lib/provider';
-import { LocalProvider } from '@cdktf/provider-local/lib/provider';
+import { provider as awsProvider } from '@cdktf/provider-aws';
+import { provider as pagerdutyProvider } from '@cdktf/provider-pagerduty';
+import { provider as archiveProvider } from '@cdktf/provider-archive';
+import { provider as nullProvider } from '@cdktf/provider-null';
+import { provider as localProvider } from '@cdktf/provider-local';
 import { ApiGateway } from './apiGateway';
 
 class SendgridData extends TerraformStack {
   constructor(scope: Construct, name: string) {
     super(scope, name);
 
-    new AwsProvider(this, 'aws', { region: 'us-east-1' });
-    new PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
-    new ArchiveProvider(this, 'archive-provider');
-    new NullProvider(this, 'null-provider');
-    new LocalProvider(this, 'local-provider');
+    new awsProvider.AwsProvider(this, 'aws', { region: 'us-east-1' });
+    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
+    new archiveProvider.ArchiveProvider(this, 'archive-provider');
+    new nullProvider.NullProvider(this, 'null-provider');
+    new localProvider.LocalProvider(this, 'local-provider');
 
     new S3Backend(this, {
       bucket: `mozilla-pocket-team-${config.environment.toLowerCase()}-terraform-state`,

--- a/infrastructure/sendgrid-data/src/utilities.ts
+++ b/infrastructure/sendgrid-data/src/utilities.ts
@@ -1,15 +1,23 @@
-import { DataAwsSsmParameter } from '@cdktf/provider-aws/lib/data-aws-ssm-parameter';
+import { dataAwsSsmParameter } from '@cdktf/provider-aws';
 import { config } from './config';
 import { Construct } from 'constructs';
 
 export function getEnvVariableValues(scope: Construct) {
-  const sentryDsn = new DataAwsSsmParameter(scope, 'sentry-dsn', {
-    name: `/${config.name}/${config.environment}/SENTRY_DSN`,
-  });
+  const sentryDsn = new dataAwsSsmParameter.DataAwsSsmParameter(
+    scope,
+    'sentry-dsn',
+    {
+      name: `/${config.name}/${config.environment}/SENTRY_DSN`,
+    },
+  );
 
-  const serviceHash = new DataAwsSsmParameter(scope, 'service-hash', {
-    name: `${config.circleCIPrefix}/SERVICE_HASH`,
-  });
+  const serviceHash = new dataAwsSsmParameter.DataAwsSsmParameter(
+    scope,
+    'service-hash',
+    {
+      name: `${config.circleCIPrefix}/SERVICE_HASH`,
+    },
+  );
 
   return { sentryDsn: sentryDsn.value, gitSha: serviceHash.value };
 }

--- a/infrastructure/shareable-lists-api/src/SQSLambda.ts
+++ b/infrastructure/shareable-lists-api/src/SQSLambda.ts
@@ -6,8 +6,7 @@ import {
   PocketVPC,
   PocketSQSWithLambdaTarget,
 } from '@pocket-tools/terraform-modules';
-import { DataAwsRegion } from '@cdktf/provider-aws/lib/data-aws-region';
-import { DataAwsCallerIdentity } from '@cdktf/provider-aws/lib/data-aws-caller-identity';
+import { dataAwsRegion, dataAwsCallerIdentity } from '@cdktf/provider-aws';
 
 export class SQSLambda extends Construct {
   public readonly lambda: PocketSQSWithLambdaTarget;
@@ -16,8 +15,8 @@ export class SQSLambda extends Construct {
     scope: Construct,
     private name: string,
     vpc: PocketVPC,
-    region: DataAwsRegion,
-    caller: DataAwsCallerIdentity,
+    region: dataAwsRegion.DataAwsRegion,
+    caller: dataAwsCallerIdentity.DataAwsCallerIdentity,
     pagerDuty?: PocketPagerDuty,
   ) {
     super(scope, name);

--- a/infrastructure/shared-snowplow-consumer/src/sharedSnowplowConsumerApp.ts
+++ b/infrastructure/shared-snowplow-consumer/src/sharedSnowplowConsumerApp.ts
@@ -3,22 +3,24 @@ import {
   PocketALBApplication,
   PocketPagerDuty,
 } from '@pocket-tools/terraform-modules';
-import { DataAwsCallerIdentity } from '@cdktf/provider-aws/lib/data-aws-caller-identity';
-import { DataAwsKmsAlias } from '@cdktf/provider-aws/lib/data-aws-kms-alias';
-import { DataAwsRegion } from '@cdktf/provider-aws/lib/data-aws-region';
-import { DataAwsSnsTopic } from '@cdktf/provider-aws/lib/data-aws-sns-topic';
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
+import {
+  dataAwsCallerIdentity,
+  dataAwsKmsAlias,
+  dataAwsRegion,
+  dataAwsSnsTopic,
+  sqsQueue,
+  cloudwatchLogGroup,
+} from '@cdktf/provider-aws';
 import { Construct } from 'constructs';
-import { CloudwatchLogGroup } from '@cdktf/provider-aws/lib/cloudwatch-log-group';
 
 export type SharedSnowplowConsumerProps = {
-  caller: DataAwsCallerIdentity;
+  caller: dataAwsCallerIdentity.DataAwsCallerIdentity;
   pagerDuty: PocketPagerDuty;
-  region: DataAwsRegion;
-  secretsManagerKmsAlias: DataAwsKmsAlias;
-  snsTopic: DataAwsSnsTopic;
-  sqsConsumeQueue: SqsQueue;
-  sqsDLQ: SqsQueue;
+  region: dataAwsRegion.DataAwsRegion;
+  secretsManagerKmsAlias: dataAwsKmsAlias.DataAwsKmsAlias;
+  snsTopic: dataAwsSnsTopic.DataAwsSnsTopic;
+  sqsConsumeQueue: sqsQueue.SqsQueue;
+  sqsDLQ: sqsQueue.SqsQueue;
 };
 
 export class SharedSnowplowConsumerApp extends Construct {
@@ -206,7 +208,7 @@ export class SharedSnowplowConsumerApp extends Construct {
    * @private
    */
   private createCustomLogGroup(containerName: string) {
-    const logGroup = new CloudwatchLogGroup(
+    const logGroup = new cloudwatchLogGroup.CloudwatchLogGroup(
       this,
       `${containerName}-log-group`,
       {

--- a/infrastructure/transactional-emails/src/transactionalEmailSQSLambda.ts
+++ b/infrastructure/transactional-emails/src/transactionalEmailSQSLambda.ts
@@ -1,6 +1,6 @@
 import { Construct } from 'constructs';
 import { config } from './config';
-import { DataAwsSsmParameter } from '@cdktf/provider-aws/lib/data-aws-ssm-parameter';
+import { dataAwsSsmParameter } from '@cdktf/provider-aws';
 import {
   PocketVPC,
   PocketSQSWithLambdaTarget,
@@ -82,11 +82,11 @@ export class TransactionalEmailSQSLambda extends Construct {
   }
 
   private getEnvVariableValues() {
-    const sentryDsn = new DataAwsSsmParameter(this, 'sentry-dsn', {
+    const sentryDsn = new dataAwsSsmParameter.DataAwsSsmParameter(this, 'sentry-dsn', {
       name: `/${config.name}/${config.environment}/SENTRY_DSN`,
     });
 
-    const serviceHash = new DataAwsSsmParameter(this, 'service-hash', {
+    const serviceHash = new dataAwsSsmParameter.DataAwsSsmParameter(this, 'service-hash', {
       name: `${config.circleCIPrefix}/SERVICE_HASH`,
     });
 

--- a/infrastructure/user-api/src/main.ts
+++ b/infrastructure/user-api/src/main.ts
@@ -5,32 +5,36 @@ import {
   S3Backend,
   TerraformStack,
 } from 'cdktf';
-import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
-import { CloudwatchLogGroup } from '@cdktf/provider-aws/lib/cloudwatch-log-group';
-import { DataAwsCallerIdentity } from '@cdktf/provider-aws/lib/data-aws-caller-identity';
-import { DataAwsKmsAlias } from '@cdktf/provider-aws/lib/data-aws-kms-alias';
-import { DataAwsRegion } from '@cdktf/provider-aws/lib/data-aws-region';
-import { DataAwsSnsTopic } from '@cdktf/provider-aws/lib/data-aws-sns-topic';
+import {
+  provider as awsProvider,
+  cloudwatchLogGroup,
+  dataAwsCallerIdentity,
+  dataAwsKmsAlias,
+  dataAwsRegion,
+  dataAwsSnsTopic,
+} from '@cdktf/provider-aws';
 import { config } from './config';
 import {
   PocketALBApplication,
   PocketPagerDuty,
   PocketVPC,
 } from '@pocket-tools/terraform-modules';
-import { LocalProvider } from '@cdktf/provider-local/lib/provider';
-import { NullProvider } from '@cdktf/provider-null/lib/provider';
-import { PagerdutyProvider } from '@cdktf/provider-pagerduty/lib/provider';
+import { provider as localProvider } from '@cdktf/provider-local';
+import { provider as nullProvider } from '@cdktf/provider-null';
+import { provider as pagerdutyProvider } from '@cdktf/provider-pagerduty';
 import * as fs from 'fs';
 
 class UserAPI extends TerraformStack {
   constructor(scope: Construct, name: string) {
     super(scope, name);
 
-    new AwsProvider(this, 'aws', { region: 'us-east-1' });
+    new awsProvider.AwsProvider(this, 'aws', { region: 'us-east-1' });
 
-    new PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
-    new LocalProvider(this, 'local_provider');
-    new NullProvider(this, 'null_provider');
+    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', {
+      token: undefined,
+    });
+    new localProvider.LocalProvider(this, 'local_provider');
+    new nullProvider.NullProvider(this, 'null_provider');
 
     new S3Backend(this, {
       bucket: `mozilla-pocket-team-${config.environment.toLowerCase()}-terraform-state`,
@@ -40,8 +44,11 @@ class UserAPI extends TerraformStack {
     });
 
     new PocketVPC(this, 'pocket-vpc');
-    const region = new DataAwsRegion(this, 'region');
-    const caller = new DataAwsCallerIdentity(this, 'caller');
+    const region = new dataAwsRegion.DataAwsRegion(this, 'region');
+    const caller = new dataAwsCallerIdentity.DataAwsCallerIdentity(
+      this,
+      'caller',
+    );
 
     this.createPocketAlbApplication({
       pagerDuty: this.createPagerDuty(),
@@ -57,7 +64,7 @@ class UserAPI extends TerraformStack {
    * @private
    */
   private getCodeDeploySnsTopic() {
-    return new DataAwsSnsTopic(this, 'backend_notifications', {
+    return new dataAwsSnsTopic.DataAwsSnsTopic(this, 'backend_notifications', {
       name: `Backend-${config.environment}-ChatBot`,
     });
   }
@@ -67,7 +74,7 @@ class UserAPI extends TerraformStack {
    * @private
    */
   private getSecretsManagerKmsAlias() {
-    return new DataAwsKmsAlias(this, 'kms_alias', {
+    return new dataAwsKmsAlias.DataAwsKmsAlias(this, 'kms_alias', {
       name: 'alias/aws/secretsmanager',
     });
   }
@@ -103,10 +110,10 @@ class UserAPI extends TerraformStack {
 
   private createPocketAlbApplication(dependencies: {
     pagerDuty: PocketPagerDuty;
-    region: DataAwsRegion;
-    caller: DataAwsCallerIdentity;
-    secretsManagerKmsAlias: DataAwsKmsAlias;
-    snsTopic: DataAwsSnsTopic;
+    region: dataAwsRegion.DataAwsRegion;
+    caller: dataAwsCallerIdentity.DataAwsCallerIdentity;
+    secretsManagerKmsAlias: dataAwsKmsAlias.DataAwsKmsAlias;
+    snsTopic: dataAwsSnsTopic.DataAwsSnsTopic;
   }): PocketALBApplication {
     const { pagerDuty, region, caller, secretsManagerKmsAlias, snsTopic } =
       dependencies;
@@ -359,7 +366,7 @@ class UserAPI extends TerraformStack {
    * @private
    */
   private createCustomLogGroup(containerName: string) {
-    const logGroup = new CloudwatchLogGroup(
+    const logGroup = new cloudwatchLogGroup.CloudwatchLogGroup(
       this,
       `${containerName}-log-group`,
       {

--- a/infrastructure/v3-proxy-api/src/main.ts
+++ b/infrastructure/v3-proxy-api/src/main.ts
@@ -1,12 +1,14 @@
-import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
-import { DataAwsCallerIdentity } from '@cdktf/provider-aws/lib/data-aws-caller-identity';
-import { DataAwsRegion } from '@cdktf/provider-aws/lib/data-aws-region';
-import { DataAwsKmsAlias } from '@cdktf/provider-aws/lib/data-aws-kms-alias';
-import { DataAwsSnsTopic } from '@cdktf/provider-aws/lib/data-aws-sns-topic';
-import { LocalProvider } from '@cdktf/provider-local/lib/provider';
-import { NullProvider } from '@cdktf/provider-null/lib/provider';
-import { PagerdutyProvider } from '@cdktf/provider-pagerduty/lib/provider';
-import { CloudwatchLogGroup } from '@cdktf/provider-aws/lib/cloudwatch-log-group';
+import {
+  provider as awsProvider,
+  dataAwsCallerIdentity,
+  dataAwsRegion,
+  dataAwsKmsAlias,
+  dataAwsSnsTopic,
+  cloudwatchLogGroup,
+} from '@cdktf/provider-aws';
+import { provider as localProvider } from '@cdktf/provider-local';
+import { provider as nullProvider } from '@cdktf/provider-null';
+import { provider as pagerdutyProvider } from '@cdktf/provider-pagerduty';
 import {
   PocketALBApplication,
   PocketPagerDuty,
@@ -20,10 +22,12 @@ class Stack extends TerraformStack {
   constructor(scope: Construct, name: string) {
     super(scope, name);
 
-    new AwsProvider(this, 'aws', { region: 'us-east-1' });
-    new PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
-    new LocalProvider(this, 'local_provider');
-    new NullProvider(this, 'null_provider');
+    new awsProvider.AwsProvider(this, 'aws', { region: 'us-east-1' });
+    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', {
+      token: undefined,
+    });
+    new localProvider.LocalProvider(this, 'local_provider');
+    new nullProvider.NullProvider(this, 'null_provider');
 
     new S3Backend(this, {
       bucket: `mozilla-pocket-team-${config.environment.toLowerCase()}-terraform-state`,
@@ -32,8 +36,11 @@ class Stack extends TerraformStack {
       region: 'us-east-1',
     });
 
-    const region = new DataAwsRegion(this, 'region');
-    const caller = new DataAwsCallerIdentity(this, 'caller');
+    const region = new dataAwsRegion.DataAwsRegion(this, 'region');
+    const caller = new dataAwsCallerIdentity.DataAwsCallerIdentity(
+      this,
+      'caller',
+    );
 
     this.createPocketAlbApplication({
       pagerDuty: this.createPagerDuty(),
@@ -49,7 +56,7 @@ class Stack extends TerraformStack {
    * @private
    */
   private getCodeDeploySnsTopic() {
-    return new DataAwsSnsTopic(this, 'backend_notifications', {
+    return new dataAwsSnsTopic.DataAwsSnsTopic(this, 'backend_notifications', {
       name: `Backend-${config.environment}-ChatBot`,
     });
   }
@@ -59,7 +66,7 @@ class Stack extends TerraformStack {
    * @private
    */
   private getSecretsManagerKmsAlias() {
-    return new DataAwsKmsAlias(this, 'kms_alias', {
+    return new dataAwsKmsAlias.DataAwsKmsAlias(this, 'kms_alias', {
       name: 'alias/aws/secretsmanager',
     });
   }
@@ -81,10 +88,10 @@ class Stack extends TerraformStack {
    */
   private createPocketAlbApplication(dependencies: {
     pagerDuty: PocketPagerDuty;
-    region: DataAwsRegion;
-    caller: DataAwsCallerIdentity;
-    secretsManagerKmsAlias: DataAwsKmsAlias;
-    snsTopic: DataAwsSnsTopic;
+    region: dataAwsRegion.DataAwsRegion;
+    caller: dataAwsCallerIdentity.DataAwsCallerIdentity;
+    secretsManagerKmsAlias: dataAwsKmsAlias.DataAwsKmsAlias;
+    snsTopic: dataAwsSnsTopic.DataAwsSnsTopic;
   }): PocketALBApplication {
     const {
       //  pagerDuty, // enable if necessary
@@ -232,7 +239,7 @@ class Stack extends TerraformStack {
    * @private
    */
   private createCustomLogGroup(containerName: string) {
-    const logGroup = new CloudwatchLogGroup(
+    const logGroup = new cloudwatchLogGroup.CloudwatchLogGroup(
       this,
       `${containerName}-log-group`,
       {

--- a/packages/terraform-modules/src/base/ApplicationAutoscaling.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationAutoscaling.spec.ts
@@ -66,7 +66,7 @@ describe('ApplicationAutoscaling', () => {
     });
   });
 
-  describe('generateCloudwatchMetricAlarm', () => {
+  describe('generatecloudwatchMetricAlarm.CloudwatchMetricAlarm', () => {
     it('renders a scale-in Cloudwatch Alarm', () => {
       const synthed = Testing.synthScope((stack) => {
         const construct = new TestResource(stack, 'test-resource');

--- a/packages/terraform-modules/src/base/ApplicationAutoscaling.ts
+++ b/packages/terraform-modules/src/base/ApplicationAutoscaling.ts
@@ -1,7 +1,9 @@
 import { TerraformMetaArguments } from 'cdktf';
-import { AppautoscalingPolicy } from '@cdktf/provider-aws/lib/appautoscaling-policy';
-import { AppautoscalingTarget } from '@cdktf/provider-aws/lib/appautoscaling-target';
-import { CloudwatchMetricAlarm } from '@cdktf/provider-aws/lib/cloudwatch-metric-alarm';
+import {
+  appautoscalingPolicy,
+  appautoscalingTarget,
+  cloudwatchMetricAlarm,
+} from '@cdktf/provider-aws';
 import { Construct } from 'constructs';
 
 export interface ApplicationAutoscalingProps extends TerraformMetaArguments {
@@ -79,20 +81,24 @@ export class ApplicationAutoscaling extends Construct {
    * Creates an Auto Scaling Target
    * @param resource
    * @param config
-   * @returns AppautoscalingTarget
+   * @returns appautoscalingTarget.AppautoscalingTarget
    */
   static generateAutoScalingTarget(
     scope: Construct,
     config: ApplicationAutoscalingProps,
-  ): AppautoscalingTarget {
-    return new AppautoscalingTarget(scope, `autoscaling_target`, {
-      maxCapacity: config.targetMaxCapacity,
-      minCapacity: config.targetMinCapacity,
-      resourceId: `service/${config.ecsClusterName}/${config.ecsServiceName}`,
-      scalableDimension: 'ecs:service:DesiredCount',
-      serviceNamespace: 'ecs',
-      provider: config.provider,
-    });
+  ): appautoscalingTarget.AppautoscalingTarget {
+    return new appautoscalingTarget.AppautoscalingTarget(
+      scope,
+      `autoscaling_target`,
+      {
+        maxCapacity: config.targetMaxCapacity,
+        minCapacity: config.targetMinCapacity,
+        resourceId: `service/${config.ecsClusterName}/${config.ecsServiceName}`,
+        scalableDimension: 'ecs:service:DesiredCount',
+        serviceNamespace: 'ecs',
+        provider: config.provider,
+      },
+    );
   }
 
   /**
@@ -101,14 +107,14 @@ export class ApplicationAutoscaling extends Construct {
    * @param config
    * @param target
    * @param type
-   * @returns AppautoscalingPolicy
+   * @returns appautoscalingPolicy.AppautoscalingPolicy
    */
   static generateAutoSclaingPolicy(
     scope: Construct,
     config: ApplicationAutoscalingProps,
-    target: AppautoscalingTarget,
+    target: appautoscalingTarget.AppautoscalingTarget,
     type: 'In' | 'Out',
-  ): AppautoscalingPolicy {
+  ): appautoscalingPolicy.AppautoscalingPolicy {
     let stepAdjustment;
 
     if (type === 'In') {
@@ -127,7 +133,7 @@ export class ApplicationAutoscaling extends Construct {
       ];
     }
 
-    const appAutoscaling = new AppautoscalingPolicy(
+    const appAutoscaling = new appautoscalingPolicy.AppautoscalingPolicy(
       scope,
       `scale_${type.toLowerCase()}_policy`,
       {
@@ -179,7 +185,7 @@ export class ApplicationAutoscaling extends Construct {
     threshold: number,
     arn: string,
   ): void {
-    new CloudwatchMetricAlarm(scope, id, {
+    new cloudwatchMetricAlarm.CloudwatchMetricAlarm(scope, id, {
       alarmName: name,
       alarmDescription: desc,
       comparisonOperator: operator,

--- a/packages/terraform-modules/src/base/ApplicationBaseDNS.ts
+++ b/packages/terraform-modules/src/base/ApplicationBaseDNS.ts
@@ -1,9 +1,11 @@
-import { DataAwsRoute53Zone } from '@cdktf/provider-aws/lib/data-aws-route53-zone';
-import { Route53Record } from '@cdktf/provider-aws/lib/route53-record';
-import { Route53Zone } from '@cdktf/provider-aws/lib/route53-zone';
+import {
+  route53Record,
+  route53Zone,
+  dataAwsRoute53Zone,
+} from '@cdktf/provider-aws';
 import { TerraformMetaArguments, TerraformProvider } from 'cdktf';
 import { Construct } from 'constructs';
-import { getRootDomain } from '../utilities.js'
+import { getRootDomain } from '../utilities.js';
 
 export interface RootDNSProps extends TerraformMetaArguments {
   domain: string;
@@ -46,11 +48,15 @@ export class ApplicationBaseDNS extends Construct {
     name: string,
     domain: string,
     provider?: TerraformProvider,
-  ): DataAwsRoute53Zone {
-    return new DataAwsRoute53Zone(scope, `${name}_main_hosted_zone`, {
-      name: getRootDomain(domain),
-      provider: provider,
-    });
+  ): dataAwsRoute53Zone.DataAwsRoute53Zone {
+    return new dataAwsRoute53Zone.DataAwsRoute53Zone(
+      scope,
+      `${name}_main_hosted_zone`,
+      {
+        name: getRootDomain(domain),
+        provider: provider,
+      },
+    );
   }
 
   static generateRoute53Zone(
@@ -58,8 +64,8 @@ export class ApplicationBaseDNS extends Construct {
     domain: string,
     tags?: { [key: string]: string },
     provider?: TerraformProvider,
-  ): Route53Zone {
-    return new Route53Zone(scope, `subhosted_zone`, {
+  ): route53Zone.Route53Zone {
+    return new route53Zone.Route53Zone(scope, `subhosted_zone`, {
       name: domain,
       tags: tags,
       provider: provider,
@@ -73,7 +79,7 @@ export class ApplicationBaseDNS extends Construct {
     records: string[],
     provider?: TerraformProvider,
   ): void {
-    new Route53Record(scope, `subhosted_zone_ns`, {
+    new route53Record.Route53Record(scope, `subhosted_zone_ns`, {
       name,
       type: 'NS',
       ttl: 86400,

--- a/packages/terraform-modules/src/base/ApplicationDynamoDBTable.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationDynamoDBTable.spec.ts
@@ -1,4 +1,4 @@
-import { DynamodbTableGlobalSecondaryIndex } from '@cdktf/provider-aws/lib/dynamodb-table';
+import { dynamodbTable } from '@cdktf/provider-aws';
 import { Testing } from 'cdktf';
 import {
   ApplicationDynamoDBTable,
@@ -117,7 +117,7 @@ describe('ApplicationDynamoDBTable', () => {
 
     (
       BASE_CONFIG.tableConfig
-        .globalSecondaryIndex as DynamodbTableGlobalSecondaryIndex[]
+        .globalSecondaryIndex as dynamodbTable.DynamodbTableGlobalSecondaryIndex[]
     ).push({
       name: 'card-index',
       hashKey: 'card-type',
@@ -149,7 +149,7 @@ describe('ApplicationDynamoDBTable', () => {
     //This test runs after the first secondary index test, so here we just add another index which gives us 2
     (
       BASE_CONFIG.tableConfig
-        .globalSecondaryIndex as DynamodbTableGlobalSecondaryIndex[]
+        .globalSecondaryIndex as dynamodbTable.DynamodbTableGlobalSecondaryIndex[]
     ).push({
       name: 'card-index-2',
       hashKey: 'card-type-123',

--- a/packages/terraform-modules/src/base/ApplicationECR.ts
+++ b/packages/terraform-modules/src/base/ApplicationECR.ts
@@ -1,11 +1,4 @@
-import {
-  EcrLifecyclePolicyConfig,
-  EcrLifecyclePolicy,
-} from '@cdktf/provider-aws/lib/ecr-lifecycle-policy';
-import {
-  EcrRepository,
-  EcrRepositoryConfig,
-} from '@cdktf/provider-aws/lib/ecr-repository';
+import { ecrRepository, ecrLifecyclePolicy } from '@cdktf/provider-aws';
 import { TerraformMetaArguments } from 'cdktf';
 import { Construct } from 'constructs';
 
@@ -15,12 +8,12 @@ export interface ECRProps extends TerraformMetaArguments {
 }
 
 export class ApplicationECR extends Construct {
-  public readonly repo: EcrRepository;
+  public readonly repo: ecrRepository.EcrRepository;
 
   constructor(scope: Construct, name: string, config: ECRProps) {
     super(scope, name);
 
-    const ecrConfig: EcrRepositoryConfig = {
+    const ecrConfig: ecrRepository.EcrRepositoryConfig = {
       name: config.name,
       tags: config.tags,
       imageScanningConfiguration: {
@@ -29,7 +22,7 @@ export class ApplicationECR extends Construct {
       provider: config.provider,
     };
 
-    this.repo = new EcrRepository(this, 'ecr-repo', ecrConfig);
+    this.repo = new ecrRepository.EcrRepository(this, 'ecr-repo', ecrConfig);
 
     // this is our default policy
     // perhaps this should be defined elsewhere? or allow to be overwritten?
@@ -51,13 +44,17 @@ export class ApplicationECR extends Construct {
       ],
     };
 
-    const ecrPolicyConfig: EcrLifecyclePolicyConfig = {
+    const ecrPolicyConfig: ecrLifecyclePolicy.EcrLifecyclePolicyConfig = {
       repository: this.repo.name,
       policy: JSON.stringify(policy),
       dependsOn: [this.repo],
       provider: config.provider,
     };
 
-    new EcrLifecyclePolicy(this, 'ecr-repo-lifecyclepolicy', ecrPolicyConfig);
+    new ecrLifecyclePolicy.EcrLifecyclePolicy(
+      this,
+      'ecr-repo-lifecyclepolicy',
+      ecrPolicyConfig,
+    );
   }
 }

--- a/packages/terraform-modules/src/base/ApplicationECSAlbCodeDeploy.ts
+++ b/packages/terraform-modules/src/base/ApplicationECSAlbCodeDeploy.ts
@@ -1,11 +1,13 @@
-import { CodedeployApp } from '@cdktf/provider-aws/lib/codedeploy-app';
-import { CodedeployDeploymentGroup } from '@cdktf/provider-aws/lib/codedeploy-deployment-group';
-import { CodestarnotificationsNotificationRule } from '@cdktf/provider-aws/lib/codestarnotifications-notification-rule';
-import { DataAwsCallerIdentity } from '@cdktf/provider-aws/lib/data-aws-caller-identity';
-import { DataAwsIamPolicyDocument } from '@cdktf/provider-aws/lib/data-aws-iam-policy-document';
-import { DataAwsRegion } from '@cdktf/provider-aws/lib/data-aws-region';
-import { IamRole } from '@cdktf/provider-aws/lib/iam-role';
-import { IamRolePolicyAttachment } from '@cdktf/provider-aws/lib/iam-role-policy-attachment';
+import {
+  iamRole,
+  iamRolePolicyAttachment,
+  dataAwsIamPolicyDocument,
+  dataAwsRegion,
+  dataAwsCallerIdentity,
+  codestarnotificationsNotificationRule,
+  codedeployApp,
+  codedeployDeploymentGroup,
+} from '@cdktf/provider-aws';
 import { TerraformMetaArguments, TerraformResource } from 'cdktf';
 import { Construct } from 'constructs';
 
@@ -28,8 +30,8 @@ export interface ApplicationECSAlbCodeDeployProps
 }
 
 interface CodeDeployResponse {
-  codeDeployApp: CodedeployApp;
-  ecsCodeDeployRole: IamRole;
+  codeDeployApp: codedeployApp.CodedeployApp;
+  ecsCodeDeployRole: iamRole.IamRole;
 }
 
 /**
@@ -38,8 +40,8 @@ interface CodeDeployResponse {
 export class ApplicationECSAlbCodeDeploy extends Construct {
   private readonly config: ApplicationECSAlbCodeDeployProps;
 
-  public readonly codeDeployApp: CodedeployApp;
-  public readonly codeDeployDeploymentGroup: CodedeployDeploymentGroup;
+  public readonly codeDeployApp: codedeployApp.CodedeployApp;
+  public readonly codeDeployDeploymentGroup: codedeployDeploymentGroup.CodedeployDeploymentGroup;
 
   constructor(
     scope: Construct,
@@ -53,49 +55,50 @@ export class ApplicationECSAlbCodeDeploy extends Construct {
     const { codeDeployApp, ecsCodeDeployRole } = this.setupCodeDeployApp();
     this.codeDeployApp = codeDeployApp;
 
-    this.codeDeployDeploymentGroup = new CodedeployDeploymentGroup(
-      this,
-      `ecs_codedeploy_deployment_group`,
-      {
-        dependsOn: config.dependsOn,
-        appName: codeDeployApp.name,
-        deploymentConfigName: 'CodeDeployDefault.ECSAllAtOnce',
-        deploymentGroupName: `${this.config.prefix}-ECS`,
-        serviceRoleArn: ecsCodeDeployRole.arn,
-        autoRollbackConfiguration: {
-          enabled: true,
-          events: ['DEPLOYMENT_FAILURE'],
-        },
-        blueGreenDeploymentConfig: {
-          deploymentReadyOption: {
-            actionOnTimeout: 'CONTINUE_DEPLOYMENT',
+    this.codeDeployDeploymentGroup =
+      new codedeployDeploymentGroup.CodedeployDeploymentGroup(
+        this,
+        `ecs_codedeploy_deployment_group`,
+        {
+          dependsOn: config.dependsOn,
+          appName: codeDeployApp.name,
+          deploymentConfigName: 'CodeDeployDefault.ECSAllAtOnce',
+          deploymentGroupName: `${this.config.prefix}-ECS`,
+          serviceRoleArn: ecsCodeDeployRole.arn,
+          autoRollbackConfiguration: {
+            enabled: true,
+            events: ['DEPLOYMENT_FAILURE'],
           },
-          terminateBlueInstancesOnDeploymentSuccess: {
-            action: 'TERMINATE',
-            terminationWaitTimeInMinutes:
-              (this.config.successTerminationWaitTimeInMinutes ??= 5),
+          blueGreenDeploymentConfig: {
+            deploymentReadyOption: {
+              actionOnTimeout: 'CONTINUE_DEPLOYMENT',
+            },
+            terminateBlueInstancesOnDeploymentSuccess: {
+              action: 'TERMINATE',
+              terminationWaitTimeInMinutes:
+                (this.config.successTerminationWaitTimeInMinutes ??= 5),
+            },
           },
-        },
-        deploymentStyle: {
-          deploymentOption: 'WITH_TRAFFIC_CONTROL',
-          deploymentType: 'BLUE_GREEN',
-        },
-        ecsService: {
-          clusterName: this.config.clusterName,
-          serviceName: this.config.serviceName,
-        },
-        loadBalancerInfo: {
-          targetGroupPairInfo: {
-            prodTrafficRoute: { listenerArns: [this.config.listenerArn] },
-            targetGroup: this.config.targetGroupNames.map((name) => {
-              return { name };
-            }),
+          deploymentStyle: {
+            deploymentOption: 'WITH_TRAFFIC_CONTROL',
+            deploymentType: 'BLUE_GREEN',
           },
+          ecsService: {
+            clusterName: this.config.clusterName,
+            serviceName: this.config.serviceName,
+          },
+          loadBalancerInfo: {
+            targetGroupPairInfo: {
+              prodTrafficRoute: { listenerArns: [this.config.listenerArn] },
+              targetGroup: this.config.targetGroupNames.map((name) => {
+                return { name };
+              }),
+            },
+          },
+          tags: this.config.tags,
+          provider: this.config.provider,
         },
-        tags: this.config.tags,
-        provider: this.config.provider,
-      },
-    );
+      );
   }
 
   /**
@@ -133,52 +136,68 @@ export class ApplicationECSAlbCodeDeploy extends Construct {
    * @private
    */
   private setupCodeDeployApp(): CodeDeployResponse {
-    const ecsCodeDeployRole = new IamRole(this, 'ecs_code_deploy_role', {
-      name: `${this.config.prefix}-ECSCodeDeployRole`,
-      assumeRolePolicy: new DataAwsIamPolicyDocument(
-        this,
-        `codedeploy_assume_role`,
-        {
-          statement: [
-            {
-              effect: 'Allow',
-              actions: ['sts:AssumeRole'],
-              principals: [
-                {
-                  identifiers: ['codedeploy.amazonaws.com'],
-                  type: 'Service',
-                },
-              ],
-            },
-          ],
-        },
-      ).json,
-      tags: this.config.tags,
-      provider: this.config.provider,
-    });
+    const ecsCodeDeployRole = new iamRole.IamRole(
+      this,
+      'ecs_code_deploy_role',
+      {
+        name: `${this.config.prefix}-ECSCodeDeployRole`,
+        assumeRolePolicy: new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
+          this,
+          `codedeploy_assume_role`,
+          {
+            statement: [
+              {
+                effect: 'Allow',
+                actions: ['sts:AssumeRole'],
+                principals: [
+                  {
+                    identifiers: ['codedeploy.amazonaws.com'],
+                    type: 'Service',
+                  },
+                ],
+              },
+            ],
+          },
+        ).json,
+        tags: this.config.tags,
+        provider: this.config.provider,
+      },
+    );
 
-    new IamRolePolicyAttachment(this, 'ecs_codedeploy_role_attachment', {
-      policyArn: 'arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS',
-      role: ecsCodeDeployRole.name,
-      dependsOn: [ecsCodeDeployRole],
-      provider: this.config.provider,
-    });
+    new iamRolePolicyAttachment.IamRolePolicyAttachment(
+      this,
+      'ecs_codedeploy_role_attachment',
+      {
+        policyArn: 'arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS',
+        role: ecsCodeDeployRole.name,
+        dependsOn: [ecsCodeDeployRole],
+        provider: this.config.provider,
+      },
+    );
 
-    const codeDeployApp = new CodedeployApp(this, 'ecs_code_deploy', {
-      computePlatform: 'ECS',
-      name: `${this.config.prefix}-ECS`,
-      tags: this.config.tags,
-      provider: this.config.provider,
-    });
+    const codeDeployApp = new codedeployApp.CodedeployApp(
+      this,
+      'ecs_code_deploy',
+      {
+        computePlatform: 'ECS',
+        name: `${this.config.prefix}-ECS`,
+        tags: this.config.tags,
+        provider: this.config.provider,
+      },
+    );
 
     if (this.config.snsNotificationTopicArn) {
-      const region = new DataAwsRegion(this, 'current_region', {
+      const region = new dataAwsRegion.DataAwsRegion(this, 'current_region', {
         provider: this.config.provider,
       });
-      const account = new DataAwsCallerIdentity(this, 'current_account', {
-        provider: this.config.provider,
-      });
-      new CodestarnotificationsNotificationRule(
+      const account = new dataAwsCallerIdentity.DataAwsCallerIdentity(
+        this,
+        'current_account',
+        {
+          provider: this.config.provider,
+        },
+      );
+      new codestarnotificationsNotificationRule.CodestarnotificationsNotificationRule(
         this,
         `ecs_codedeploy_notifications`,
         {

--- a/packages/terraform-modules/src/base/ApplicationECSCluster.ts
+++ b/packages/terraform-modules/src/base/ApplicationECSCluster.ts
@@ -1,4 +1,4 @@
-import { EcsCluster } from '@cdktf/provider-aws/lib/ecs-cluster';
+import { ecsCluster } from '@cdktf/provider-aws';
 import { TerraformMetaArguments } from 'cdktf';
 import { Construct } from 'constructs';
 
@@ -11,7 +11,7 @@ export interface ApplicationECSClusterProps extends TerraformMetaArguments {
  * Generates an Application Certificate given a domain name and zoneId
  */
 export class ApplicationECSCluster extends Construct {
-  public readonly cluster: EcsCluster;
+  public readonly cluster: ecsCluster.EcsCluster;
 
   constructor(
     scope: Construct,
@@ -20,7 +20,7 @@ export class ApplicationECSCluster extends Construct {
   ) {
     super(scope, name);
 
-    this.cluster = new EcsCluster(this, `ecs_cluster`, {
+    this.cluster = new ecsCluster.EcsCluster(this, `ecs_cluster`, {
       tags: config.tags,
       name: config.prefix,
       setting: [

--- a/packages/terraform-modules/src/base/ApplicationECSIAM.ts
+++ b/packages/terraform-modules/src/base/ApplicationECSIAM.ts
@@ -1,17 +1,16 @@
 import {
-  DataAwsIamPolicyDocumentStatement,
-  DataAwsIamPolicyDocument,
-} from '@cdktf/provider-aws/lib/data-aws-iam-policy-document';
-import { IamPolicy } from '@cdktf/provider-aws/lib/iam-policy';
-import { IamRole } from '@cdktf/provider-aws/lib/iam-role';
-import { IamRolePolicyAttachment } from '@cdktf/provider-aws/lib/iam-role-policy-attachment';
+  dataAwsIamPolicyDocument,
+  iamPolicy,
+  iamRole,
+  iamRolePolicyAttachment,
+} from '@cdktf/provider-aws';
 import { TerraformMetaArguments } from 'cdktf';
 import { Construct } from 'constructs';
 
 export interface ApplicationECSIAMProps extends TerraformMetaArguments {
   prefix: string;
-  taskExecutionRolePolicyStatements: DataAwsIamPolicyDocumentStatement[];
-  taskRolePolicyStatements: DataAwsIamPolicyDocumentStatement[];
+  taskExecutionRolePolicyStatements: dataAwsIamPolicyDocument.DataAwsIamPolicyDocumentStatement[];
+  taskRolePolicyStatements: dataAwsIamPolicyDocument.DataAwsIamPolicyDocumentStatement[];
   taskExecutionDefaultAttachmentArn?: string;
   tags?: { [key: string]: string };
 }
@@ -19,42 +18,47 @@ export interface ApplicationECSIAMProps extends TerraformMetaArguments {
 export class ApplicationECSIAM extends Construct {
   public readonly taskExecutionRoleArn;
   public readonly taskRoleArn;
-  public readonly taskRole: IamRole;
+  public readonly taskRole: iamRole.IamRole;
 
   constructor(scope: Construct, name: string, config: ApplicationECSIAMProps) {
     super(scope, name);
 
     // does anything here need to be in config?
-    const dataEcsTaskAssume = new DataAwsIamPolicyDocument(
+    const dataEcsTaskAssume =
+      new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
+        this,
+        'ecs-task-assume',
+        {
+          version: '2012-10-17',
+          statement: [
+            {
+              effect: 'Allow',
+              actions: ['sts:AssumeRole'],
+              principals: [
+                {
+                  identifiers: ['ecs-tasks.amazonaws.com'],
+                  type: 'Service',
+                },
+              ],
+            },
+          ],
+          provider: config.provider,
+        },
+      );
+
+    const ecsTaskExecutionRole = new iamRole.IamRole(
       this,
-      'ecs-task-assume',
+      'ecs-execution-role',
       {
-        version: '2012-10-17',
-        statement: [
-          {
-            effect: 'Allow',
-            actions: ['sts:AssumeRole'],
-            principals: [
-              {
-                identifiers: ['ecs-tasks.amazonaws.com'],
-                type: 'Service',
-              },
-            ],
-          },
-        ],
+        assumeRolePolicy: dataEcsTaskAssume.json,
+        name: `${config.prefix}-TaskExecutionRole`,
+        tags: config.tags,
         provider: config.provider,
       },
     );
 
-    const ecsTaskExecutionRole = new IamRole(this, 'ecs-execution-role', {
-      assumeRolePolicy: dataEcsTaskAssume.json,
-      name: `${config.prefix}-TaskExecutionRole`,
-      tags: config.tags,
-      provider: config.provider,
-    });
-
     if (config.taskExecutionDefaultAttachmentArn) {
-      new IamRolePolicyAttachment(
+      new iamRolePolicyAttachment.IamRolePolicyAttachment(
         this,
         'ecs-task-execution-default-attachment',
         {
@@ -66,17 +70,18 @@ export class ApplicationECSIAM extends Construct {
     }
 
     if (config.taskExecutionRolePolicyStatements.length > 0) {
-      const dataEcsTaskExecutionRolePolicy = new DataAwsIamPolicyDocument(
-        this,
-        'data-ecs-task-execution-role-policy',
-        {
-          version: '2012-10-17',
-          statement: config.taskExecutionRolePolicyStatements,
-          provider: config.provider,
-        },
-      );
+      const dataEcsTaskExecutionRolePolicy =
+        new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
+          this,
+          'data-ecs-task-execution-role-policy',
+          {
+            version: '2012-10-17',
+            statement: config.taskExecutionRolePolicyStatements,
+            provider: config.provider,
+          },
+        );
 
-      const ecsTaskExecutionRolePolicy = new IamPolicy(
+      const ecsTaskExecutionRolePolicy = new iamPolicy.IamPolicy(
         this,
         'ecs-task-execution-role-policy',
         {
@@ -87,7 +92,7 @@ export class ApplicationECSIAM extends Construct {
         },
       );
 
-      new IamRolePolicyAttachment(
+      new iamRolePolicyAttachment.IamRolePolicyAttachment(
         this,
         'ecs-task-execution-custom-attachment',
         {
@@ -98,7 +103,7 @@ export class ApplicationECSIAM extends Construct {
       );
     }
 
-    const ecsTaskRole = new IamRole(this, 'ecs-task-role', {
+    const ecsTaskRole = new iamRole.IamRole(this, 'ecs-task-role', {
       assumeRolePolicy: dataEcsTaskAssume.json,
       name: `${config.prefix}-TaskRole`,
       tags: config.tags,
@@ -106,28 +111,37 @@ export class ApplicationECSIAM extends Construct {
     });
 
     if (config.taskRolePolicyStatements.length > 0) {
-      const dataEcsTaskRolePolicy = new DataAwsIamPolicyDocument(
+      const dataEcsTaskRolePolicy =
+        new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
+          this,
+          'data-ecs-task-role-policy',
+          {
+            version: '2012-10-17',
+            statement: config.taskRolePolicyStatements,
+            provider: config.provider,
+          },
+        );
+
+      const ecsTaskRolePolicy = new iamPolicy.IamPolicy(
         this,
-        'data-ecs-task-role-policy',
+        'ecs-task-role-policy',
         {
-          version: '2012-10-17',
-          statement: config.taskRolePolicyStatements,
+          name: `${config.prefix}-TaskRolePolicy`,
+          policy: dataEcsTaskRolePolicy.json,
           provider: config.provider,
+          tags: config.tags,
         },
       );
 
-      const ecsTaskRolePolicy = new IamPolicy(this, 'ecs-task-role-policy', {
-        name: `${config.prefix}-TaskRolePolicy`,
-        policy: dataEcsTaskRolePolicy.json,
-        provider: config.provider,
-        tags: config.tags,
-      });
-
-      new IamRolePolicyAttachment(this, 'ecs-task-custom-attachment', {
-        policyArn: ecsTaskRolePolicy.arn,
-        role: ecsTaskRole.id,
-        provider: config.provider,
-      });
+      new iamRolePolicyAttachment.IamRolePolicyAttachment(
+        this,
+        'ecs-task-custom-attachment',
+        {
+          policyArn: ecsTaskRolePolicy.arn,
+          role: ecsTaskRole.id,
+          provider: config.provider,
+        },
+      );
     }
 
     // make arns available to other modules

--- a/packages/terraform-modules/src/base/ApplicationEventBridgeRule.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationEventBridgeRule.spec.ts
@@ -1,4 +1,4 @@
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
+import { sqsQueue } from '@cdktf/provider-aws';
 import { Testing } from 'cdktf';
 import {
   ApplicationEventBridgeRule,
@@ -23,7 +23,7 @@ describe('AplicationEventBridgeRule', () => {
 
   it('renders an event bridge with sqs target', () => {
     const synthed = Testing.synthScope((stack) => {
-      const appSqs = new SqsQueue(stack, 'test-queue', {
+      const appSqs = new sqsQueue.SqsQueue(stack, 'test-queue', {
         name: 'Test-SQS-Queue',
       });
 
@@ -43,7 +43,7 @@ describe('AplicationEventBridgeRule', () => {
 
   it('renders an event bridge with pre-existing sqs target', () => {
     const synthed = Testing.synthScope((stack) => {
-      const appSqs = new SqsQueue(stack, 'test-queue', {
+      const appSqs = new sqsQueue.SqsQueue(stack, 'test-queue', {
         name: 'Test-SQS-Queue',
       });
 

--- a/packages/terraform-modules/src/base/ApplicationEventBridgeRule.ts
+++ b/packages/terraform-modules/src/base/ApplicationEventBridgeRule.ts
@@ -1,10 +1,9 @@
 import { TerraformMetaArguments, TerraformResource } from 'cdktf';
 import { Construct } from 'constructs';
-import { CloudwatchEventRule } from '@cdktf/provider-aws/lib/cloudwatch-event-rule';
 import {
-  CloudwatchEventTarget,
-  CloudwatchEventTargetConfig,
-} from '@cdktf/provider-aws/lib/cloudwatch-event-target';
+  cloudwatchEventTarget,
+  cloudwatchEventRule,
+} from '@cdktf/provider-aws';
 
 export type Target = {
   arn: string;
@@ -36,7 +35,7 @@ export interface ApplicationEventBridgeRuleProps
 }
 
 export class ApplicationEventBridgeRule extends Construct {
-  public readonly rule: CloudwatchEventRule;
+  public readonly rule: cloudwatchEventRule.CloudwatchEventRule;
 
   constructor(
     scope: Construct,
@@ -54,18 +53,22 @@ export class ApplicationEventBridgeRule extends Construct {
     }
     const eventBus = this.config.eventBusName ?? 'default';
     const { scheduleExpression, eventPattern } = this.config;
-    const rule = new CloudwatchEventRule(this, 'event-bridge-rule', {
-      name: `${this.config.name}-Rule`,
-      description: this.config.description,
-      eventPattern: eventPattern ? JSON.stringify(eventPattern) : undefined,
-      scheduleExpression,
-      eventBusName: eventBus,
-      lifecycle: {
-        preventDestroy: this.config.preventDestroy,
+    const rule = new cloudwatchEventRule.CloudwatchEventRule(
+      this,
+      'event-bridge-rule',
+      {
+        name: `${this.config.name}-Rule`,
+        description: this.config.description,
+        eventPattern: eventPattern ? JSON.stringify(eventPattern) : undefined,
+        scheduleExpression,
+        eventBusName: eventBus,
+        lifecycle: {
+          preventDestroy: this.config.preventDestroy,
+        },
+        tags: this.config.tags,
+        provider: this.config.provider,
       },
-      tags: this.config.tags,
-      provider: this.config.provider,
-    });
+    );
 
     if (this.config.targets) {
       this.config.targets.forEach((t) => {
@@ -89,11 +92,11 @@ export class ApplicationEventBridgeRule extends Construct {
           eventTargetConfig.dependsOn = [t.dependsOn, rule];
         }
 
-        new CloudwatchEventTarget(
+        new cloudwatchEventTarget.CloudwatchEventTarget(
           this,
           `event-bridge-target-${t.targetId}`,
           // yuck!
-          eventTargetConfig as CloudwatchEventTargetConfig,
+          eventTargetConfig as cloudwatchEventTarget.CloudwatchEventTargetConfig,
         );
       });
     }

--- a/packages/terraform-modules/src/base/ApplicationEventBus.ts
+++ b/packages/terraform-modules/src/base/ApplicationEventBus.ts
@@ -1,4 +1,4 @@
-import { CloudwatchEventBus } from '@cdktf/provider-aws/lib/cloudwatch-event-bus';
+import { cloudwatchEventBus } from '@cdktf/provider-aws';
 import { TerraformMetaArguments } from 'cdktf';
 import { Construct } from 'constructs';
 
@@ -8,7 +8,7 @@ export interface ApplicationEventBusProps extends TerraformMetaArguments {
 }
 
 export class ApplicationEventBus extends Construct {
-  public readonly bus: CloudwatchEventBus;
+  public readonly bus: cloudwatchEventBus.CloudwatchEventBus;
 
   constructor(
     scope: Construct,
@@ -20,11 +20,15 @@ export class ApplicationEventBus extends Construct {
     this.bus = this.createCloudWatchEventBus();
   }
 
-  private createCloudWatchEventBus(): CloudwatchEventBus {
-    return new CloudwatchEventBus(this, `event-bus-${this.config.name}`, {
-      name: this.config.name,
-      tags: this.config.tags,
-      provider: this.config.provider,
-    });
+  private createCloudWatchEventBus(): cloudwatchEventBus.CloudwatchEventBus {
+    return new cloudwatchEventBus.CloudwatchEventBus(
+      this,
+      `event-bus-${this.config.name}`,
+      {
+        name: this.config.name,
+        tags: this.config.tags,
+        provider: this.config.provider,
+      },
+    );
   }
 }

--- a/packages/terraform-modules/src/base/ApplicationLambdaSnsTopicSubscription.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationLambdaSnsTopicSubscription.spec.ts
@@ -1,4 +1,4 @@
-import { DataAwsLambdaFunction } from '@cdktf/provider-aws/lib/data-aws-lambda-function';
+import { dataAwsLambdaFunction } from '@cdktf/provider-aws';
 import { Testing } from 'cdktf';
 import { ApplicationLambdaSnsTopicSubscription } from './ApplicationLambdaSnsTopicSubscription.js'
 
@@ -6,7 +6,7 @@ describe('ApplicationSqsSnsTopicSubscription', () => {
   const getConfig = (stack) => ({
     name: 'test-sns-subscription',
     snsTopicArn: 'arn:aws:sns:TopicName',
-    lambda: new DataAwsLambdaFunction(stack, 'lambda', {
+    lambda: new dataAwsLambdaFunction.DataAwsLambdaFunction(stack, 'lambda', {
       functionName: 'test-lambda',
     }),
   });

--- a/packages/terraform-modules/src/base/ApplicationLoadBalancer.ts
+++ b/packages/terraform-modules/src/base/ApplicationLoadBalancer.ts
@@ -1,10 +1,12 @@
-import { Alb, AlbAccessLogs, AlbConfig } from '@cdktf/provider-aws/lib/alb';
-import { DataAwsElbServiceAccount } from '@cdktf/provider-aws/lib/data-aws-elb-service-account';
-import { DataAwsIamPolicyDocument } from '@cdktf/provider-aws/lib/data-aws-iam-policy-document';
-import { DataAwsS3Bucket } from '@cdktf/provider-aws/lib/data-aws-s3-bucket';
-import { S3Bucket } from '@cdktf/provider-aws/lib/s3-bucket';
-import { S3BucketPolicy } from '@cdktf/provider-aws/lib/s3-bucket-policy';
-import { SecurityGroup } from '@cdktf/provider-aws/lib/security-group';
+import {
+  dataAwsIamPolicyDocument,
+  s3Bucket,
+  s3BucketPolicy,
+  securityGroup,
+  alb,
+  dataAwsElbServiceAccount,
+  dataAwsS3Bucket,
+} from '@cdktf/provider-aws';
 import { TerraformMetaArguments, TerraformProvider } from 'cdktf';
 import { Construct } from 'constructs';
 
@@ -41,8 +43,8 @@ export interface ApplicationLoadBalancerProps extends TerraformMetaArguments {
  * Generates an Application Certificate given a domain name and zoneId
  */
 export class ApplicationLoadBalancer extends Construct {
-  public readonly alb: Alb;
-  public readonly securityGroup: SecurityGroup;
+  public readonly alb: alb.Alb;
+  public readonly securityGroup: securityGroup.SecurityGroup;
 
   constructor(
     scope: Construct,
@@ -51,47 +53,51 @@ export class ApplicationLoadBalancer extends Construct {
   ) {
     super(scope, name);
 
-    this.securityGroup = new SecurityGroup(this, `alb_security_group`, {
-      namePrefix: `${config.prefix}-HTTP/S Security Group`,
-      description: 'External security group  (Managed by Terraform)',
-      vpcId: config.vpcId,
-      ingress: [
-        {
-          fromPort: 443,
-          toPort: 443,
-          protocol: 'TCP',
-          cidrBlocks: ['0.0.0.0/0'],
+    this.securityGroup = new securityGroup.SecurityGroup(
+      this,
+      `alb_security_group`,
+      {
+        namePrefix: `${config.prefix}-HTTP/S Security Group`,
+        description: 'External security group  (Managed by Terraform)',
+        vpcId: config.vpcId,
+        ingress: [
+          {
+            fromPort: 443,
+            toPort: 443,
+            protocol: 'TCP',
+            cidrBlocks: ['0.0.0.0/0'],
+          },
+          {
+            fromPort: 80,
+            toPort: 80,
+            protocol: 'TCP',
+            cidrBlocks: ['0.0.0.0/0'],
+          },
+        ],
+        egress: [
+          {
+            fromPort: 0,
+            protocol: '-1',
+            toPort: 0,
+            cidrBlocks: ['0.0.0.0/0'],
+            description: 'required',
+            ipv6CidrBlocks: [],
+            prefixListIds: [],
+            securityGroups: [],
+          },
+        ],
+        tags: {
+          ...config.tags,
+          Name: `${config.prefix}-HTTP/S Security Group`,
         },
-        {
-          fromPort: 80,
-          toPort: 80,
-          protocol: 'TCP',
-          cidrBlocks: ['0.0.0.0/0'],
+        lifecycle: {
+          createBeforeDestroy: true,
         },
-      ],
-      egress: [
-        {
-          fromPort: 0,
-          protocol: '-1',
-          toPort: 0,
-          cidrBlocks: ['0.0.0.0/0'],
-          description: 'required',
-          ipv6CidrBlocks: [],
-          prefixListIds: [],
-          securityGroups: [],
-        },
-      ],
-      tags: {
-        ...config.tags,
-        Name: `${config.prefix}-HTTP/S Security Group`,
+        provider: config.provider,
       },
-      lifecycle: {
-        createBeforeDestroy: true,
-      },
-      provider: config.provider,
-    });
+    );
 
-    let logsConfig: AlbAccessLogs = undefined;
+    let logsConfig: alb.AlbAccessLogs = undefined;
     if (config.accessLogs !== undefined) {
       const defaultPrefix = `server-logs/${config.prefix.toLowerCase()}/alb`;
 
@@ -121,7 +127,7 @@ export class ApplicationLoadBalancer extends Construct {
       };
     }
 
-    const albConfig: AlbConfig = {
+    const albConfig: alb.AlbConfig = {
       namePrefix: config.alb6CharacterPrefix,
       securityGroups: [this.securityGroup.id],
       internal: config.internal !== undefined ? config.internal : false,
@@ -130,7 +136,7 @@ export class ApplicationLoadBalancer extends Construct {
       accessLogs: logsConfig,
       provider: config.provider,
     };
-    this.alb = new Alb(this, `alb`, albConfig);
+    this.alb = new alb.Alb(this, `alb`, albConfig);
   }
 
   /**
@@ -151,25 +157,25 @@ export class ApplicationLoadBalancer extends Construct {
     }
 
     if (config.existingBucket !== undefined) {
-      return new DataAwsS3Bucket(this, 'log-bucket', {
+      return new dataAwsS3Bucket.DataAwsS3Bucket(this, 'log-bucket', {
         bucket: config.existingBucket,
         provider: config.provider,
       }).bucket;
     }
 
-    const s3Bucket = new S3Bucket(this, 'log-bucket', {
+    const s3BucketResource = new s3Bucket.S3Bucket(this, 'log-bucket', {
       bucket: config.bucket,
       provider: config.provider,
       tags: config.tags,
     });
 
-    const albAccountId = new DataAwsElbServiceAccount(
+    const albAccountId = new dataAwsElbServiceAccount.DataAwsElbServiceAccount(
       this,
       'elb-service-account',
       { provider: config.provider },
     ).id;
 
-    const s3IAMDocument = new DataAwsIamPolicyDocument(
+    const s3IAMDocument = new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
       this,
       'iam-log-bucket-policy-document',
       {
@@ -183,19 +189,19 @@ export class ApplicationLoadBalancer extends Construct {
               },
             ],
             actions: ['s3:PutObject'],
-            resources: [`arn:aws:s3:::${s3Bucket.bucket}/*`],
+            resources: [`arn:aws:s3:::${s3BucketResource.bucket}/*`],
           },
         ],
         provider: config.provider,
       },
     );
 
-    new S3BucketPolicy(this, 'log-bucket-policy', {
-      bucket: s3Bucket.bucket,
+    new s3BucketPolicy.S3BucketPolicy(this, 'log-bucket-policy', {
+      bucket: s3BucketResource.bucket,
       policy: s3IAMDocument.json,
       provider: config.provider,
     });
 
-    return s3Bucket.bucket;
+    return s3BucketResource.bucket;
   }
 }

--- a/packages/terraform-modules/src/base/ApplicationMemcache.ts
+++ b/packages/terraform-modules/src/base/ApplicationMemcache.ts
@@ -4,8 +4,7 @@ import {
   ApplicationElasticacheEngine,
 } from './ApplicationElasticacheCluster.js';
 import { Construct } from 'constructs';
-import { DataAwsVpc } from '@cdktf/provider-aws/lib/data-aws-vpc';
-import { ElasticacheCluster } from '@cdktf/provider-aws/lib/elasticache-cluster';
+import { dataAwsVpc, elasticacheCluster } from '@cdktf/provider-aws';
 
 const DEFAULT_CONFIG = {
   node: {
@@ -15,7 +14,7 @@ const DEFAULT_CONFIG = {
 };
 
 export class ApplicationMemcache extends ApplicationElasticacheCluster {
-  public elasticacheCluster: ElasticacheCluster;
+  public elasticacheCluster: elasticacheCluster.ElasticacheCluster;
 
   constructor(
     scope: Construct,
@@ -48,9 +47,9 @@ export class ApplicationMemcache extends ApplicationElasticacheCluster {
    */
   private static createElasticacheCluster(
     scope: Construct,
-    appVpc: DataAwsVpc,
+    appVpc: dataAwsVpc.DataAwsVpc,
     config: ApplicationElasticacheClusterProps,
-  ): ElasticacheCluster {
+  ): elasticacheCluster.ElasticacheCluster {
     const engine = ApplicationElasticacheEngine.MEMCACHED;
     const port = ApplicationElasticacheCluster.getPortForEngine(engine);
 
@@ -63,22 +62,26 @@ export class ApplicationMemcache extends ApplicationElasticacheCluster {
 
     const subnetGroup = ApplicationMemcache.createSubnet(scope, config);
 
-    return new ElasticacheCluster(scope, `elasticache_cluster`, {
-      clusterId: config.prefix.toLowerCase(),
-      engine: engine.toString(),
-      nodeType: config.node.size,
-      numCacheNodes: config.node.count,
-      parameterGroupName:
-        ApplicationMemcache.getParameterGroupForEngine(engine),
-      port: port,
-      engineVersion:
-        ApplicationElasticacheCluster.getEngineVersionForEngine(engine),
-      subnetGroupName: subnetGroup.name,
-      securityGroupIds: [securityGroup.id],
-      tags: config.tags,
-      applyImmediately: true,
-      dependsOn: [subnetGroup, securityGroup],
-      provider: config.provider,
-    });
+    return new elasticacheCluster.ElasticacheCluster(
+      scope,
+      `elasticache_cluster`,
+      {
+        clusterId: config.prefix.toLowerCase(),
+        engine: engine.toString(),
+        nodeType: config.node.size,
+        numCacheNodes: config.node.count,
+        parameterGroupName:
+          ApplicationMemcache.getParameterGroupForEngine(engine),
+        port: port,
+        engineVersion:
+          ApplicationElasticacheCluster.getEngineVersionForEngine(engine),
+        subnetGroupName: subnetGroup.name,
+        securityGroupIds: [securityGroup.id],
+        tags: config.tags,
+        applyImmediately: true,
+        dependsOn: [subnetGroup, securityGroup],
+        provider: config.provider,
+      },
+    );
   }
 }

--- a/packages/terraform-modules/src/base/ApplicationRedis.ts
+++ b/packages/terraform-modules/src/base/ApplicationRedis.ts
@@ -4,8 +4,7 @@ import {
   ApplicationElasticacheEngine,
 } from './ApplicationElasticacheCluster.js';
 import { Construct } from 'constructs';
-import { DataAwsVpc } from '@cdktf/provider-aws/lib/data-aws-vpc';
-import { ElasticacheReplicationGroup } from '@cdktf/provider-aws/lib/elasticache-replication-group';
+import { dataAwsVpc, elasticacheReplicationGroup } from '@cdktf/provider-aws';
 
 const DEFAULT_CONFIG = {
   node: {
@@ -15,7 +14,7 @@ const DEFAULT_CONFIG = {
 };
 
 export class ApplicationRedis extends ApplicationElasticacheCluster {
-  public elasticacheReplicationGroup: ElasticacheReplicationGroup;
+  public elasticacheReplicationGroup: elasticacheReplicationGroup.ElasticacheReplicationGroup;
 
   constructor(
     scope: Construct,
@@ -49,9 +48,9 @@ export class ApplicationRedis extends ApplicationElasticacheCluster {
    */
   private static createElasticacheReplicationCluster(
     scope: Construct,
-    appVpc: DataAwsVpc,
+    appVpc: dataAwsVpc.DataAwsVpc,
     config: ApplicationElasticacheClusterProps,
-  ): ElasticacheReplicationGroup {
+  ): elasticacheReplicationGroup.ElasticacheReplicationGroup {
     const engine = ApplicationElasticacheEngine.REDIS;
     const port = ApplicationElasticacheCluster.getPortForEngine(engine);
 
@@ -64,7 +63,7 @@ export class ApplicationRedis extends ApplicationElasticacheCluster {
 
     const subnetGroup = ApplicationRedis.createSubnet(scope, config);
 
-    return new ElasticacheReplicationGroup(
+    return new elasticacheReplicationGroup.ElasticacheReplicationGroup(
       scope,
       'elasticache_replication_group',
       {

--- a/packages/terraform-modules/src/base/ApplicationSQSQueue.ts
+++ b/packages/terraform-modules/src/base/ApplicationSQSQueue.ts
@@ -1,4 +1,4 @@
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
+import { sqsQueue } from '@cdktf/provider-aws';
 import { TerraformMetaArguments } from 'cdktf';
 import { Construct } from 'constructs';
 
@@ -71,8 +71,8 @@ const validations: {
  * Creates an SQS Queue with a dead letter queue
  */
 export class ApplicationSQSQueue extends Construct {
-  public readonly sqsQueue: SqsQueue;
-  public deadLetterQueue: SqsQueue | undefined;
+  public readonly sqsQueue: sqsQueue.SqsQueue;
+  public deadLetterQueue: sqsQueue.SqsQueue | undefined;
 
   constructor(
     scope: Construct,
@@ -107,7 +107,7 @@ export class ApplicationSQSQueue extends Construct {
   }
 
   private createSQSQueue(config: ApplicationSQSQueueProps) {
-    //Have to use the any type because SqsQueueConfig marks the properties as readonly 🤦🏼‍
+    //Have to use the any type because sqsQueue.SqsQueueConfig marks the properties as readonly 🤦🏼‍
     const sqsConfig: any = {
       name: config.name,
       messageRetentionSeconds: config.messageRetentionSeconds,
@@ -127,7 +127,7 @@ export class ApplicationSQSQueue extends Construct {
       });
     }
 
-    return new SqsQueue(this, `sqs_queue`, sqsConfig);
+    return new sqsQueue.SqsQueue(this, `sqs_queue`, sqsConfig);
   }
 
   /**
@@ -136,7 +136,7 @@ export class ApplicationSQSQueue extends Construct {
    * @private
    */
   private createDeadLetterSQSQueue(config: ApplicationSQSQueueProps) {
-    return new SqsQueue(this, `redrive_sqs_queue`, {
+    return new sqsQueue.SqsQueue(this, `redrive_sqs_queue`, {
       name: `${config.name}-Deadletter`,
       tags: config.tags,
       fifoQueue: false,

--- a/packages/terraform-modules/src/base/ApplicationServerlessRedis.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationServerlessRedis.spec.ts
@@ -4,7 +4,7 @@ import {
   ApplicationServerlessRedis,
   ApplicationServerlessRedisProps,
 } from './ApplicationServerlessRedis';
-import { DataAwsSubnets } from '@cdktf/provider-aws/lib/data-aws-subnets';
+import { dataAwsSubnets } from '@cdktf/provider-aws';
 
 const BASE_CONFIG: ApplicationServerlessRedisProps = {
   allowedIngressSecurityGroupIds: [],
@@ -40,7 +40,7 @@ describe('ApplicationRedis', () => {
       ...BASE_CONFIG,
     };
     const synthed = Testing.synthScope((stack) => {
-      const subnets = new DataAwsSubnets(stack, 'subnets', {});
+      const subnets = new dataAwsSubnets.DataAwsSubnets(stack, 'subnets', {});
 
       new ApplicationServerlessRedis(stack, 'testRedis', {
         ...config,
@@ -55,7 +55,7 @@ describe('ApplicationRedis', () => {
       ...BASE_CONFIG,
     };
     const synthed = Testing.synthScope((stack) => {
-      const subnets = new DataAwsSubnets(stack, 'subnets', {});
+      const subnets = new dataAwsSubnets.DataAwsSubnets(stack, 'subnets', {});
 
       new ApplicationServerlessRedis(stack, 'testRedis', {
         ...config,

--- a/packages/terraform-modules/src/base/ApplicationServerlessRedis.ts
+++ b/packages/terraform-modules/src/base/ApplicationServerlessRedis.ts
@@ -5,20 +5,19 @@ import {
 } from './ApplicationElasticacheCluster.js';
 import { Construct } from 'constructs';
 import { Fn } from 'cdktf';
-import { DataAwsVpc } from '@cdktf/provider-aws/lib/data-aws-vpc';
-import {
-  ElasticacheServerlessCache,
-  ElasticacheServerlessCacheConfig,
-} from '@cdktf/provider-aws/lib/elasticache-serverless-cache';
+import { dataAwsVpc, elasticacheServerlessCache } from '@cdktf/provider-aws';
 
 export type ApplicationServerlessRedisProps = Omit<
   ApplicationElasticacheClusterProps,
   'node' | 'overrideEngineVersion'
 > &
-  Pick<ElasticacheServerlessCacheConfig, 'cacheUsageLimits'>;
+  Pick<
+    elasticacheServerlessCache.ElasticacheServerlessCacheConfig,
+    'cacheUsageLimits'
+  >;
 
 export class ApplicationServerlessRedis extends ApplicationElasticacheCluster {
-  public elasticache: ElasticacheServerlessCache;
+  public elasticache: elasticacheServerlessCache.ElasticacheServerlessCache;
 
   constructor(
     scope: Construct,
@@ -44,9 +43,9 @@ export class ApplicationServerlessRedis extends ApplicationElasticacheCluster {
    */
   private static createElasticacheServerless(
     scope: Construct,
-    appVpc: DataAwsVpc,
+    appVpc: dataAwsVpc.DataAwsVpc,
     config: ApplicationServerlessRedisProps,
-  ): ElasticacheServerlessCache {
+  ): elasticacheServerlessCache.ElasticacheServerlessCache {
     const engine = ApplicationElasticacheEngine.REDIS;
     const port = ApplicationElasticacheCluster.getPortForEngine(engine);
 
@@ -57,18 +56,22 @@ export class ApplicationServerlessRedis extends ApplicationElasticacheCluster {
       port,
     );
 
-    return new ElasticacheServerlessCache(scope, 'elasticache_serverless', {
-      engine: engine,
-      name: config.prefix.toLowerCase(),
-      description: `Redis for ${config.prefix}`,
-      provider: config.provider,
-      securityGroupIds: [securityGroup.id],
-      cacheUsageLimits: config.cacheUsageLimits,
-      // SubnetIds comes usually from PocketVPC, it is declared as a string[] but in reality its a special terraform value determined at runtime.
-      // So we need to use a terraform function to splice the array, because Serverless redis only lets us use 2-3 subnets.
-      // In the future we should see if there is a way to fix the CDKTF type in terrraform modules so that developers are not tricked by string[] on subnetIds on pocketvpc.
-      subnetIds: Fn.slice(config.subnetIds, 0, 3),
-      tags: config.tags,
-    });
+    return new elasticacheServerlessCache.ElasticacheServerlessCache(
+      scope,
+      'elasticache_serverless',
+      {
+        engine: engine,
+        name: config.prefix.toLowerCase(),
+        description: `Redis for ${config.prefix}`,
+        provider: config.provider,
+        securityGroupIds: [securityGroup.id],
+        cacheUsageLimits: config.cacheUsageLimits,
+        // SubnetIds comes usually from PocketVPC, it is declared as a string[] but in reality its a special terraform value determined at runtime.
+        // So we need to use a terraform function to splice the array, because Serverless redis only lets us use 2-3 subnets.
+        // In the future we should see if there is a way to fix the CDKTF type in terrraform modules so that developers are not tricked by string[] on subnetIds on pocketvpc.
+        subnetIds: Fn.slice(config.subnetIds, 0, 3),
+        tags: config.tags,
+      },
+    );
   }
 }

--- a/packages/terraform-modules/src/base/ApplicationSqsSnsTopicSubscription.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationSqsSnsTopicSubscription.spec.ts
@@ -1,4 +1,4 @@
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
+import { sqsQueue } from '@cdktf/provider-aws';
 import { Testing } from 'cdktf';
 import { ApplicationSqsSnsTopicSubscription } from './ApplicationSqsSnsTopicSubscription.js'
 
@@ -6,7 +6,7 @@ describe('ApplicationSqsSnsTopicSubscription', () => {
   const getConfig = (stack) => ({
     name: 'test-sns-subscription',
     snsTopicArn: 'arn:aws:sns:TopicName',
-    sqsQueue: new SqsQueue(stack, 'sqs', {
+    sqsQueue: new sqsQueue.SqsQueue(stack, 'sqs', {
       name: 'test-sqs',
     }),
   });
@@ -14,10 +14,10 @@ describe('ApplicationSqsSnsTopicSubscription', () => {
   const getConfigWithDlq = (stack) => ({
     name: 'test-sns-subscription',
     snsTopicArn: 'arn:aws:sns:TopicName',
-    sqsQueue: new SqsQueue(stack, 'sqs', {
+    sqsQueue: new sqsQueue.SqsQueue(stack, 'sqs', {
       name: 'test-sqs',
     }),
-    snsDlq: new SqsQueue(stack, 'dlq', {
+    snsDlq: new sqsQueue.SqsQueue(stack, 'dlq', {
       name: 'test-sqs-dlq',
     }),
   });

--- a/packages/terraform-modules/src/base/ApplicationTargetGroup.ts
+++ b/packages/terraform-modules/src/base/ApplicationTargetGroup.ts
@@ -1,4 +1,4 @@
-import { AlbTargetGroup } from '@cdktf/provider-aws/lib/alb-target-group';
+import { albTargetGroup } from '@cdktf/provider-aws';
 import { TerraformMetaArguments } from 'cdktf';
 import { Construct } from 'constructs';
 
@@ -10,7 +10,7 @@ export interface ApplicationTargetGroupProps extends TerraformMetaArguments {
 }
 
 export class ApplicationTargetGroup extends Construct {
-  public readonly targetGroup: AlbTargetGroup;
+  public readonly targetGroup: albTargetGroup.AlbTargetGroup;
 
   constructor(
     scope: Construct,
@@ -19,22 +19,26 @@ export class ApplicationTargetGroup extends Construct {
   ) {
     super(scope, name);
 
-    this.targetGroup = new AlbTargetGroup(this, 'ecs_target_group', {
-      namePrefix: config.shortName,
-      protocol: 'HTTP',
-      vpcId: config.vpcId,
-      tags: config.tags,
-      targetType: 'ip',
-      port: 80,
-      deregistrationDelay: '120',
-      healthCheck: {
-        interval: 15,
-        path: config.healthCheckPath,
+    this.targetGroup = new albTargetGroup.AlbTargetGroup(
+      this,
+      'ecs_target_group',
+      {
+        namePrefix: config.shortName,
         protocol: 'HTTP',
-        healthyThreshold: 5,
-        unhealthyThreshold: 3,
+        vpcId: config.vpcId,
+        tags: config.tags,
+        targetType: 'ip',
+        port: 80,
+        deregistrationDelay: '120',
+        healthCheck: {
+          interval: 15,
+          path: config.healthCheckPath,
+          protocol: 'HTTP',
+          healthyThreshold: 5,
+          unhealthyThreshold: 3,
+        },
+        provider: config.provider,
       },
-      provider: config.provider,
-    });
+    );
   }
 }

--- a/packages/terraform-modules/src/base/__snapshots__/ApplicationAutoscaling.spec.ts.snap
+++ b/packages/terraform-modules/src/base/__snapshots__/ApplicationAutoscaling.spec.ts.snap
@@ -198,7 +198,7 @@ exports[`ApplicationAutoscaling generateAutoScalingTarget renders an Autoscaling
 }"
 `;
 
-exports[`ApplicationAutoscaling generateCloudwatchMetricAlarm renders a scale-in Cloudwatch Alarm 1`] = `
+exports[`ApplicationAutoscaling generatecloudwatchMetricAlarm.CloudwatchMetricAlarm renders a scale-in Cloudwatch Alarm 1`] = `
 "{
   "resource": {
     "aws_appautoscaling_policy": {
@@ -259,7 +259,7 @@ exports[`ApplicationAutoscaling generateCloudwatchMetricAlarm renders a scale-in
 }"
 `;
 
-exports[`ApplicationAutoscaling generateCloudwatchMetricAlarm renders a scale-out Cloudwatch Alarm 1`] = `
+exports[`ApplicationAutoscaling generatecloudwatchMetricAlarm.CloudwatchMetricAlarm renders a scale-out Cloudwatch Alarm 1`] = `
 "{
   "resource": {
     "aws_appautoscaling_policy": {

--- a/packages/terraform-modules/src/example.ts
+++ b/packages/terraform-modules/src/example.ts
@@ -1,14 +1,13 @@
 import { Construct } from 'constructs';
 import { App, TerraformStack } from 'cdktf';
-import { provider as awsProvider } from '@cdktf/provider-aws';
-import { PocketALBApplication } from './pocket/PocketALBApplication.js'
-import { ApplicationECSContainerDefinitionProps } from './base/ApplicationECSContainerDefinition.js'
+import { provider as awsProvider, wafv2WebAcl } from '@cdktf/provider-aws';
+import { PocketALBApplication } from './pocket/PocketALBApplication.js';
+import { ApplicationECSContainerDefinitionProps } from './base/ApplicationECSContainerDefinition.js';
 import { provider as localProvider } from '@cdktf/provider-local';
 import { provider as nullProvider } from '@cdktf/provider-null';
 import { provider as timeProvider } from '@cdktf/provider-time';
-import { Wafv2WebAcl } from '@cdktf/provider-aws/lib/wafv2-web-acl';
-import { PocketAwsSyntheticChecks } from './pocket/PocketCloudwatchSynthetics.js'
-import { PocketVPC } from './pocket/PocketVPC.js'
+import { PocketAwsSyntheticChecks } from './pocket/PocketCloudwatchSynthetics.js';
+import { PocketVPC } from './pocket/PocketVPC.js';
 
 class Example extends TerraformStack {
   constructor(scope: Construct, name: string) {
@@ -59,7 +58,7 @@ class Example extends TerraformStack {
       ],
     };
 
-    const wafAcl = new Wafv2WebAcl(this, 'example_waf_acl', {
+    const wafAcl = new wafv2WebAcl.Wafv2WebAcl(this, 'example_waf_acl', {
       description: 'Example Pocket Waf ACL',
       name: 'pocket-example-waf',
       scope: 'REGIONAL',

--- a/packages/terraform-modules/src/example.ts
+++ b/packages/terraform-modules/src/example.ts
@@ -1,11 +1,11 @@
 import { Construct } from 'constructs';
 import { App, TerraformStack } from 'cdktf';
-import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
+import { provider as awsProvider } from '@cdktf/provider-aws';
 import { PocketALBApplication } from './pocket/PocketALBApplication.js'
 import { ApplicationECSContainerDefinitionProps } from './base/ApplicationECSContainerDefinition.js'
-import { LocalProvider } from '@cdktf/provider-local/lib/provider';
-import { NullProvider } from '@cdktf/provider-null/lib/provider';
-import { TimeProvider } from '@cdktf/provider-time/lib/provider';
+import { provider as localProvider } from '@cdktf/provider-local';
+import { provider as nullProvider } from '@cdktf/provider-null';
+import { provider as timeProvider } from '@cdktf/provider-time';
 import { Wafv2WebAcl } from '@cdktf/provider-aws/lib/wafv2-web-acl';
 import { PocketAwsSyntheticChecks } from './pocket/PocketCloudwatchSynthetics.js'
 import { PocketVPC } from './pocket/PocketVPC.js'
@@ -14,12 +14,12 @@ class Example extends TerraformStack {
   constructor(scope: Construct, name: string) {
     super(scope, name);
 
-    new AwsProvider(this, 'aws', {
+    new awsProvider.AwsProvider(this, 'aws', {
       region: 'us-east-1',
     });
-    new LocalProvider(this, 'local', {});
-    new NullProvider(this, 'null', {});
-    new TimeProvider(this, 'timeProvider', {});
+    new localProvider.LocalProvider(this, 'local', {});
+    new nullProvider.NullProvider(this, 'null', {});
+    new timeProvider.TimeProvider(this, 'timeProvider', {});
 
     const pocketVpc = new PocketVPC(this, 'pocket-vpc');
 

--- a/packages/terraform-modules/src/pocket/PocketApiGatewayLambdaIntegration.ts
+++ b/packages/terraform-modules/src/pocket/PocketApiGatewayLambdaIntegration.ts
@@ -7,19 +7,18 @@ import {
   ApplicationCertificate,
 } from '../index.js';
 import { Fn, TerraformMetaArguments } from 'cdktf';
-import { ApiGatewayBasePathMapping } from '@cdktf/provider-aws/lib/api-gateway-base-path-mapping';
 import {
-  ApiGatewayDeploymentConfig,
-  ApiGatewayDeployment,
-} from '@cdktf/provider-aws/lib/api-gateway-deployment';
-import { ApiGatewayDomainName } from '@cdktf/provider-aws/lib/api-gateway-domain-name';
-import { ApiGatewayIntegration } from '@cdktf/provider-aws/lib/api-gateway-integration';
-import { ApiGatewayMethod } from '@cdktf/provider-aws/lib/api-gateway-method';
-import { ApiGatewayResource } from '@cdktf/provider-aws/lib/api-gateway-resource';
-import { ApiGatewayRestApi } from '@cdktf/provider-aws/lib/api-gateway-rest-api';
-import { ApiGatewayStage } from '@cdktf/provider-aws/lib/api-gateway-stage';
-import { LambdaPermission } from '@cdktf/provider-aws/lib/lambda-permission';
-import { Route53Record } from '@cdktf/provider-aws/lib/route53-record';
+  lambdaPermission,
+  route53Record,
+  apiGatewayStage,
+  apiGatewayRestApi,
+  apiGatewayResource,
+  apiGatewayMethod,
+  apiGatewayIntegration,
+  apiGatewayDomainName,
+  apiGatewayDeployment,
+  apiGatewayBasePathMapping,
+} from '@cdktf/provider-aws';
 
 export interface ApiGatewayLambdaRoute {
   path: string;
@@ -38,16 +37,16 @@ export interface PocketApiGatewayProps extends TerraformMetaArguments {
   routes: ApiGatewayLambdaRoute[];
   tags?: { [key: string]: string };
   // Should not contain lists/arrays, should only contain objects
-  triggers?: ApiGatewayDeploymentConfig['triggers'];
+  triggers?: apiGatewayDeployment.ApiGatewayDeploymentConfig['triggers'];
   domain?: string;
   basePath?: string;
 }
 
 interface InitializedGatewayRoute {
   lambda: PocketVersionedLambda;
-  resource: ApiGatewayResource;
-  method: ApiGatewayMethod;
-  integration: ApiGatewayIntegration;
+  resource: apiGatewayResource.ApiGatewayResource;
+  method: apiGatewayMethod.ApiGatewayMethod;
+  integration: apiGatewayIntegration.ApiGatewayIntegration;
 }
 
 /**
@@ -55,10 +54,10 @@ interface InitializedGatewayRoute {
  * to a custom domain owned by the account.
  */
 export class PocketApiGateway extends Construct {
-  private apiGatewayRestApi: ApiGatewayRestApi;
+  private apiGatewayRestApi: apiGatewayRestApi.ApiGatewayRestApi;
   private routes: InitializedGatewayRoute[];
-  private apiGatewayDeployment: ApiGatewayDeployment;
-  private apiGatewayStage: ApiGatewayStage;
+  private apiGatewayDeployment: apiGatewayDeployment.ApiGatewayDeployment;
+  private apiGatewayStage: apiGatewayStage.ApiGatewayStage;
 
   constructor(
     scope: Construct,
@@ -66,11 +65,15 @@ export class PocketApiGateway extends Construct {
     private readonly config: PocketApiGatewayProps,
   ) {
     super(scope, name);
-    this.apiGatewayRestApi = new ApiGatewayRestApi(scope, `api-gateway-rest`, {
-      name: config.name,
-      tags: config.tags,
-      provider: config.provider,
-    });
+    this.apiGatewayRestApi = new apiGatewayRestApi.ApiGatewayRestApi(
+      scope,
+      `api-gateway-rest`,
+      {
+        name: config.name,
+        tags: config.tags,
+        provider: config.provider,
+      },
+    );
 
     // https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_deployment
     this.routes = this.createLambdaIntegrations(config);
@@ -86,7 +89,7 @@ export class PocketApiGateway extends Construct {
     const triggers = config.triggers ?? { deployedAt: Date.now().toString() };
 
     // Deployment before adding permissions, so we can restrict to the stage
-    this.apiGatewayDeployment = new ApiGatewayDeployment(
+    this.apiGatewayDeployment = new apiGatewayDeployment.ApiGatewayDeployment(
       scope,
       'api-gateway-deployment',
       {
@@ -104,13 +107,17 @@ export class PocketApiGateway extends Construct {
         provider: config.provider,
       },
     );
-    this.apiGatewayStage = new ApiGatewayStage(scope, 'api-gateway-stage', {
-      deploymentId: this.apiGatewayDeployment.id,
-      restApiId: this.apiGatewayRestApi.id,
-      stageName: config.stage,
-      provider: config.provider,
-      tags: config.tags,
-    });
+    this.apiGatewayStage = new apiGatewayStage.ApiGatewayStage(
+      scope,
+      'api-gateway-stage',
+      {
+        deploymentId: this.apiGatewayDeployment.id,
+        restApiId: this.apiGatewayRestApi.id,
+        stageName: config.stage,
+        provider: config.provider,
+        tags: config.tags,
+      },
+    );
     if (config.domain != null) {
       this.createRoute53Record(config);
     }
@@ -143,7 +150,7 @@ export class PocketApiGateway extends Construct {
     );
 
     //setup custom domain name for API gateway
-    const customDomainName = new ApiGatewayDomainName(
+    const customDomainName = new apiGatewayDomainName.ApiGatewayDomainName(
       this,
       `api-gateway-domain-name`,
       {
@@ -155,7 +162,7 @@ export class PocketApiGateway extends Construct {
       },
     );
 
-    new Route53Record(this, `apigateway-route53-domain-record`, {
+    new route53Record.Route53Record(this, `apigateway-route53-domain-record`, {
       name: customDomainName.domainName,
       type: 'A',
       zoneId: baseDNS.zoneId,
@@ -168,13 +175,17 @@ export class PocketApiGateway extends Construct {
       provider: config.provider,
     });
 
-    new ApiGatewayBasePathMapping(this, `api-gateway-base-path-mapping`, {
-      apiId: this.apiGatewayRestApi.id,
-      stageName: this.apiGatewayStage.stageName,
-      domainName: customDomainName.domainName,
-      basePath: config.basePath ?? '',
-      provider: config.provider,
-    });
+    new apiGatewayBasePathMapping.ApiGatewayBasePathMapping(
+      this,
+      `api-gateway-base-path-mapping`,
+      {
+        apiId: this.apiGatewayRestApi.id,
+        stageName: this.apiGatewayStage.stageName,
+        domainName: customDomainName.domainName,
+        basePath: config.basePath ?? '',
+        provider: config.provider,
+      },
+    );
   }
 
   /**
@@ -183,7 +194,7 @@ export class PocketApiGateway extends Construct {
   private addInvokePermissions() {
     this.routes.map(({ lambda, resource, method }) => {
       const friendlyUniqueId = lambda.lambda.versionedLambda.friendlyUniqueId;
-      new LambdaPermission(
+      new lambdaPermission.LambdaPermission(
         this,
         `${friendlyUniqueId}-allow-gateway-lambda-invoke`,
         {
@@ -212,21 +223,29 @@ export class PocketApiGateway extends Construct {
         `${route.path}-lambda`,
         route.eventHandler,
       );
-      const resource = new ApiGatewayResource(this, route.path, {
-        parentId: this.apiGatewayRestApi.rootResourceId,
-        pathPart: route.path,
-        restApiId: this.apiGatewayRestApi.id,
-        provider: config.provider,
-      });
-      const method = new ApiGatewayMethod(this, `${route.path}-method`, {
-        restApiId: this.apiGatewayRestApi.id,
-        resourceId: resource.id,
-        // authorization: route.authorizationType,
-        authorization: 'NONE',
-        httpMethod: route.method,
-        provider: config.provider,
-      });
-      const integration = new ApiGatewayIntegration(
+      const resource = new apiGatewayResource.ApiGatewayResource(
+        this,
+        route.path,
+        {
+          parentId: this.apiGatewayRestApi.rootResourceId,
+          pathPart: route.path,
+          restApiId: this.apiGatewayRestApi.id,
+          provider: config.provider,
+        },
+      );
+      const method = new apiGatewayMethod.ApiGatewayMethod(
+        this,
+        `${route.path}-method`,
+        {
+          restApiId: this.apiGatewayRestApi.id,
+          resourceId: resource.id,
+          // authorization: route.authorizationType,
+          authorization: 'NONE',
+          httpMethod: route.method,
+          provider: config.provider,
+        },
+      );
+      const integration = new apiGatewayIntegration.ApiGatewayIntegration(
         this,
         `${route.path}-integration`,
         {

--- a/packages/terraform-modules/src/pocket/PocketEventBridgeRuleWithMultipleTargets.spec.ts
+++ b/packages/terraform-modules/src/pocket/PocketEventBridgeRuleWithMultipleTargets.spec.ts
@@ -8,7 +8,7 @@ import {
   PocketVersionedLambdaProps,
 } from './PocketVersionedLambda';
 import { LAMBDA_RUNTIMES } from '../base/ApplicationVersionedLambda.js'
-import { SqsQueue } from '@cdktf/provider-aws/lib/sqs-queue';
+import { sqsQueue } from '@cdktf/provider-aws';
 
 describe('PocketEventBridgeRuleWithMultipleTargets', () => {
   test('renders an event bridge and multiple targets', () => {
@@ -26,7 +26,7 @@ describe('PocketEventBridgeRuleWithMultipleTargets', () => {
         lambdaConfig,
       );
 
-      const testSqs = new SqsQueue(stack, 'test-queue', {
+      const testSqs = new sqsQueue.SqsQueue(stack, 'test-queue', {
         name: 'Test-SQS-Queue',
       });
 

--- a/packages/terraform-modules/src/pocket/PocketEventBridgeWithLambdaTarget.ts
+++ b/packages/terraform-modules/src/pocket/PocketEventBridgeWithLambdaTarget.ts
@@ -1,4 +1,4 @@
-import { LambdaPermission } from '@cdktf/provider-aws/lib/lambda-permission';
+import { lambdaPermission } from '@cdktf/provider-aws';
 import { Construct } from 'constructs';
 import {
   ApplicationEventBridgeRule,
@@ -45,7 +45,7 @@ export class PocketEventBridgeWithLambdaTarget extends PocketVersionedLambda {
     eventBridgeRule: ApplicationEventBridgeRule,
   ): void {
     targetLambdas.forEach((lambda) => {
-      new LambdaPermission(this, 'lambda-permission', {
+      new lambdaPermission.LambdaPermission(this, 'lambda-permission', {
         action: 'lambda:InvokeFunction',
         functionName: lambda.versionedLambda.functionName,
         qualifier: lambda.versionedLambda.name,

--- a/packages/terraform-modules/src/pocket/PocketSynthetics.ts
+++ b/packages/terraform-modules/src/pocket/PocketSynthetics.ts
@@ -1,5 +1,7 @@
-import { NrqlAlertCondition } from '@cdktf/provider-newrelic/lib/nrql-alert-condition';
-import { SyntheticsMonitor } from '@cdktf/provider-newrelic/lib/synthetics-monitor';
+import {
+  nrqlAlertCondition,
+  syntheticsMonitor,
+} from '@cdktf/provider-newrelic';
 import { Construct } from 'constructs';
 
 export interface PocketSyntheticProps {
@@ -47,7 +49,7 @@ export class PocketSyntheticCheck extends Construct {
       this.config.policyId = 1707149; // Pocket-Default-Policy
     }
 
-    const pocketMonitor = new SyntheticsMonitor(
+    const pocketMonitor = new syntheticsMonitor.SyntheticsMonitor(
       this,
       `${this.name}-synthetics-monitor`,
       {
@@ -83,7 +85,7 @@ export class PocketSyntheticCheck extends Construct {
       ...config.nrqlConfig,
     };
 
-    new NrqlAlertCondition(this, 'alert-condition', {
+    new nrqlAlertCondition.NrqlAlertCondition(this, 'alert-condition', {
       name: `${this.name}-nrql`,
       policyId: this.config.policyId,
       fillValue: 0,

--- a/packages/terraform-modules/src/pocket/PocketVPC.spec.ts
+++ b/packages/terraform-modules/src/pocket/PocketVPC.spec.ts
@@ -1,7 +1,7 @@
 import { Testing } from 'cdktf';
 import { PocketVPC } from './PocketVPC.js';
 import 'cdktf/lib/testing/adapters/jest';
-import { DataAwsVpc } from '@cdktf/provider-aws/lib/data-aws-vpc';
+import { dataAwsVpc } from '@cdktf/provider-aws';
 
 test('renders a VPC with minimal config', () => {
   const synthed = Testing.synthScope((stack) => {
@@ -9,5 +9,5 @@ test('renders a VPC with minimal config', () => {
   });
 
   expect(synthed).toMatchSnapshot();
-  expect(synthed).toHaveDataSource(DataAwsVpc);
+  expect(synthed).toHaveDataSource(dataAwsVpc.DataAwsVpc);
 });

--- a/packages/terraform-modules/src/pocket/PocketVPC.ts
+++ b/packages/terraform-modules/src/pocket/PocketVPC.ts
@@ -1,34 +1,44 @@
-import { DataAwsCallerIdentity } from '@cdktf/provider-aws/lib/data-aws-caller-identity';
-import { DataAwsKmsAlias } from '@cdktf/provider-aws/lib/data-aws-kms-alias';
-import { DataAwsRegion } from '@cdktf/provider-aws/lib/data-aws-region';
-import { DataAwsSecurityGroups } from '@cdktf/provider-aws/lib/data-aws-security-groups';
-import { DataAwsSsmParameter } from '@cdktf/provider-aws/lib/data-aws-ssm-parameter';
-import { DataAwsSubnets } from '@cdktf/provider-aws/lib/data-aws-subnets';
-import { DataAwsVpc } from '@cdktf/provider-aws/lib/data-aws-vpc';
-import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
+import {
+  provider as awsProvider,
+  dataAwsRegion,
+  dataAwsVpc,
+  dataAwsKmsAlias,
+  dataAwsCallerIdentity,
+  dataAwsSsmParameter,
+  dataAwsSubnets,
+  dataAwsSecurityGroups,
+} from '@cdktf/provider-aws';
 import { Fn } from 'cdktf';
 import { Construct } from 'constructs';
 
 export class PocketVPC extends Construct {
-  public readonly vpc: DataAwsVpc;
+  public readonly vpc: dataAwsVpc.DataAwsVpc;
 
   public readonly region: string;
   public readonly accountId: string;
   public readonly privateSubnetIds: string[];
   public readonly publicSubnetIds: string[];
-  public readonly secretsManagerSecretKey: DataAwsKmsAlias;
-  public readonly defaultSecurityGroups: DataAwsSecurityGroups;
-  public readonly internalSecurityGroups: DataAwsSecurityGroups;
+  public readonly secretsManagerSecretKey: dataAwsKmsAlias.DataAwsKmsAlias;
+  public readonly defaultSecurityGroups: dataAwsSecurityGroups.DataAwsSecurityGroups;
+  public readonly internalSecurityGroups: dataAwsSecurityGroups.DataAwsSecurityGroups;
 
-  constructor(scope: Construct, name: string, provider?: AwsProvider) {
+  constructor(
+    scope: Construct,
+    name: string,
+    provider?: awsProvider.AwsProvider,
+  ) {
     super(scope, name);
 
-    const vpcSSMParam = new DataAwsSsmParameter(this, `vpc_ssm_param`, {
-      provider: provider,
-      name: '/Shared/Vpc',
-    });
+    const vpcSSMParam = new dataAwsSsmParameter.DataAwsSsmParameter(
+      this,
+      `vpc_ssm_param`,
+      {
+        provider: provider,
+        name: '/Shared/Vpc',
+      },
+    );
 
-    this.vpc = new DataAwsVpc(this, `vpc`, {
+    this.vpc = new dataAwsVpc.DataAwsVpc(this, `vpc`, {
       provider: provider,
       filter: [
         {
@@ -38,53 +48,73 @@ export class PocketVPC extends Construct {
       ],
     });
 
-    const privateString = new DataAwsSsmParameter(this, `private_subnets`, {
-      provider: provider,
-      name: '/Shared/PrivateSubnets',
-    });
+    const privateString = new dataAwsSsmParameter.DataAwsSsmParameter(
+      this,
+      `private_subnets`,
+      {
+        provider: provider,
+        name: '/Shared/PrivateSubnets',
+      },
+    );
 
-    const privateSubnets = new DataAwsSubnets(this, `private_subnet_ids`, {
-      provider: provider,
-      filter: [
-        {
-          name: 'subnet-id',
-          values: Fn.split(',', privateString.value),
-        },
-        { name: 'vpc-id', values: [this.vpc.id] },
-      ],
-    });
+    const privateSubnets = new dataAwsSubnets.DataAwsSubnets(
+      this,
+      `private_subnet_ids`,
+      {
+        provider: provider,
+        filter: [
+          {
+            name: 'subnet-id',
+            values: Fn.split(',', privateString.value),
+          },
+          { name: 'vpc-id', values: [this.vpc.id] },
+        ],
+      },
+    );
 
     this.privateSubnetIds = privateSubnets.ids;
 
-    const publicString = new DataAwsSsmParameter(this, `public_subnets`, {
-      provider: provider,
-      name: '/Shared/PublicSubnets',
-    });
+    const publicString = new dataAwsSsmParameter.DataAwsSsmParameter(
+      this,
+      `public_subnets`,
+      {
+        provider: provider,
+        name: '/Shared/PublicSubnets',
+      },
+    );
 
-    const publicSubnets = new DataAwsSubnets(this, `public_subnet_ids`, {
-      provider: provider,
-      filter: [
-        {
-          name: 'subnet-id',
-          values: Fn.split(',', publicString.value),
-        },
-        { name: 'vpc-id', values: [this.vpc.id] },
-      ],
-    });
+    const publicSubnets = new dataAwsSubnets.DataAwsSubnets(
+      this,
+      `public_subnet_ids`,
+      {
+        provider: provider,
+        filter: [
+          {
+            name: 'subnet-id',
+            values: Fn.split(',', publicString.value),
+          },
+          { name: 'vpc-id', values: [this.vpc.id] },
+        ],
+      },
+    );
 
     this.publicSubnetIds = publicSubnets.ids;
 
-    const identity = new DataAwsCallerIdentity(this, `current_identity`, {
-      provider: provider,
-    });
+    const identity = new dataAwsCallerIdentity.DataAwsCallerIdentity(
+      this,
+      `current_identity`,
+      {
+        provider: provider,
+      },
+    );
     this.accountId = identity.accountId;
 
-    const region = new DataAwsRegion(this, 'current_region', {
+    const region = new dataAwsRegion.DataAwsRegion(this, 'current_region', {
       provider: provider,
     });
     this.region = region.name;
 
-    this.secretsManagerSecretKey = new DataAwsKmsAlias(
+    this.secretsManagerSecretKey = new dataAwsKmsAlias.DataAwsKmsAlias(
       this,
       'secrets_manager_key',
       {
@@ -93,40 +123,42 @@ export class PocketVPC extends Construct {
       },
     );
 
-    this.defaultSecurityGroups = new DataAwsSecurityGroups(
-      this,
-      'default_security_groups',
-      {
-        provider: provider,
-        filter: [
-          {
-            name: 'group-name',
-            values: ['default'],
-          },
-          {
-            name: 'vpc-id',
-            values: [this.vpc.id],
-          },
-        ],
-      },
-    );
+    this.defaultSecurityGroups =
+      new dataAwsSecurityGroups.DataAwsSecurityGroups(
+        this,
+        'default_security_groups',
+        {
+          provider: provider,
+          filter: [
+            {
+              name: 'group-name',
+              values: ['default'],
+            },
+            {
+              name: 'vpc-id',
+              values: [this.vpc.id],
+            },
+          ],
+        },
+      );
 
-    this.internalSecurityGroups = new DataAwsSecurityGroups(
-      this,
-      'internal_security_groups',
-      {
-        provider: provider,
-        filter: [
-          {
-            name: 'group-name',
-            values: ['pocket-vpc-internal'],
-          },
-          {
-            name: 'vpc-id',
-            values: [this.vpc.id],
-          },
-        ],
-      },
-    );
+    this.internalSecurityGroups =
+      new dataAwsSecurityGroups.DataAwsSecurityGroups(
+        this,
+        'internal_security_groups',
+        {
+          provider: provider,
+          filter: [
+            {
+              name: 'group-name',
+              values: ['pocket-vpc-internal'],
+            },
+            {
+              name: 'vpc-id',
+              values: [this.vpc.id],
+            },
+          ],
+        },
+      );
   }
 }


### PR DESCRIPTION
## Goal

The way we were importing cdktf was actually not "supported" and when beginning to look at esm conversion would throw a ton of errors because it is more strict.

This moves us towards esm by fixing all the imports in the cdktf modules.