### PR TITLE
fix(lambda): making lambda ignore git_sha changes

### DIFF
--- a/.circleci/common.yml
+++ b/.circleci/common.yml
@@ -433,6 +433,7 @@ jobs:
             NEW_ENVVARS=$(aws lambda get-function-configuration --function-name '<< parameters.function-name >>' --query "Environment.Variables | merge(@, \`{\"GIT_SHA\":\"$CIRCLE_SHA1\"}\`)")
             echo $NEW_ENVVARS
             aws lambda update-function-configuration --function-name '<< parameters.function-name >>' --environment "{ \"Variables\": $NEW_ENVVARS }"
+            aws lambda wait function-updated --function-name '<< parameters.function-name >>'
 
             versionId=$(aws lambda publish-version \
                 --function-name '<< parameters.function-name >>' | jq -r .Version)

--- a/.circleci/common.yml
+++ b/.circleci/common.yml
@@ -157,7 +157,6 @@ commands:
       - run: 
           name: Install and setup node
           command: |
-            printenv
             nvm install
             nvm use
             npm install -g pnpm   
@@ -430,6 +429,10 @@ jobs:
                 --s3-key "$s3Key"
 
             aws lambda wait function-updated --function-name '<< parameters.function-name >>'
+
+            NEW_ENVVARS=$(aws lambda get-function-configuration --function-name '<< parameters.function-name >>' --query "Environment.Variables | merge(@, \`{\"GIT_SHA\":\"$CIRCLE_SHA1\"}\`)")
+            echo $NEW_ENVVARS
+            aws lambda update-function-configuration --function-name '<< parameters.function-name >>' --environment "{ \"Variables\": $NEW_ENVVARS }"
 
             versionId=$(aws lambda publish-version \
                 --function-name '<< parameters.function-name >>' | jq -r .Version)

--- a/.circleci/common.yml
+++ b/.circleci/common.yml
@@ -431,7 +431,6 @@ jobs:
             aws lambda wait function-updated --function-name '<< parameters.function-name >>'
 
             NEW_ENVVARS=$(aws lambda get-function-configuration --function-name '<< parameters.function-name >>' --query "Environment.Variables | merge(@, \`{\"GIT_SHA\":\"$CIRCLE_SHA1\"}\`)")
-            echo $NEW_ENVVARS
             aws lambda update-function-configuration --function-name '<< parameters.function-name >>' --environment "{ \"Variables\": $NEW_ENVVARS }"
             aws lambda wait function-updated --function-name '<< parameters.function-name >>'
 

--- a/.circleci/common.yml
+++ b/.circleci/common.yml
@@ -277,9 +277,12 @@ jobs:
           steps:
             - run:
                 name: Terraform apply
+                # Re-add this when tfcmt supports ignoring no change applies
+                # https://github.com/suzuki-shunsuke/tfcmt/issues/1184
+                #  /home/circleci/tfcmt --var target:<< parameters.scope >><<#parameters.dev>>-dev<</parameters.dev>> apply -- terraform apply -auto-approve -lock-timeout=10m
                 command: |
                   cd << parameters.stack-output-path >>
-                  /home/circleci/tfcmt --var target:<< parameters.scope >><<#parameters.dev>>-dev<</parameters.dev>> apply -- terraform apply -auto-approve -lock-timeout=10m
+                  terraform apply -auto-approve -lock-timeout=10m
                   mkdir -p /tmp/workspace
                   echo "$(terraform output -json)" > /tmp/workspace/tf_output.json
             # Persist TF_OUTPUT using workspace

--- a/.tfcmt.yml
+++ b/.tfcmt.yml
@@ -1,0 +1,137 @@
+# Default conifg for us to modify from https://suzuki-shunsuke.github.io/tfcmt/config#default-configuration
+embedded_var_names: []
+templates:
+  plan_title: "## {{if eq .ExitCode 1}}:x: {{end}}Plan Result{{if .Vars.target}} ({{.Vars.target}}){{end}}"
+  apply_title: "## :{{if eq .ExitCode 0}}white_check_mark{{else}}x{{end}}: Apply Result{{if .Vars.target}} ({{.Vars.target}}){{end}}"
+
+  result: "{{if .Result}}<pre><code>{{ .Result }}</code></pre>{{end}}"
+  updated_resources: |
+    {{if .CreatedResources}}
+    * Create
+    {{- range .CreatedResources}}
+      * {{.}}
+    {{- end}}{{end}}{{if .UpdatedResources}}
+    * Update
+    {{- range .UpdatedResources}}
+      * {{.}}
+    {{- end}}{{end}}{{if .DeletedResources}}
+    * Delete
+    {{- range .DeletedResources}}
+      * {{.}}
+    {{- end}}{{end}}{{if .ReplacedResources}}
+    * Replace
+    {{- range .ReplacedResources}}
+      * {{.}}
+    {{- end}}{{end}}{{if .ImportedResources}}
+    * Import
+    {{- range .ImportedResources}}
+      * {{.}}
+    {{- end}}{{end}}{{if .MovedResources}}
+    * Move
+    {{- range .MovedResources}}
+      * {{.Before}} => {{.After}}
+    {{- end}}{{end}}
+  deletion_warning: |
+    {{if .HasDestroy}}
+    ### :warning: Resource Deletion will happen :warning:
+    This plan contains resource delete operation. Please check the plan result very carefully!
+    {{end}}
+  changed_result: |
+    {{if .ChangedResult}}
+    <details><summary>Change Result (Click me)</summary>
+    {{wrapCode .ChangedResult}}
+    </details>
+    {{end}}
+  change_outside_terraform: |
+    {{if .ChangeOutsideTerraform}}
+    <details><summary>:information_source: Objects have changed outside of Terraform</summary>
+
+    _This feature was introduced from [Terraform v0.15.4](https://github.com/hashicorp/terraform/releases/tag/v0.15.4)._
+    {{wrapCode .ChangeOutsideTerraform}}
+    </details>
+    {{end}}
+  warning: |
+    {{if .Warning}}
+    ## :warning: Warnings :warning:
+    {{wrapCode .Warning}}
+    {{end}}
+  error_messages: |
+    {{if .ErrorMessages}}
+    ## :warning: Errors
+    {{range .ErrorMessages}}
+    * {{. -}}
+    {{- end}}{{end}}
+  guide_apply_failure: ""
+  guide_apply_parse_error: ""
+terraform:
+  plan:
+    disable_label: false
+    template: |
+      {{template "plan_title" .}}
+
+      {{if .Link}}[CI link]({{.Link}}){{end}}
+
+      {{template "deletion_warning" .}}
+      {{template "result" .}}
+      {{template "updated_resources" .}}
+
+      {{template "changed_result" .}}
+      {{template "change_outside_terraform" .}}
+      {{template "warning" .}}
+      {{template "error_messages" .}}
+    when_add_or_update_only:
+      label: "{{if .Vars.target}}{{.Vars.target}}/{{end}}add-or-update"
+      label_color: 1d76db # blue
+      # disable_label: false
+    when_destroy:
+      label: "{{if .Vars.target}}{{.Vars.target}}/{{end}}destroy"
+      label_color: d93f0b # red
+      # disable_label: false
+    when_no_changes:
+      label: "{{if .Vars.target}}{{.Vars.target}}/{{end}}no-changes"
+      label_color: 0e8a16 # green
+      disable_label: true
+      disable_comment: true
+    when_plan_error:
+      label:
+      label_color:
+      # disable_label: false
+    when_parse_error:
+      template: |
+        {{template "plan_title" .}}
+
+        {{if .Link}}[CI link]({{.Link}}){{end}}
+
+        It failed to parse the result.
+
+        <details><summary>Details (Click me)</summary>
+        {{wrapCode .CombinedOutput}}
+        </details>
+  apply:
+    template: |
+      {{template "apply_title" .}}
+
+      {{if .Link}}[CI link]({{.Link}}){{end}}
+
+      {{if ne .ExitCode 0}}{{template "guide_apply_failure" .}}{{end}}
+
+      {{template "result" .}}
+
+      <details><summary>Details (Click me)</summary>
+      {{wrapCode .CombinedOutput}}
+      </details>
+      {{template "error_messages" .}}
+    when_parse_error:
+      template: |
+        {{template "apply_title" .}}
+
+        {{if .Link}}[CI link]({{.Link}}){{end}}
+
+        {{template "guide_apply_parse_error" .}}
+
+        It failed to parse the result.
+
+        <details><summary>Details (Click me)</summary>
+        {{wrapCode .CombinedOutput}}
+        </details>
+# When https://github.com/suzuki-shunsuke/tfcmt/issues/1184 is done, we can make it so tfcmt doesn't comment on a no-op apply!

--- a/infrastructure/account-data-deleter/src/lambda/base/sqsLambda.ts
+++ b/infrastructure/account-data-deleter/src/lambda/base/sqsLambda.ts
@@ -29,7 +29,7 @@ export class SqsLambda extends Construct {
   ) {
     super(scope, name.toLowerCase());
 
-    const { sentryDsn, gitSha } = this.getEnvVariableValues();
+    const { sentryDsn } = this.getEnvVariableValues();
 
     this.lambda = new PocketSQSWithLambdaTarget(this, name.toLowerCase(), {
       name: `${stackConfig.prefix}-${name}`,
@@ -54,6 +54,7 @@ export class SqsLambda extends Construct {
             stackConfig.environment === 'Prod' ? 'production' : 'development',
           SENTRY_DSN: sentryDsn,
         },
+        ignoreEnvironmentVars: ['GIT_SHA'],
         handler: 'index.handler',
         reservedConcurrencyLimit: config.reservedConcurrencyLimit,
         runtime: LAMBDA_RUNTIMES.NODEJS20,
@@ -76,14 +77,6 @@ export class SqsLambda extends Construct {
       },
     );
 
-    const serviceHash = new dataAwsSsmParameter.DataAwsSsmParameter(
-      this,
-      'service-hash',
-      {
-        name: `${stackConfig.circleCIPrefix}/SERVICE_HASH`,
-      },
-    );
-
-    return { sentryDsn: sentryDsn.value, gitSha: serviceHash.value };
+    return { sentryDsn: sentryDsn.value };
   }
 }

--- a/infrastructure/account-data-deleter/src/lambda/base/sqsLambda.ts
+++ b/infrastructure/account-data-deleter/src/lambda/base/sqsLambda.ts
@@ -52,7 +52,6 @@ export class SqsLambda extends Construct {
             stackConfig.environment === 'Prod' ? 'production' : 'development',
           NODE_ENV:
             stackConfig.environment === 'Prod' ? 'production' : 'development',
-          GIT_SHA: gitSha,
           SENTRY_DSN: sentryDsn,
         },
         handler: 'index.handler',

--- a/infrastructure/account-data-deleter/src/lambda/batchDeleteLambdaResources.ts
+++ b/infrastructure/account-data-deleter/src/lambda/batchDeleteLambdaResources.ts
@@ -55,7 +55,6 @@ export class BatchDeleteLambdaResources extends Construct {
           timeout: 120,
           environment: {
             SENTRY_DSN: sentryDsn,
-            GIT_SHA: gitSha,
             ENVIRONMENT:
               stackConfig.environment === 'Prod' ? 'production' : 'development',
             NODE_ENV:

--- a/infrastructure/account-data-deleter/src/lambda/batchDeleteLambdaResources.ts
+++ b/infrastructure/account-data-deleter/src/lambda/batchDeleteLambdaResources.ts
@@ -61,6 +61,7 @@ export class BatchDeleteLambdaResources extends Construct {
               stackConfig.environment === 'Prod' ? 'production' : 'development',
             USER_API: `https://${stackConfig.userApiDomain}`,
           },
+          ignoreEnvironmentVars: ['GIT_SHA'],
           vpcConfig: {
             securityGroupIds: this.vpc.defaultSecurityGroups.ids,
             subnetIds: this.vpc.privateSubnetIds,

--- a/infrastructure/account-data-deleter/src/lambda/batchDeleteLambdaResources.ts
+++ b/infrastructure/account-data-deleter/src/lambda/batchDeleteLambdaResources.ts
@@ -31,7 +31,7 @@ export class BatchDeleteLambdaResources extends Construct {
   ) {
     super(scope, name.toLowerCase());
 
-    const { sentryDsn, gitSha } = this.getEnvVariableValues();
+    const { sentryDsn } = this.getEnvVariableValues();
 
     // Tables for retrieving historically deleted user ID lists
     // and keeping track of which ones have been processed
@@ -119,24 +119,28 @@ export class BatchDeleteLambdaResources extends Construct {
     );
 
     //permission for scheduledEvent to invoke the batchDeleteLambda
-    new lambdaPermission.LambdaPermission(this, `${config.prefix}-batchLambda-permission`, {
-      principal: 'events.amazonaws.com',
-      action: 'lambda:InvokeFunction',
-      functionName: this.batchDeleteLambda.lambda.defaultLambda.arn,
-      sourceArn: scheduledEvent.rule.arn,
-    });
+    new lambdaPermission.LambdaPermission(
+      this,
+      `${config.prefix}-batchLambda-permission`,
+      {
+        principal: 'events.amazonaws.com',
+        action: 'lambda:InvokeFunction',
+        functionName: this.batchDeleteLambda.lambda.defaultLambda.arn,
+        sourceArn: scheduledEvent.rule.arn,
+      },
+    );
   }
 
   private getEnvVariableValues() {
-    const sentryDsn = new dataAwsSsmParameter.DataAwsSsmParameter(this, 'sentry-dsn', {
-      name: `/${stackConfig.name}/${stackConfig.environment}/SENTRY_DSN`,
-    });
+    const sentryDsn = new dataAwsSsmParameter.DataAwsSsmParameter(
+      this,
+      'sentry-dsn',
+      {
+        name: `/${stackConfig.name}/${stackConfig.environment}/SENTRY_DSN`,
+      },
+    );
 
-    const serviceHash = new dataAwsSsmParameter.DataAwsSsmParameter(this, 'service-hash', {
-      name: `${stackConfig.circleCIPrefix}/SERVICE_HASH`,
-    });
-
-    return { sentryDsn: sentryDsn.value, gitSha: serviceHash.value };
+    return { sentryDsn: sentryDsn.value };
   }
 
   /**
@@ -206,23 +210,27 @@ export class BatchDeleteLambdaResources extends Construct {
     actions: string[],
   ) {
     const resources = dynamoTables.map((_) => _.arn);
-    const policy = new iamPolicy.IamPolicy(this, `${name}-lambda-dynamo-policy`, {
-      name: `${this.name}-${name}-DynamoLambdaPolicy`,
-      policy: new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
-        this,
-        `${name}-lambda-dynamo-policy-doc`,
-        {
-          statement: [
-            {
-              effect: 'Allow',
-              actions,
-              resources,
-            },
-          ],
-        },
-      ).json,
-      dependsOn: [lambdaExecutionRole],
-    });
+    const policy = new iamPolicy.IamPolicy(
+      this,
+      `${name}-lambda-dynamo-policy`,
+      {
+        name: `${this.name}-${name}-DynamoLambdaPolicy`,
+        policy: new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
+          this,
+          `${name}-lambda-dynamo-policy-doc`,
+          {
+            statement: [
+              {
+                effect: 'Allow',
+                actions,
+                resources,
+              },
+            ],
+          },
+        ).json,
+        dependsOn: [lambdaExecutionRole],
+      },
+    );
     return new iamRolePolicyAttachment.IamRolePolicyAttachment(
       this,
       `${name}-execution-role-policy-attachment`,

--- a/infrastructure/account-delete-monitor/src/sqsEventLambda.ts
+++ b/infrastructure/account-delete-monitor/src/sqsEventLambda.ts
@@ -25,7 +25,7 @@ export class SQSEventLambda extends Construct {
   constructor(scope: Construct, name: string, config: SqsLambdaProps) {
     super(scope, name.toLowerCase());
 
-    const { sentryDsn, gitSha } = this.getEnvVariableValues();
+    const { sentryDsn } = this.getEnvVariableValues();
 
     this.construct = new PocketSQSWithLambdaTarget(this, name.toLowerCase(), {
       name: `${stackConfig.prefix}-${name}`,
@@ -47,6 +47,7 @@ export class SQSEventLambda extends Construct {
           EVENT_TRACKER_DYNAMO: config.dynamoTable.dynamodb.name,
           USER_API_URL: stackConfig.userApi.prodUrl,
         },
+        ignoreEnvironmentVars: ['GIT_SHA'],
         vpcConfig: {
           securityGroupIds: config.vpc.defaultSecurityGroups.ids,
           subnetIds: config.vpc.privateSubnetIds,
@@ -70,14 +71,6 @@ export class SQSEventLambda extends Construct {
       },
     );
 
-    const serviceHash = new dataAwsSsmParameter.DataAwsSsmParameter(
-      this,
-      'service-hash',
-      {
-        name: `${stackConfig.circleCIPrefix}/SERVICE_HASH`,
-      },
-    );
-
-    return { sentryDsn: sentryDsn.value, gitSha: serviceHash.value };
+    return { sentryDsn: sentryDsn.value };
   }
 }

--- a/infrastructure/account-delete-monitor/src/sqsEventLambda.ts
+++ b/infrastructure/account-delete-monitor/src/sqsEventLambda.ts
@@ -42,7 +42,6 @@ export class SQSEventLambda extends Construct {
         reservedConcurrencyLimit: 10,
         environment: {
           SENTRY_DSN: sentryDsn,
-          GIT_SHA: gitSha,
           ENVIRONMENT:
             stackConfig.environment === 'Prod' ? 'production' : 'development',
           EVENT_TRACKER_DYNAMO: config.dynamoTable.dynamodb.name,

--- a/infrastructure/annotations-api/src/SqsLambda.ts
+++ b/infrastructure/annotations-api/src/SqsLambda.ts
@@ -37,7 +37,6 @@ export class SqsLambda extends Construct {
         reservedConcurrencyLimit: config.reservedConcurrencyLimit,
         environment: {
           SENTRY_DSN: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/SENTRY_DSN`,
-          RELEASE_SHA: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/SERVICE_HASH`,
           ENVIRONMENT:
             config.environment === 'Prod' ? 'production' : 'development',
           ANNOTATIONS_API_URI:

--- a/infrastructure/annotations-api/src/SqsLambda.ts
+++ b/infrastructure/annotations-api/src/SqsLambda.ts
@@ -45,6 +45,7 @@ export class SqsLambda extends Construct {
               ? 'https://annotations-api.readitlater.com'
               : 'https://annotations-api.getpocket.dev',
         },
+        ignoreEnvironmentVars: ['GIT_SHA'],
         vpcConfig: {
           securityGroupIds: vpc.defaultSecurityGroups.ids,
           subnetIds: vpc.privateSubnetIds,

--- a/infrastructure/annotations-api/src/SqsLambda.ts
+++ b/infrastructure/annotations-api/src/SqsLambda.ts
@@ -37,7 +37,6 @@ export class SqsLambda extends Construct {
         reservedConcurrencyLimit: config.reservedConcurrencyLimit,
         environment: {
           SENTRY_DSN: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/SENTRY_DSN`,
-          GIT_SHA: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/SERVICE_HASH`,
           RELEASE_SHA: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/SERVICE_HASH`,
           ENVIRONMENT:
             config.environment === 'Prod' ? 'production' : 'development',

--- a/infrastructure/fxa-webhook-proxy/src/apiGateway.ts
+++ b/infrastructure/fxa-webhook-proxy/src/apiGateway.ts
@@ -20,7 +20,7 @@ export class ApiGateway extends Construct {
     pagerDuty?: PocketPagerDuty,
   ) {
     super(scope, name);
-    const { sentryDsn, gitSha } = getEnvVariableValues(this);
+    const { sentryDsn } = getEnvVariableValues(this);
     const fxaEventsRoute: ApiGatewayLambdaRoute = {
       path: 'events',
       method: 'POST',

--- a/infrastructure/fxa-webhook-proxy/src/apiGateway.ts
+++ b/infrastructure/fxa-webhook-proxy/src/apiGateway.ts
@@ -39,7 +39,6 @@ export class ApiGateway extends Construct {
           timeout: 120,
           environment: {
             SENTRY_DSN: sentryDsn,
-            GIT_SHA: gitSha,
             ENVIRONMENT:
               config.environment === 'Prod' ? 'production' : 'development',
             SQS_FXA_EVENTS_URL: sqsQueue.url,

--- a/infrastructure/fxa-webhook-proxy/src/main.ts
+++ b/infrastructure/fxa-webhook-proxy/src/main.ts
@@ -24,7 +24,9 @@ class FxAWebhookProxy extends TerraformStack {
     super(scope, name);
 
     new awsProvider.AwsProvider(this, 'aws', { region: 'us-east-1' });
-    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
+    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', {
+      token: undefined,
+    });
     new archiveProvider.ArchiveProvider(this, 'archive-provider');
     new nullProvider.NullProvider(this, 'null-provider');
     new localProvider.LocalProvider(this, 'local-provider');

--- a/infrastructure/fxa-webhook-proxy/src/sqsLambda.ts
+++ b/infrastructure/fxa-webhook-proxy/src/sqsLambda.ts
@@ -19,7 +19,7 @@ export class SqsLambda extends Construct {
   ) {
     super(scope, name);
 
-    const { sentryDsn, gitSha } = getEnvVariableValues(this);
+    const { sentryDsn } = getEnvVariableValues(this);
 
     new PocketSQSWithLambdaTarget(this, 'fxa-events-sqs-lambda', {
       name: `${config.prefix}-Sqs-FxA-Events`,
@@ -40,6 +40,7 @@ export class SqsLambda extends Construct {
           ENVIRONMENT:
             config.environment === 'Prod' ? 'production' : 'development',
         },
+        ignoreEnvironmentVars: ['GIT_SHA'],
         vpcConfig: {
           securityGroupIds: vpc.internalSecurityGroups.ids,
           subnetIds: vpc.privateSubnetIds,

--- a/infrastructure/fxa-webhook-proxy/src/sqsLambda.ts
+++ b/infrastructure/fxa-webhook-proxy/src/sqsLambda.ts
@@ -37,7 +37,6 @@ export class SqsLambda extends Construct {
           REGION: vpc.region,
           JWT_KEY: config.sqsLambda.jwtKey,
           SENTRY_DSN: sentryDsn,
-          GIT_SHA: gitSha,
           ENVIRONMENT:
             config.environment === 'Prod' ? 'production' : 'development',
         },

--- a/infrastructure/fxa-webhook-proxy/src/utilities.ts
+++ b/infrastructure/fxa-webhook-proxy/src/utilities.ts
@@ -11,13 +11,5 @@ export function getEnvVariableValues(scope: Construct) {
     },
   );
 
-  const serviceHash = new dataAwsSsmParameter.DataAwsSsmParameter(
-    scope,
-    'service-hash',
-    {
-      name: `${config.circleCIPrefix}/SERVICE_HASH`,
-    },
-  );
-
-  return { sentryDsn: sentryDsn.value, gitSha: serviceHash.value };
+  return { sentryDsn: sentryDsn.value };
 }

--- a/infrastructure/pocket-event-bridge/src/main.ts
+++ b/infrastructure/pocket-event-bridge/src/main.ts
@@ -42,7 +42,9 @@ class PocketEventBus extends TerraformStack {
       region: 'us-east-1',
       defaultTags: [{ tags: config.tags }],
     });
-    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', { token: undefined });
+    new pagerdutyProvider.PagerdutyProvider(this, 'pagerduty_provider', {
+      token: undefined,
+    });
     new localProvider.LocalProvider(this, 'local_provider');
     new nullProvider.NullProvider(this, 'null_provider');
     new archiveProvider.ArchiveProvider(this, 'archive_provider');

--- a/infrastructure/sendgrid-data/src/apiGateway.ts
+++ b/infrastructure/sendgrid-data/src/apiGateway.ts
@@ -55,7 +55,6 @@ export class ApiGateway extends Construct {
           timeout: 120,
           environment: {
             SENTRY_DSN: sentryDsn,
-            GIT_SHA: gitSha,
             ENVIRONMENT:
               config.environment === 'Prod' ? 'production' : 'development',
             AWS_CLOUDWATCH_METRIC_NAMESPACE: config.prefix,

--- a/infrastructure/sendgrid-data/src/apiGateway.ts
+++ b/infrastructure/sendgrid-data/src/apiGateway.ts
@@ -18,7 +18,7 @@ export class ApiGateway extends Construct {
     pagerDuty?: PocketPagerDuty,
   ) {
     super(scope, name);
-    const { sentryDsn, gitSha } = getEnvVariableValues(this);
+    const { sentryDsn } = getEnvVariableValues(this);
 
     const sendGridDataRoute: ApiGatewayLambdaRoute = {
       path: 'events',
@@ -60,6 +60,7 @@ export class ApiGateway extends Construct {
             AWS_CLOUDWATCH_METRIC_NAMESPACE: config.prefix,
             AWS_FIREHOSE_DELIVERY_STREAM_NAME: config.firehoseStream,
           },
+          ignoreEnvironmentVars: ['GIT_SHA'],
           vpcConfig: {
             securityGroupIds: vpc.internalSecurityGroups.ids,
             subnetIds: vpc.privateSubnetIds,

--- a/infrastructure/sendgrid-data/src/utilities.ts
+++ b/infrastructure/sendgrid-data/src/utilities.ts
@@ -11,13 +11,5 @@ export function getEnvVariableValues(scope: Construct) {
     },
   );
 
-  const serviceHash = new dataAwsSsmParameter.DataAwsSsmParameter(
-    scope,
-    'service-hash',
-    {
-      name: `${config.circleCIPrefix}/SERVICE_HASH`,
-    },
-  );
-
-  return { sentryDsn: sentryDsn.value, gitSha: serviceHash.value };
+  return { sentryDsn: sentryDsn.value };
 }

--- a/infrastructure/shareable-lists-api/src/SQSLambda.ts
+++ b/infrastructure/shareable-lists-api/src/SQSLambda.ts
@@ -37,7 +37,6 @@ export class SQSLambda extends Construct {
         reservedConcurrencyLimit: config.reservedConcurrencyLimit,
         environment: {
           SENTRY_DSN: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/SENTRY_DSN`,
-          GIT_SHA: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/SERVICE_HASH`,
           RELEASE_SHA: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/SERVICE_HASH`,
           ENVIRONMENT:
             config.environment === 'Prod' ? 'production' : 'development',

--- a/infrastructure/shareable-lists-api/src/SQSLambda.ts
+++ b/infrastructure/shareable-lists-api/src/SQSLambda.ts
@@ -45,6 +45,7 @@ export class SQSLambda extends Construct {
               ? 'https://shareablelistsapi.readitlater.com'
               : 'https://shareablelistsapi.getpocket.dev',
         },
+        ignoreEnvironmentVars: ['GIT_SHA'],
         vpcConfig: {
           securityGroupIds: vpc.defaultSecurityGroups.ids,
           subnetIds: vpc.privateSubnetIds,

--- a/infrastructure/shareable-lists-api/src/SQSLambda.ts
+++ b/infrastructure/shareable-lists-api/src/SQSLambda.ts
@@ -37,7 +37,6 @@ export class SQSLambda extends Construct {
         reservedConcurrencyLimit: config.reservedConcurrencyLimit,
         environment: {
           SENTRY_DSN: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/SENTRY_DSN`,
-          RELEASE_SHA: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/SERVICE_HASH`,
           ENVIRONMENT:
             config.environment === 'Prod' ? 'production' : 'development',
           SHAREABLE_LISTS_API_URI:

--- a/infrastructure/transactional-emails/src/transactionalEmailSQSLambda.ts
+++ b/infrastructure/transactional-emails/src/transactionalEmailSQSLambda.ts
@@ -18,7 +18,7 @@ export class TransactionalEmailSQSLambda extends Construct {
   ) {
     super(scope, name);
 
-    const { sentryDsn, gitSha } = this.getEnvVariableValues();
+    const { sentryDsn } = this.getEnvVariableValues();
 
     this.construct = new PocketSQSWithLambdaTarget(this, 'sqs-event-consumer', {
       name: `${config.prefix}-Sqs-Event-Consumer`,
@@ -46,6 +46,7 @@ export class TransactionalEmailSQSLambda extends Construct {
           BRAZE_FORGOT_PASSWORD_CAMPAIGN_ID:
             config.lambda.braze.forgotPasswordCampaignId,
         },
+        ignoreEnvironmentVars: ['GIT_SHA'],
         vpcConfig: {
           securityGroupIds: vpc.defaultSecurityGroups.ids,
           subnetIds: vpc.privateSubnetIds,
@@ -81,14 +82,14 @@ export class TransactionalEmailSQSLambda extends Construct {
   }
 
   private getEnvVariableValues() {
-    const sentryDsn = new dataAwsSsmParameter.DataAwsSsmParameter(this, 'sentry-dsn', {
-      name: `/${config.name}/${config.environment}/SENTRY_DSN`,
-    });
+    const sentryDsn = new dataAwsSsmParameter.DataAwsSsmParameter(
+      this,
+      'sentry-dsn',
+      {
+        name: `/${config.name}/${config.environment}/SENTRY_DSN`,
+      },
+    );
 
-    const serviceHash = new dataAwsSsmParameter.DataAwsSsmParameter(this, 'service-hash', {
-      name: `${config.circleCIPrefix}/SERVICE_HASH`,
-    });
-
-    return { sentryDsn: sentryDsn.value, gitSha: serviceHash.value };
+    return { sentryDsn: sentryDsn.value };
   }
 }

--- a/infrastructure/transactional-emails/src/transactionalEmailSQSLambda.ts
+++ b/infrastructure/transactional-emails/src/transactionalEmailSQSLambda.ts
@@ -35,7 +35,6 @@ export class TransactionalEmailSQSLambda extends Construct {
         timeout: 120,
         environment: {
           SENTRY_DSN: sentryDsn,
-          GIT_SHA: gitSha,
           NODE_ENV:
             config.environment === 'Prod' ? 'production' : 'development',
           SSM_BRAZE_API_KEY_NAME: `/${config.name}/${config.environment}/BRAZE_API_KEY`,

--- a/packages/terraform-modules/src/base/ApplicationAutoscaling.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationAutoscaling.spec.ts
@@ -1,5 +1,5 @@
 import { Testing } from 'cdktf';
-import { TestResource } from '../testHelpers.js'
+import { TestResource } from '../testHelpers.js';
 import {
   ApplicationAutoscaling,
   ApplicationAutoscalingProps,

--- a/packages/terraform-modules/src/base/ApplicationBackups.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationBackups.spec.ts
@@ -1,5 +1,5 @@
 import { Testing } from 'cdktf';
-import { ApplicationBackup } from './ApplicationBackups.js'
+import { ApplicationBackup } from './ApplicationBackups.js';
 
 describe('ApplicationBackup', () => {
   it('renders vault with plans without tags', () => {

--- a/packages/terraform-modules/src/base/ApplicationBaseDNS.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationBaseDNS.spec.ts
@@ -1,6 +1,6 @@
 import { Testing } from 'cdktf';
-import { TestResource } from '../testHelpers.js'
-import { ApplicationBaseDNS } from './ApplicationBaseDNS.js'
+import { TestResource } from '../testHelpers.js';
+import { ApplicationBaseDNS } from './ApplicationBaseDNS.js';
 
 describe('ApplicationBaseDNS', () => {
   const tags = {

--- a/packages/terraform-modules/src/base/ApplicationCertificate.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationCertificate.spec.ts
@@ -1,6 +1,6 @@
 import { Testing, TerraformStack } from 'cdktf';
-import { TestResource } from '../testHelpers.js'
-import { ApplicationCertificate } from './ApplicationCertificate.js'
+import { TestResource } from '../testHelpers.js';
+import { ApplicationCertificate } from './ApplicationCertificate.js';
 
 describe('ApplicationCertificate', () => {
   const tags = {

--- a/packages/terraform-modules/src/base/ApplicationECR.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationECR.spec.ts
@@ -1,5 +1,5 @@
 import { Testing } from 'cdktf';
-import { ApplicationECR } from './ApplicationECR.js'
+import { ApplicationECR } from './ApplicationECR.js';
 
 describe('ApplicationECR', () => {
   it('renders an ECR without tags', () => {

--- a/packages/terraform-modules/src/base/ApplicationECSAlbCodeDeploy.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationECSAlbCodeDeploy.spec.ts
@@ -1,5 +1,5 @@
 import { Testing } from 'cdktf';
-import { ApplicationECSAlbCodeDeploy } from './ApplicationECSAlbCodeDeploy.js'
+import { ApplicationECSAlbCodeDeploy } from './ApplicationECSAlbCodeDeploy.js';
 
 describe('ApplicationECSAlbCodeDeploy', () => {
   it('renders a CodeDeploy without a sns', () => {

--- a/packages/terraform-modules/src/base/ApplicationECSCluster.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationECSCluster.spec.ts
@@ -1,5 +1,5 @@
 import { Testing } from 'cdktf';
-import { ApplicationECSCluster } from './ApplicationECSCluster.js'
+import { ApplicationECSCluster } from './ApplicationECSCluster.js';
 
 describe('ApplicationECSCluster', () => {
   it('renders an ECS cluster without tags', () => {

--- a/packages/terraform-modules/src/base/ApplicationECSIAM.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationECSIAM.spec.ts
@@ -1,5 +1,8 @@
 import { Testing } from 'cdktf';
-import { ApplicationECSIAM, ApplicationECSIAMProps } from './ApplicationECSIAM.js'
+import {
+  ApplicationECSIAM,
+  ApplicationECSIAMProps,
+} from './ApplicationECSIAM.js';
 
 const BASE_CONFIG: ApplicationECSIAMProps = {
   prefix: 'abides-dev',

--- a/packages/terraform-modules/src/base/ApplicationLambdaSnsTopicSubscription.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationLambdaSnsTopicSubscription.spec.ts
@@ -1,6 +1,6 @@
 import { dataAwsLambdaFunction } from '@cdktf/provider-aws';
 import { Testing } from 'cdktf';
-import { ApplicationLambdaSnsTopicSubscription } from './ApplicationLambdaSnsTopicSubscription.js'
+import { ApplicationLambdaSnsTopicSubscription } from './ApplicationLambdaSnsTopicSubscription.js';
 
 describe('ApplicationSqsSnsTopicSubscription', () => {
   const getConfig = (stack) => ({

--- a/packages/terraform-modules/src/base/ApplicationLoadBalancer.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationLoadBalancer.spec.ts
@@ -1,5 +1,5 @@
 import { Testing } from 'cdktf';
-import { ApplicationLoadBalancer } from './ApplicationLoadBalancer.js'
+import { ApplicationLoadBalancer } from './ApplicationLoadBalancer.js';
 
 describe('ApplicationLoadBalancer', () => {
   it('renders an ALB without tags', () => {

--- a/packages/terraform-modules/src/base/ApplicationMemcache.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationMemcache.spec.ts
@@ -1,7 +1,7 @@
 import { Testing } from 'cdktf';
-import { ApplicationElasticacheClusterProps } from './ApplicationElasticacheCluster.js'
+import { ApplicationElasticacheClusterProps } from './ApplicationElasticacheCluster.js';
 
-import { ApplicationMemcache } from './ApplicationMemcache.js'
+import { ApplicationMemcache } from './ApplicationMemcache.js';
 
 const BASE_CONFIG: ApplicationElasticacheClusterProps = {
   allowedIngressSecurityGroupIds: [],

--- a/packages/terraform-modules/src/base/ApplicationRDSCluster.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationRDSCluster.spec.ts
@@ -1,5 +1,5 @@
 import { Testing } from 'cdktf';
-import { ApplicationRDSCluster } from './ApplicationRDSCluster.js'
+import { ApplicationRDSCluster } from './ApplicationRDSCluster.js';
 
 describe('ApplicationRDSCluster', () => {
   it('renders a RDS cluster', () => {

--- a/packages/terraform-modules/src/base/ApplicationRedis.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationRedis.spec.ts
@@ -1,7 +1,7 @@
 import { Testing } from 'cdktf';
-import { ApplicationElasticacheClusterProps } from './ApplicationElasticacheCluster.js'
+import { ApplicationElasticacheClusterProps } from './ApplicationElasticacheCluster.js';
 
-import { ApplicationRedis } from './ApplicationRedis.js'
+import { ApplicationRedis } from './ApplicationRedis.js';
 
 const BASE_CONFIG: ApplicationElasticacheClusterProps = {
   allowedIngressSecurityGroupIds: [],

--- a/packages/terraform-modules/src/base/ApplicationSqsSnsTopicSubscription.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationSqsSnsTopicSubscription.spec.ts
@@ -1,6 +1,6 @@
 import { sqsQueue } from '@cdktf/provider-aws';
 import { Testing } from 'cdktf';
-import { ApplicationSqsSnsTopicSubscription } from './ApplicationSqsSnsTopicSubscription.js'
+import { ApplicationSqsSnsTopicSubscription } from './ApplicationSqsSnsTopicSubscription.js';
 
 describe('ApplicationSqsSnsTopicSubscription', () => {
   const getConfig = (stack) => ({

--- a/packages/terraform-modules/src/base/ApplicationTargetGroup.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationTargetGroup.spec.ts
@@ -1,5 +1,5 @@
 import { Testing } from 'cdktf';
-import { ApplicationTargetGroup } from './ApplicationTargetGroup.js'
+import { ApplicationTargetGroup } from './ApplicationTargetGroup.js';
 
 describe('ApplicationTargetGroup', () => {
   it('renders a Target Group without tags', () => {

--- a/packages/terraform-modules/src/base/ApplicationVersionedLambda.ts
+++ b/packages/terraform-modules/src/base/ApplicationVersionedLambda.ts
@@ -16,7 +16,7 @@ import {
   lambdaAlias,
 } from '@cdktf/provider-aws';
 
-import { Fn, TerraformMetaArguments } from 'cdktf';
+import { Fn, TerraformMetaArguments, TerraformOutput } from 'cdktf';
 import { Construct } from 'constructs';
 
 export enum LAMBDA_RUNTIMES {
@@ -46,6 +46,7 @@ export interface ApplicationVersionedLambdaProps
   logRetention?: number;
   s3Bucket: string;
   usesCodeDeploy?: boolean;
+  ignoreEnvironmentVars?: string[];
 }
 
 const DEFAULT_TIMEOUT = 5;
@@ -65,6 +66,10 @@ export class ApplicationVersionedLambda extends Construct {
     private config: ApplicationVersionedLambdaProps,
   ) {
     super(scope, name);
+
+    if (!config.ignoreEnvironmentVars) {
+      config.ignoreEnvironmentVars = [];
+    }
 
     this.createCodeBucket();
     const { versionedLambda, lambda } = this.createLambdaFunction();
@@ -117,6 +122,9 @@ export class ApplicationVersionedLambda extends Construct {
           'filename',
           'source_code_hash',
           this.shouldIgnorePublish() ? 'publish' : '',
+          ...this.config.ignoreEnvironmentVars.map(
+            (value) => `environment.0.variables["${value}"]`,
+          ),
         ].filter((v: string) => v),
       },
       tags: this.config.tags,
@@ -131,6 +139,16 @@ export class ApplicationVersionedLambda extends Construct {
       'lambda',
       lambdaConfig,
     );
+
+    new TerraformOutput(this, 'lambda_function_name', {
+      value: lambda.functionName,
+      description: 'Lambda Function Name',
+    });
+
+    new TerraformOutput(this, 'lambda_arn', {
+      value: lambda.arn,
+      description: 'Lambda Function ARN',
+    });
 
     new cloudwatchLogGroup.CloudwatchLogGroup(this, 'log-group', {
       name: `/aws/lambda/${lambda.functionName}`,
@@ -150,6 +168,12 @@ export class ApplicationVersionedLambda extends Construct {
       dependsOn: [lambda],
       provider: this.config.provider,
     });
+
+    new TerraformOutput(this, 'lambda_version_arn', {
+      value: versionedLambda.arn,
+      description: 'Lambda Version ARN',
+    });
+
     return { versionedLambda, lambda };
   }
 

--- a/packages/terraform-modules/src/base/__snapshots__/ApplicationLambdaCodeDeploy.spec.ts.snap
+++ b/packages/terraform-modules/src/base/__snapshots__/ApplicationLambdaCodeDeploy.spec.ts.snap
@@ -24,6 +24,16 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app 1`] = `
       }
     }
   },
+  "output": {
+    "test-lambda-code-deploy_lambda_codedeploy_app_08E19C48": {
+      "description": "Lambda CodeDeploy App Name",
+      "value": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}"
+    },
+    "test-lambda-code-deploy_lambda_codedeploy_group_FC959693": {
+      "description": "Lambda CodeDeploy Group Name",
+      "value": "\${aws_codedeploy_deployment_group.test-lambda-code-deploy_code-deployment-group_3F73EBCE.deployment_group_name}"
+    }
+  },
   "resource": {
     "aws_codedeploy_app": {
       "test-lambda-code-deploy_code-deploy-app_A7640CFE": {
@@ -93,6 +103,16 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with all n
           }
         ]
       }
+    }
+  },
+  "output": {
+    "test-lambda-code-deploy_lambda_codedeploy_app_08E19C48": {
+      "description": "Lambda CodeDeploy App Name",
+      "value": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}"
+    },
+    "test-lambda-code-deploy_lambda_codedeploy_group_FC959693": {
+      "description": "Lambda CodeDeploy Group Name",
+      "value": "\${aws_codedeploy_deployment_group.test-lambda-code-deploy_code-deployment-group_3F73EBCE.deployment_group_name}"
     }
   },
   "resource": {
@@ -183,6 +203,16 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with defau
       }
     }
   },
+  "output": {
+    "test-lambda-code-deploy_lambda_codedeploy_app_08E19C48": {
+      "description": "Lambda CodeDeploy App Name",
+      "value": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}"
+    },
+    "test-lambda-code-deploy_lambda_codedeploy_group_FC959693": {
+      "description": "Lambda CodeDeploy Group Name",
+      "value": "\${aws_codedeploy_deployment_group.test-lambda-code-deploy_code-deployment-group_3F73EBCE.deployment_group_name}"
+    }
+  },
   "resource": {
     "aws_codedeploy_app": {
       "test-lambda-code-deploy_code-deploy-app_A7640CFE": {
@@ -267,6 +297,16 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with sns t
           }
         ]
       }
+    }
+  },
+  "output": {
+    "test-lambda-code-deploy_lambda_codedeploy_app_08E19C48": {
+      "description": "Lambda CodeDeploy App Name",
+      "value": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}"
+    },
+    "test-lambda-code-deploy_lambda_codedeploy_group_FC959693": {
+      "description": "Lambda CodeDeploy Group Name",
+      "value": "\${aws_codedeploy_deployment_group.test-lambda-code-deploy_code-deployment-group_3F73EBCE.deployment_group_name}"
     }
   },
   "resource": {
@@ -355,6 +395,16 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with sns t
       }
     }
   },
+  "output": {
+    "test-lambda-code-deploy_lambda_codedeploy_app_08E19C48": {
+      "description": "Lambda CodeDeploy App Name",
+      "value": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}"
+    },
+    "test-lambda-code-deploy_lambda_codedeploy_group_FC959693": {
+      "description": "Lambda CodeDeploy Group Name",
+      "value": "\${aws_codedeploy_deployment_group.test-lambda-code-deploy_code-deployment-group_3F73EBCE.deployment_group_name}"
+    }
+  },
   "resource": {
     "aws_codedeploy_app": {
       "test-lambda-code-deploy_code-deploy-app_A7640CFE": {
@@ -439,6 +489,16 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with start
           }
         ]
       }
+    }
+  },
+  "output": {
+    "test-lambda-code-deploy_lambda_codedeploy_app_08E19C48": {
+      "description": "Lambda CodeDeploy App Name",
+      "value": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}"
+    },
+    "test-lambda-code-deploy_lambda_codedeploy_group_FC959693": {
+      "description": "Lambda CodeDeploy Group Name",
+      "value": "\${aws_codedeploy_deployment_group.test-lambda-code-deploy_code-deployment-group_3F73EBCE.deployment_group_name}"
     }
   },
   "resource": {

--- a/packages/terraform-modules/src/base/__snapshots__/ApplicationVersionedLambda.spec.ts.snap
+++ b/packages/terraform-modules/src/base/__snapshots__/ApplicationVersionedLambda.spec.ts.snap
@@ -55,6 +55,20 @@ exports[`ApplicationVersionedLambda renders a lambda with a node v14 runtime 1`]
       }
     }
   },
+  "output": {
+    "test-versioned-lambda_lambda_arn_EE780827": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.arn}"
+    },
+    "test-versioned-lambda_lambda_function_name_8E4C0AF1": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}"
+    },
+    "test-versioned-lambda_lambda_version_arn_0407D06E": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-versioned-lambda_alias_60AF9CE1.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_log_group": {
       "test-versioned-lambda_log-group_CB8A67E7": {
@@ -209,6 +223,20 @@ exports[`ApplicationVersionedLambda renders a versioned lambda 1`] = `
         ],
         "version": "2012-10-17"
       }
+    }
+  },
+  "output": {
+    "test-versioned-lambda_lambda_arn_EE780827": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.arn}"
+    },
+    "test-versioned-lambda_lambda_function_name_8E4C0AF1": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}"
+    },
+    "test-versioned-lambda_lambda_version_arn_0407D06E": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-versioned-lambda_alias_60AF9CE1.arn}"
     }
   },
   "resource": {
@@ -367,6 +395,20 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with description 
       }
     }
   },
+  "output": {
+    "test-versioned-lambda_lambda_arn_EE780827": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.arn}"
+    },
+    "test-versioned-lambda_lambda_function_name_8E4C0AF1": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}"
+    },
+    "test-versioned-lambda_lambda_version_arn_0407D06E": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-versioned-lambda_alias_60AF9CE1.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_log_group": {
       "test-versioned-lambda_log-group_CB8A67E7": {
@@ -521,6 +563,20 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with environment 
         ],
         "version": "2012-10-17"
       }
+    }
+  },
+  "output": {
+    "test-versioned-lambda_lambda_arn_EE780827": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.arn}"
+    },
+    "test-versioned-lambda_lambda_function_name_8E4C0AF1": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}"
+    },
+    "test-versioned-lambda_lambda_version_arn_0407D06E": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-versioned-lambda_alias_60AF9CE1.arn}"
     }
   },
   "resource": {
@@ -694,6 +750,20 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with execution po
       }
     }
   },
+  "output": {
+    "test-versioned-lambda_lambda_arn_EE780827": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.arn}"
+    },
+    "test-versioned-lambda_lambda_function_name_8E4C0AF1": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}"
+    },
+    "test-versioned-lambda_lambda_version_arn_0407D06E": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-versioned-lambda_alias_60AF9CE1.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_log_group": {
       "test-versioned-lambda_log-group_CB8A67E7": {
@@ -850,6 +920,20 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with log retentio
       }
     }
   },
+  "output": {
+    "test-versioned-lambda_lambda_arn_EE780827": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.arn}"
+    },
+    "test-versioned-lambda_lambda_function_name_8E4C0AF1": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}"
+    },
+    "test-versioned-lambda_lambda_version_arn_0407D06E": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-versioned-lambda_alias_60AF9CE1.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_log_group": {
       "test-versioned-lambda_log-group_CB8A67E7": {
@@ -1004,6 +1088,20 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with publish igno
         ],
         "version": "2012-10-17"
       }
+    }
+  },
+  "output": {
+    "test-versioned-lambda_lambda_arn_EE780827": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.arn}"
+    },
+    "test-versioned-lambda_lambda_function_name_8E4C0AF1": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}"
+    },
+    "test-versioned-lambda_lambda_version_arn_0407D06E": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-versioned-lambda_alias_60AF9CE1.arn}"
     }
   },
   "resource": {
@@ -1163,6 +1261,20 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with s3 bucket 1`
       }
     }
   },
+  "output": {
+    "test-versioned-lambda_lambda_arn_EE780827": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.arn}"
+    },
+    "test-versioned-lambda_lambda_function_name_8E4C0AF1": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}"
+    },
+    "test-versioned-lambda_lambda_version_arn_0407D06E": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-versioned-lambda_alias_60AF9CE1.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_log_group": {
       "test-versioned-lambda_log-group_CB8A67E7": {
@@ -1317,6 +1429,20 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with tags 1`] = `
         ],
         "version": "2012-10-17"
       }
+    }
+  },
+  "output": {
+    "test-versioned-lambda_lambda_arn_EE780827": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.arn}"
+    },
+    "test-versioned-lambda_lambda_function_name_8E4C0AF1": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}"
+    },
+    "test-versioned-lambda_lambda_version_arn_0407D06E": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-versioned-lambda_alias_60AF9CE1.arn}"
     }
   },
   "resource": {
@@ -1495,6 +1621,20 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with timeout 1`] 
       }
     }
   },
+  "output": {
+    "test-versioned-lambda_lambda_arn_EE780827": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.arn}"
+    },
+    "test-versioned-lambda_lambda_function_name_8E4C0AF1": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}"
+    },
+    "test-versioned-lambda_lambda_version_arn_0407D06E": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-versioned-lambda_alias_60AF9CE1.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_log_group": {
       "test-versioned-lambda_log-group_CB8A67E7": {
@@ -1662,6 +1802,20 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with vpc 1`] = `
         ],
         "version": "2012-10-17"
       }
+    }
+  },
+  "output": {
+    "test-versioned-lambda_lambda_arn_EE780827": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.arn}"
+    },
+    "test-versioned-lambda_lambda_function_name_8E4C0AF1": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}"
+    },
+    "test-versioned-lambda_lambda_version_arn_0407D06E": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-versioned-lambda_alias_60AF9CE1.arn}"
     }
   },
   "resource": {

--- a/packages/terraform-modules/src/pocket/PocketApiGatewayLambdaIntegration.spec.ts
+++ b/packages/terraform-modules/src/pocket/PocketApiGatewayLambdaIntegration.spec.ts
@@ -1,5 +1,5 @@
 import { Testing } from 'cdktf';
-import { LAMBDA_RUNTIMES } from '../base/ApplicationVersionedLambda.js'
+import { LAMBDA_RUNTIMES } from '../base/ApplicationVersionedLambda.js';
 import {
   PocketApiGateway,
   PocketApiGatewayProps,

--- a/packages/terraform-modules/src/pocket/PocketApiGatewayLambdaIntegration.ts
+++ b/packages/terraform-modules/src/pocket/PocketApiGatewayLambdaIntegration.ts
@@ -84,9 +84,8 @@ export class PocketApiGateway extends Construct {
       route.lambda.lambda.versionedLambda,
     ]);
 
-    // Use the current timestamp in milliseconds to trigger a redeployment if no triggers are provided.
-    // If no triggers are provided, this resource will be redeployed on every "terraform apply".
-    const triggers = config.triggers ?? { deployedAt: Date.now().toString() };
+    // If no triggers are provided, this resource will be redeployed only if soemthing changes to cause it.
+    const triggers = config.triggers ?? {};
 
     // Deployment before adding permissions, so we can restrict to the stage
     this.apiGatewayDeployment = new apiGatewayDeployment.ApiGatewayDeployment(

--- a/packages/terraform-modules/src/pocket/PocketApiGatewayLambdaIntegration.ts
+++ b/packages/terraform-modules/src/pocket/PocketApiGatewayLambdaIntegration.ts
@@ -84,7 +84,7 @@ export class PocketApiGateway extends Construct {
       route.lambda.lambda.versionedLambda,
     ]);
 
-    // If no triggers are provided, this resource will be redeployed only if soemthing changes to cause it.
+    // If no triggers are provided, this resource will be redeployed only if something changes to cause it.
     const triggers = config.triggers ?? {};
 
     // Deployment before adding permissions, so we can restrict to the stage

--- a/packages/terraform-modules/src/pocket/PocketEventBridgeRuleWithMultipleTargets.spec.ts
+++ b/packages/terraform-modules/src/pocket/PocketEventBridgeRuleWithMultipleTargets.spec.ts
@@ -7,7 +7,7 @@ import {
   PocketVersionedLambda,
   PocketVersionedLambdaProps,
 } from './PocketVersionedLambda';
-import { LAMBDA_RUNTIMES } from '../base/ApplicationVersionedLambda.js'
+import { LAMBDA_RUNTIMES } from '../base/ApplicationVersionedLambda.js';
 import { sqsQueue } from '@cdktf/provider-aws';
 
 describe('PocketEventBridgeRuleWithMultipleTargets', () => {

--- a/packages/terraform-modules/src/pocket/PocketEventBridgeWithLambdaTarget.spec.ts
+++ b/packages/terraform-modules/src/pocket/PocketEventBridgeWithLambdaTarget.spec.ts
@@ -3,7 +3,7 @@ import {
   PocketEventBridgeWithLambdaTarget,
   PocketEventBridgeWithLambdaTargetProps,
 } from './PocketEventBridgeWithLambdaTarget';
-import { LAMBDA_RUNTIMES } from '../base/ApplicationVersionedLambda.js'
+import { LAMBDA_RUNTIMES } from '../base/ApplicationVersionedLambda.js';
 
 const config: PocketEventBridgeWithLambdaTargetProps = {
   name: 'test-event-bridge-lambda',

--- a/packages/terraform-modules/src/pocket/PocketPagerDuty.spec.ts
+++ b/packages/terraform-modules/src/pocket/PocketPagerDuty.spec.ts
@@ -1,5 +1,5 @@
 import { Testing } from 'cdktf';
-import { PocketPagerDuty, PocketPagerDutyProps } from './PocketPagerDuty.js'
+import { PocketPagerDuty, PocketPagerDutyProps } from './PocketPagerDuty.js';
 
 const config: PocketPagerDutyProps = {
   prefix: 'Test-Env',

--- a/packages/terraform-modules/src/pocket/PocketSQSWithLambdaTarget.spec.ts
+++ b/packages/terraform-modules/src/pocket/PocketSQSWithLambdaTarget.spec.ts
@@ -1,5 +1,5 @@
 import { TerraformStack, Testing } from 'cdktf';
-import { LAMBDA_RUNTIMES } from '../base/ApplicationVersionedLambda.js'
+import { LAMBDA_RUNTIMES } from '../base/ApplicationVersionedLambda.js';
 import {
   PocketSQSWithLambdaTarget,
   PocketSQSWithLambdaTargetProps,

--- a/packages/terraform-modules/src/pocket/PocketSynthetics.spec.ts
+++ b/packages/terraform-modules/src/pocket/PocketSynthetics.spec.ts
@@ -1,5 +1,8 @@
 import { Testing } from 'cdktf';
-import { PocketSyntheticProps, PocketSyntheticCheck } from './PocketSynthetics.js'
+import {
+  PocketSyntheticProps,
+  PocketSyntheticCheck,
+} from './PocketSynthetics.js';
 
 const config: PocketSyntheticProps = {
   uri: 'acme.getpocket.dev',

--- a/packages/terraform-modules/src/pocket/PocketVersionedLambda.spec.ts
+++ b/packages/terraform-modules/src/pocket/PocketVersionedLambda.spec.ts
@@ -3,7 +3,7 @@ import {
   PocketVersionedLambda,
   PocketVersionedLambdaProps,
 } from './PocketVersionedLambda';
-import { LAMBDA_RUNTIMES } from '../base/ApplicationVersionedLambda.js'
+import { LAMBDA_RUNTIMES } from '../base/ApplicationVersionedLambda.js';
 
 const config: PocketVersionedLambdaProps = {
   name: 'test-lambda',

--- a/packages/terraform-modules/src/pocket/PocketVersionedLambda.ts
+++ b/packages/terraform-modules/src/pocket/PocketVersionedLambda.ts
@@ -39,6 +39,7 @@ export interface PocketVersionedLambdaProps extends TerraformMetaArguments {
     reservedConcurrencyLimit?: number;
     memorySizeInMb?: number;
     environment?: { [key: string]: string };
+    ignoreEnvironmentVars?: string[];
     vpcConfig?: lambdaFunction.LambdaFunctionVpcConfig;
     executionPolicyStatements?: dataAwsIamPolicyDocument.DataAwsIamPolicyDocumentStatement[];
     logRetention?: number;
@@ -197,6 +198,7 @@ export class PocketVersionedLambda extends Construct {
       timeout: lambdaConfig.timeout,
       environment: lambdaConfig.environment,
       vpcConfig: lambdaConfig.vpcConfig,
+      ignoreEnvironmentVars: lambdaConfig.ignoreEnvironmentVars,
       executionPolicyStatements: lambdaConfig.executionPolicyStatements,
       logRetention: lambdaConfig.logRetention,
       s3Bucket:

--- a/packages/terraform-modules/src/pocket/__snapshots__/PocketApiGatewayLambdaIntegration.spec.ts.snap
+++ b/packages/terraform-modules/src/pocket/__snapshots__/PocketApiGatewayLambdaIntegration.spec.ts.snap
@@ -117,7 +117,6 @@ exports[`PocketApiGatewayLambdaIntegration renders an api gateway with a lambda 
         },
         "rest_api_id": "\${aws_api_gateway_rest_api.api-gateway-rest.id}",
         "triggers": {
-          "deployedAt": "1637693316456",
           "redeployment": "\${sha1(jsonencode({\\"resources\\" = [aws_api_gateway_integration.test-api-lambda_endpoint-integration_8D80A8F8.id, aws_api_gateway_method.test-api-lambda_endpoint-method_B2F73D1A.id, aws_api_gateway_resource.test-api-lambda_endpoint_02B05EB1.id, aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8.id]}))}"
         }
       }

--- a/packages/terraform-modules/src/pocket/__snapshots__/PocketApiGatewayLambdaIntegration.spec.ts.snap
+++ b/packages/terraform-modules/src/pocket/__snapshots__/PocketApiGatewayLambdaIntegration.spec.ts.snap
@@ -60,6 +60,20 @@ exports[`PocketApiGatewayLambdaIntegration renders an api gateway with a lambda 
       }
     }
   },
+  "output": {
+    "test-api-lambda_endpoint-lambda_lambda_arn_160BFD72": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-api-lambda_endpoint-lambda_3FA91964.arn}"
+    },
+    "test-api-lambda_endpoint-lambda_lambda_function_name_83D1A2F3": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-api-lambda_endpoint-lambda_3FA91964.function_name}"
+    },
+    "test-api-lambda_endpoint-lambda_lambda_version_arn_920D0E8C": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8.arn}"
+    }
+  },
   "resource": {
     "aws_acm_certificate": {
       "test-api-lambda_api-gateway-certificate_8D77B940": {

--- a/packages/terraform-modules/src/pocket/__snapshots__/PocketEventBridgeRuleWithMultipleTargets.spec.ts.snap
+++ b/packages/terraform-modules/src/pocket/__snapshots__/PocketEventBridgeRuleWithMultipleTargets.spec.ts.snap
@@ -55,6 +55,20 @@ exports[`PocketEventBridgeRuleWithMultipleTargets renders an event bridge and mu
       }
     }
   },
+  "output": {
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_event_rule": {
       "test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B": {

--- a/packages/terraform-modules/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
+++ b/packages/terraform-modules/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
@@ -55,6 +55,20 @@ exports[`renders an event bridge and lambda target with event bus name 1`] = `
       }
     }
   },
+  "output": {
+    "test-event-bridge-lambda_lambda_arn_96078D0A": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.arn}"
+    },
+    "test-event-bridge-lambda_lambda_function_name_D7307C54": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.function_name}"
+    },
+    "test-event-bridge-lambda_lambda_version_arn_96661CD8": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_event_rule": {
       "test-event-bridge-lambda_event-bridge-rule_529FF7C2": {
@@ -245,6 +259,20 @@ exports[`renders an event bridge and lambda target with rule description 1`] = `
         ],
         "version": "2012-10-17"
       }
+    }
+  },
+  "output": {
+    "test-event-bridge-lambda_lambda_arn_96078D0A": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.arn}"
+    },
+    "test-event-bridge-lambda_lambda_function_name_D7307C54": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.function_name}"
+    },
+    "test-event-bridge-lambda_lambda_version_arn_96661CD8": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.arn}"
     }
   },
   "resource": {

--- a/packages/terraform-modules/src/pocket/__snapshots__/PocketSQSWithLambdaTarget.spec.ts.snap
+++ b/packages/terraform-modules/src/pocket/__snapshots__/PocketSQSWithLambdaTarget.spec.ts.snap
@@ -77,6 +77,20 @@ exports[`renders a lambda triggered by an existing sqs queue 1`] = `
       }
     }
   },
+  "output": {
+    "test-sqs-lambda_lambda_arn_BFDEC9C8": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.arn}"
+    },
+    "test-sqs-lambda_lambda_function_name_E2ECB413": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}"
+    },
+    "test-sqs-lambda_lambda_version_arn_1B6A0BE0": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-sqs-lambda_alias_2C2A09A2.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_log_group": {
       "test-sqs-lambda_log-group_F69AB78F": {
@@ -269,6 +283,20 @@ exports[`renders a plain sqs queue and lambda target 1`] = `
           }
         ]
       }
+    }
+  },
+  "output": {
+    "test-sqs-lambda_lambda_arn_BFDEC9C8": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.arn}"
+    },
+    "test-sqs-lambda_lambda_function_name_E2ECB413": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}"
+    },
+    "test-sqs-lambda_lambda_version_arn_1B6A0BE0": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-sqs-lambda_alias_2C2A09A2.arn}"
     }
   },
   "resource": {
@@ -469,6 +497,20 @@ exports[`renders a plain sqs queue with a deadletter and lambda target 1`] = `
           }
         ]
       }
+    }
+  },
+  "output": {
+    "test-sqs-lambda_lambda_arn_BFDEC9C8": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.arn}"
+    },
+    "test-sqs-lambda_lambda_function_name_E2ECB413": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}"
+    },
+    "test-sqs-lambda_lambda_version_arn_1B6A0BE0": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-sqs-lambda_alias_2C2A09A2.arn}"
     }
   },
   "resource": {

--- a/packages/terraform-modules/src/pocket/__snapshots__/PocketVersionedLambda.spec.ts.snap
+++ b/packages/terraform-modules/src/pocket/__snapshots__/PocketVersionedLambda.spec.ts.snap
@@ -55,6 +55,20 @@ exports[`it can treat missing data as breaching 1`] = `
       }
     }
   },
+  "output": {
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_log_group": {
       "test-lambda_log-group_ACC182B5": {
@@ -236,6 +250,20 @@ exports[`renders a lambda target 1`] = `
       }
     }
   },
+  "output": {
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_log_group": {
       "test-lambda_log-group_ACC182B5": {
@@ -390,6 +418,20 @@ exports[`renders a lambda target with tags 1`] = `
         ],
         "version": "2012-10-17"
       }
+    }
+  },
+  "output": {
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
     }
   },
   "resource": {
@@ -566,6 +608,20 @@ exports[`renders a lambda with alarms 1`] = `
         ],
         "version": "2012-10-17"
       }
+    }
+  },
+  "output": {
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
     }
   },
   "resource": {
@@ -859,6 +915,28 @@ exports[`renders a lambda with code deploy 1`] = `
       }
     }
   },
+  "output": {
+    "test-lambda_lambda-code-deploy_lambda_codedeploy_app_58EECEC5": {
+      "description": "Lambda CodeDeploy App Name",
+      "value": "\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}"
+    },
+    "test-lambda_lambda-code-deploy_lambda_codedeploy_group_1AD43D58": {
+      "description": "Lambda CodeDeploy Group Name",
+      "value": "\${aws_codedeploy_deployment_group.test-lambda_lambda-code-deploy_code-deployment-group_07908CD9.deployment_group_name}"
+    },
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_log_group": {
       "test-lambda_log-group_ACC182B5": {
@@ -1087,6 +1165,28 @@ exports[`renders a lambda with code deploy with all deploy notifications turned 
       }
     }
   },
+  "output": {
+    "test-lambda_lambda-code-deploy_lambda_codedeploy_app_58EECEC5": {
+      "description": "Lambda CodeDeploy App Name",
+      "value": "\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}"
+    },
+    "test-lambda_lambda-code-deploy_lambda_codedeploy_group_1AD43D58": {
+      "description": "Lambda CodeDeploy Group Name",
+      "value": "\${aws_codedeploy_deployment_group.test-lambda_lambda-code-deploy_code-deployment-group_07908CD9.deployment_group_name}"
+    },
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_log_group": {
       "test-lambda_log-group_ACC182B5": {
@@ -1299,6 +1399,20 @@ exports[`renders a lambda with concurrencyLimit 1`] = `
       }
     }
   },
+  "output": {
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_log_group": {
       "test-lambda_log-group_ACC182B5": {
@@ -1453,6 +1567,20 @@ exports[`renders a lambda with environment variables 1`] = `
         ],
         "version": "2012-10-17"
       }
+    }
+  },
+  "output": {
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
     }
   },
   "resource": {
@@ -1626,6 +1754,20 @@ exports[`renders a lambda with execution policy 1`] = `
       }
     }
   },
+  "output": {
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_log_group": {
       "test-lambda_log-group_ACC182B5": {
@@ -1780,6 +1922,20 @@ exports[`renders a lambda with lambda description 1`] = `
         ],
         "version": "2012-10-17"
       }
+    }
+  },
+  "output": {
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
     }
   },
   "resource": {
@@ -1938,6 +2094,20 @@ exports[`renders a lambda with log retention 1`] = `
       }
     }
   },
+  "output": {
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_log_group": {
       "test-lambda_log-group_ACC182B5": {
@@ -2092,6 +2262,20 @@ exports[`renders a lambda with memorySizeInMb 1`] = `
         ],
         "version": "2012-10-17"
       }
+    }
+  },
+  "output": {
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
     }
   },
   "resource": {
@@ -2250,6 +2434,20 @@ exports[`renders a lambda with s3 bucket 1`] = `
       }
     }
   },
+  "output": {
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
+    }
+  },
   "resource": {
     "aws_cloudwatch_log_group": {
       "test-lambda_log-group_ACC182B5": {
@@ -2404,6 +2602,20 @@ exports[`renders a lambda with timeout 1`] = `
         ],
         "version": "2012-10-17"
       }
+    }
+  },
+  "output": {
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
     }
   },
   "resource": {
@@ -2573,6 +2785,20 @@ exports[`renders a lambda with vpc config 1`] = `
         ],
         "version": "2012-10-17"
       }
+    }
+  },
+  "output": {
+    "test-lambda_lambda_arn_DFC95AD9": {
+      "description": "Lambda Function ARN",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.arn}"
+    },
+    "test-lambda_lambda_function_name_9563C002": {
+      "description": "Lambda Function Name",
+      "value": "\${aws_lambda_function.test-lambda_8915D118.function_name}"
+    },
+    "test-lambda_lambda_version_arn_A02B37A5": {
+      "description": "Lambda Version ARN",
+      "value": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.arn}"
     }
   },
   "resource": {

--- a/packages/terraform-modules/src/utilities.jest.ts
+++ b/packages/terraform-modules/src/utilities.jest.ts
@@ -1,4 +1,4 @@
-import { getRootDomain, truncateString } from './utilities.js'
+import { getRootDomain, truncateString } from './utilities.js';
 
 describe('utilities', () => {
   describe('getRootDomain()', () => {

--- a/packages/ts-logger/src/logger.ts
+++ b/packages/ts-logger/src/logger.ts
@@ -75,7 +75,7 @@ export function createLogger(options: LoggerOptions | undefined = {}): Logger {
   };
 
   const enchancedDefaultMeta = {
-    releaseSha: process.env.RELEASE_SHA || null,
+    releaseSha: process.env.RELEASE_SHA || process.env.GIT_SHA || null,
     ...options.defaultMeta,
   };
 


### PR DESCRIPTION
## Goal

Make it so that Lambda deploys happen like ECS deploys in https://github.com/Pocket/pocket-monorepo/pull/324

This should lessen the commenting by the pocket-ci bot unless there is actually a change we should verify.