### PR TITLE
feat(v3proxy/send): implement add/readd

### DIFF
--- a/servers/v3-proxy-api/src/graph/graphQLClient.ts
+++ b/servers/v3-proxy-api/src/graph/graphQLClient.ts
@@ -207,29 +207,22 @@ export async function callSearchByOffsetComplete(
  * @param tags tags to associate to the saved item (optional)
  */
 export async function addSavedItem(
-  accessToken: string,
-  consumerKey: string,
-  headers: any,
+  client: GraphQLClient,
   variables: AddSavedItemCompleteMutationVariables,
 ): Promise<AddSavedItemCompleteMutation>;
 export async function addSavedItem(
-  accessToken: string,
-  consumerKey: string,
-  headers: any,
+  client: GraphQLClient,
   variables: AddSavedItemBeforeTagMutationVariables,
   tags: string[],
 ): Promise<AddTagsToSavedItemMutation>;
 export async function addSavedItem(
-  accessToken: string,
-  consumerKey: string,
-  headers: any,
+  client: GraphQLClient,
   variables: // These are the same types...
   | AddSavedItemBeforeTagMutationVariables
     | AddSavedItemCompleteMutationVariables,
   tags?: string[],
 ): Promise<AddSavedItemCompleteMutation | AddTagsToSavedItemMutation> {
   Sentry.addBreadcrumb({ message: 'invoking addSavedItem' });
-  const client = getClient(accessToken, consumerKey, headers);
   if (tags) {
     const addResult = await client.request<
       AddSavedItemBeforeTagMutation,

--- a/servers/v3-proxy-api/src/routes/ActionsRouter.ts
+++ b/servers/v3-proxy-api/src/routes/ActionsRouter.ts
@@ -1,0 +1,122 @@
+import { ClientError, GraphQLClient } from 'graphql-request';
+import { getClient } from '../graph/graphQLClient';
+import {
+  ItemAction,
+  ItemAddAction,
+  SendAction,
+} from './validations/SendActionValidators';
+import { AddResponse, PendingAddResponse } from '../graph/types';
+import { processV3Add } from './v3Add';
+import * as Sentry from '@sentry/node';
+import { SavedItemUpsertInput } from '../generated/graphql/types';
+import { serverLogger } from '@pocket-tools/ts-logger';
+import { customErrorHeaders } from '../middleware';
+import { Request } from 'express';
+
+type SendActionError = {
+  message: string;
+  type: string;
+  code: string;
+};
+
+type SendActionResult = {
+  status: 1;
+  action_errors: Array<SendActionError | null>;
+  action_results: Array<AddResponse | PendingAddResponse | boolean>;
+};
+
+export class ActionsRouter {
+  private client: GraphQLClient;
+  constructor(
+    accessToken: string,
+    consumerKey: string,
+    headers: Request['headers'],
+  ) {
+    this.client = getClient(accessToken, consumerKey, headers);
+  }
+  public async processActions(
+    actions: SendAction[], // Right now this is the only kind of action supported
+  ): Promise<SendActionResult> {
+    const result: SendActionResult = {
+      status: 1,
+      // Default values
+      action_errors: Array(actions.length).fill(null),
+      action_results: Array(actions.length).fill(false),
+    };
+    let i = 0;
+    for await (const action of actions) {
+      try {
+        Sentry.addBreadcrumb({ data: action });
+        const actionResult = await this[action.action](action);
+        result['action_results'][i] = actionResult;
+      } catch (err) {
+        const defaultMessage = 'Something Went Wrong';
+        if (err instanceof ClientError) {
+          // Log bad inputs because that indicates a bug in the proxy code
+          // Anything else should be captured by the router/subgraphs
+          if (err.response.status === 400) {
+            serverLogger.error(`/v3/send: ${err}`);
+            Sentry.captureException(err);
+          }
+          const primaryError = err.response.errors[0];
+          const primaryErrorData = customErrorHeaders(
+            primaryError.extensions.code,
+          );
+          const errorResult = {
+            message: primaryError.message ?? defaultMessage,
+            type: primaryErrorData['X-Error'],
+            code: primaryErrorData['X-Error-Code'],
+          } as SendActionError;
+          result['action_errors'][i] = errorResult;
+        } else {
+          // If an error occurs that doesn't originate from the client request,
+          // populate a default error and log to Cloudwatch/Sentry
+          const defaultError = customErrorHeaders('INTENAL_SERVER_ERROR');
+          const errorResult = {
+            message: defaultMessage,
+            type: defaultError['X-Error'],
+            code: defaultError['X-Error-Code'],
+          } as SendActionError;
+          result['action_errors'][i] = errorResult;
+          serverLogger.error(`/v3/send: ${err}`);
+          Sentry.captureException(err);
+        }
+      } finally {
+        i += 1;
+      }
+    }
+    return result;
+  }
+  /**
+   * Process the 'add' action from a batch of actions sent to /v3/send.
+   * The actions should be validated and sanitized before this is invoked.
+   * Public for unit-testing (consuming functions should use `processActions`).
+   */
+  public async add(
+    input: ItemAddAction,
+  ): Promise<AddResponse | PendingAddResponse> {
+    const addVars: {
+      input: SavedItemUpsertInput;
+    } = {
+      input: {
+        url: input.url,
+        ...(input.time && { timestamp: input.time }),
+        ...(input.title && { title: input.title }),
+      },
+    };
+    return await processV3Add(this.client, addVars, input.tags);
+  }
+  public async readd(
+    input: Omit<ItemAction, 'action'> & { action: 'readd' },
+  ): Promise<AddResponse | PendingAddResponse> {
+    const addVars: {
+      input: SavedItemUpsertInput;
+    } = {
+      input: {
+        url: input.url,
+        ...(input.time && { timestamp: input.time }),
+      },
+    };
+    return await processV3Add(this.client, addVars);
+  }
+}

--- a/servers/v3-proxy-api/src/routes/v3Send.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Send.integration.ts
@@ -2,6 +2,10 @@ import request from 'supertest';
 import { startServer } from '../server';
 import { Server } from 'http';
 import { Application } from 'express';
+import { ActionsRouter } from './ActionsRouter';
+import { expectedAddResponses } from '../test/fixtures/add';
+import { ClientError } from 'graphql-request';
+import { GraphQLError } from 'graphql-request/build/esm/types';
 
 describe('v3Get', () => {
   let app: Application;
@@ -17,28 +21,74 @@ describe('v3Get', () => {
   });
 
   describe('v3/send', () => {
-    it('Returns 400 if action array element name is not in allowlist', async () => {
-      const response = await request(app)
-        .post('/v3/send')
-        .send({
-          consumer_key: 'test',
-          access_token: 'test',
-          actions: [{ action: 'really_add', url: 'http://domain.com/path' }],
-        });
-      expect(response.status).toEqual(400);
+    describe('validation', () => {
+      it('Returns 400 if action array element name is not in allowlist', async () => {
+        const response = await request(app)
+          .post('/v3/send')
+          .send({
+            consumer_key: 'test',
+            access_token: 'test',
+            actions: [{ action: 'really_add', url: 'http://domain.com/path' }],
+          });
+        expect(response.status).toEqual(400);
+      });
+      it('Returns 400 if action array element fails validation', async () => {
+        const response = await request(app)
+          .post('/v3/send')
+          .send({
+            consumer_key: 'test',
+            access_token: 'test',
+            actions: [
+              { action: 'add', url: 'http://domain.com/path' },
+              { action: 'add', url: 'not a url' },
+            ],
+          });
+        expect(response.status).toEqual(400);
+      });
     });
-    it('Returns 400 if action array element fails validation', async () => {
-      const response = await request(app)
-        .post('/v3/send')
-        .send({
-          consumer_key: 'test',
-          access_token: 'test',
-          actions: [
-            { action: 'add', url: 'http://domain.com/path' },
-            { action: 'add', url: 'not a url' },
+    describe('actions', () => {
+      beforeAll(() =>
+        jest
+          .spyOn(ActionsRouter.prototype, 'add')
+          .mockResolvedValueOnce(expectedAddResponses[0])
+          .mockRejectedValueOnce(
+            new ClientError(
+              {
+                data: null,
+                status: 403,
+                errors: [
+                  {
+                    extensions: { code: 'FORBIDDEN' },
+                  } as unknown as GraphQLError,
+                ],
+              },
+              {} as any,
+            ),
+          ),
+      );
+      afterAll(() => jest.restoreAllMocks());
+      it('sends an array of responses and errors', async () => {
+        const response = await request(app)
+          .post('/v3/send')
+          .send({
+            consumer_key: 'test',
+            access_token: 'test',
+            actions: [
+              { action: 'add', url: 'http://domain.com/path' },
+              { action: 'add', url: 'http://domain.com/another-path' },
+            ],
+          });
+        const expected = {
+          status: 1,
+          action_results: [expectedAddResponses[0], false],
+          action_errors: [
+            null,
+            { message: 'Something Went Wrong', type: 'Forbidden', code: 5200 },
           ],
-        });
-      expect(response.status).toEqual(400);
+        };
+        expect(response.status).toEqual(200);
+        expect(response.body).toEqual(expected);
+      });
     });
   });
 });

--- a/servers/v3-proxy-api/src/routes/validations/SendSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/SendSchema.ts
@@ -37,7 +37,7 @@ export const V3SendSchema: Schema = {
       options: [
         [
           'add',
-          // 'readd',
+          'readd',
           // 'archive',
           // 'favorite',
           // 'unfavorite',


### PR DESCRIPTION
Add/readd actions on the v3/send endpoint.

Implementing add/readd by item_id is ticketed in Pocket-9805 (not available in the graph, seems also a weird use case but... whatever)

[POCKET-9624]

[POCKET-9624]: https://mozilla-hub.atlassian.net/browse/POCKET-9624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ