### PR TITLE
chore(turbo): make turbo repo performant based on inputs and outputs

### DIFF
--- a/.circleci/common.yml
+++ b/.circleci/common.yml
@@ -144,23 +144,43 @@ commands:
 
   install_pnpm:  
     steps:
+      - restore_cache:
+          name: Restore pnpm Package Cache
+          keys:
+            - pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
       - run:
           name: Install pnpm package manager
           command: |
             corepack prepare pnpm@latest-8 --activate
+            pnpm config set store-dir .pnpm-store
       - run:  
           name: Install Dependencies
           command: |
             pnpm install
+      - save_cache:
+          name: Save pnpm Package Cache
+          key: pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
+          paths:
+            - .pnpm-store
   install_infrastructure_pnpm:
     steps:
+      - restore_cache:
+          name: Restore pnpm Package Cache
+          keys:
+            - pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
       - run: 
           name: Install and setup node
           command: |
             nvm install
             nvm use
-            npm install -g pnpm   
-            pnpm install     
+            npm install -g pnpm
+            pnpm config set store-dir .pnpm-store
+            pnpm install    
+      - save_cache:
+          name: Save pnpm Package Cache
+          key: pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
+          paths:
+            - .pnpm-store 
   install_codebuild_secrets:
     steps:
       - run: 

--- a/.circleci/repo-jobs.yml
+++ b/.circleci/repo-jobs.yml
@@ -7,9 +7,8 @@ jobs:
       - install_pnpm
       - run:
           name: Lint
-          # Need to build first, so the linter picks up all needed imports
           command: |
-            pnpm run lint --concurrency=1
+            pnpm run lint
 
   mismatched_versions:
     docker:

--- a/.circleci/repo-jobs.yml
+++ b/.circleci/repo-jobs.yml
@@ -31,7 +31,7 @@ jobs:
       - run:
           name: Test
           command: |
-            pnpm run test --concurrency=2
+            pnpm run test
 
 workflows:
   repo:

--- a/.circleci/repo-jobs.yml
+++ b/.circleci/repo-jobs.yml
@@ -30,8 +30,9 @@ jobs:
       - install_pnpm
       - run:
           name: Test
+          # Following uses a 2 concurrency because terraform modules seems to fail with an OOM error on CI if we do more.
           command: |
-            pnpm run test
+            pnpm run test --concurrency=2 
 
 workflows:
   repo:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ Where annotations-api is the server name from package.json you want to run. `...
 You can expand this to run multiple specific servers as well like:
 ```pnpm run dev --filter=list-api... --filter=feature-flags...```
 
+### Caching
+
+This repo relies on Turbo repos caching strategies to speed up development and only execute tasks that are needed when certain files change.
+
+More information can be found on [Turbo repos site](https://turbo.build/repo/docs/core-concepts/caching).
+
+If you add new build outputs or inputs, you will need to add them to the necessary area in [turbo.json](./turbo.json).
+
+If for any reason you need to bypass caching you can add `--force` to any command. It would be run like:
+
+```bash
+pnpm run test --force
+```
+
+or
+
+```bash
+pnpm run test --filter=annocations-api... --force
+```
+
 ### Testing
 
 ### Updating Packages

--- a/infrastructure/account-data-deleter/package.json
+++ b/infrastructure/account-data-deleter/package.json
@@ -10,8 +10,7 @@
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
     "watch": "tsc -w",
-    "test": "echo ok",
-    "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
+    "lint":  "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },
   "dependencies": {

--- a/infrastructure/account-delete-monitor/package.json
+++ b/infrastructure/account-delete-monitor/package.json
@@ -9,8 +9,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/infrastructure/annotations-api/package.json
+++ b/infrastructure/annotations-api/package.json
@@ -9,8 +9,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/infrastructure/braze/package.json
+++ b/infrastructure/braze/package.json
@@ -9,8 +9,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/infrastructure/client-api/package.json
+++ b/infrastructure/client-api/package.json
@@ -8,8 +8,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/infrastructure/feature-flags/package.json
+++ b/infrastructure/feature-flags/package.json
@@ -8,8 +8,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/infrastructure/fxa-webhook-proxy/package.json
+++ b/infrastructure/fxa-webhook-proxy/package.json
@@ -9,8 +9,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/infrastructure/image-api/package.json
+++ b/infrastructure/image-api/package.json
@@ -8,8 +8,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/infrastructure/list-api/package.json
+++ b/infrastructure/list-api/package.json
@@ -8,8 +8,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/infrastructure/parser-graphql-wrapper/package.json
+++ b/infrastructure/parser-graphql-wrapper/package.json
@@ -9,8 +9,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/infrastructure/pocket-event-bridge/package.json
+++ b/infrastructure/pocket-event-bridge/package.json
@@ -9,8 +9,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/infrastructure/push-server/package.json
+++ b/infrastructure/push-server/package.json
@@ -8,8 +8,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/infrastructure/sendgrid-data/package.json
+++ b/infrastructure/sendgrid-data/package.json
@@ -9,8 +9,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/infrastructure/shareable-lists-api/package.json
+++ b/infrastructure/shareable-lists-api/package.json
@@ -7,8 +7,7 @@
   "private": true,
   "scripts": {
     "build": "rm -rf dist && tsc",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\"",
     "synth": "cdktf synth",

--- a/infrastructure/shared-snowplow-consumer/package.json
+++ b/infrastructure/shared-snowplow-consumer/package.json
@@ -9,8 +9,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/infrastructure/transactional-emails/package.json
+++ b/infrastructure/transactional-emails/package.json
@@ -9,8 +9,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/infrastructure/user-api/package.json
+++ b/infrastructure/user-api/package.json
@@ -8,8 +8,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/infrastructure/v3-proxy-api/package.json
+++ b/infrastructure/v3-proxy-api/package.json
@@ -9,8 +9,7 @@
     "build": "rm -rf dist && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
+    "watch": "tsc -w", 
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\""
   },

--- a/servers/push-server/package.json
+++ b/servers/push-server/package.json
@@ -19,7 +19,6 @@
   "scripts": {
     "start": "node -r dotenv/config dist/index.js",
     "build": "rm -rf dist && tsc",
-    "test": "echo ok",
     "dev": "npm run build && npm run watch",
     "test-integrations": "jest \"\\.integration\\.ts\" --runInBand --forceExit",
     "test:watch": "npm test -- --watchAll",

--- a/turbo.json
+++ b/turbo.json
@@ -12,8 +12,8 @@
     },
     "synth": {
       "dependsOn": ["^build", "build"],
-      "inputs": ["src/**/*", "package.json", "cdktf.json", ".terraform-version", "cdktf.out/**/*"],
-      "outputs": ["cdktf.out/**"]
+      "inputs": ["src/**/*", "package.json", "cdktf.json", ".terraform-version"],
+      "outputs": ["cdktf.out/**/*"]
     },
     "lint": {
       "inputs": ["src/**/*", ".eslintrc.js", "package.json"],

--- a/turbo.json
+++ b/turbo.json
@@ -12,10 +12,10 @@
       "outputs": ["cdktf.out/**"]
     },
     "lint": {
-      "dependsOn": ["^build", "build"]
+      "dependsOn": ["^build", "prebuild"]
     },
     "format": {
-      "dependsOn": ["^build", "build"]
+      "dependsOn": ["^build", "prebuild"]
     },
     "semantic-release": {
       "dependsOn": ["^build", "build"]

--- a/turbo.json
+++ b/turbo.json
@@ -1,27 +1,35 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local", "packages/tsconfig/**"],
+  "globalEnv": ["NODE_ENV"],
   "globalDotEnv": [".env", ".env.example"],
   "pipeline": {
     "build": {
       "dependsOn": ["prebuild", "^build"],
-      "outputs": ["dist/**"]
+      "inputs": ["src/**/*", "tsconfig.json", "package.json"],
+      "outputs": ["dist/**"],
+      "cache": true
     },
     "synth": {
       "dependsOn": ["^build", "build"],
+      "inputs": ["src/**/*", "package.json", "cdktf.json", ".terraform-version"],
       "outputs": ["cdktf.out/**"]
     },
     "lint": {
+      "inputs": ["src/**/*", ".eslintrc.js", "package.json"],
       "dependsOn": ["^build", "prebuild"]
     },
     "format": {
+      "inputs": ["src/**/*", ".eslintrc.js", "package.json"],
       "dependsOn": ["^build", "prebuild"]
     },
     "semantic-release": {
       "dependsOn": ["^build", "build"]
     },
     "test": {
-      "dependsOn": ["^build", "build"]
+      "inputs": ["src/**/*", "package.json", "jest.config.js", "jest.setup.js"],
+      "dependsOn": ["^build", "build"],
+      "cache": true
     },
     "test-integrations": {
       "dependsOn": ["^build", "build", "pretest"],
@@ -32,7 +40,9 @@
       "persistent": true
     },
     "prebuild": {
-      "cache": false
+      "inputs": ["schema-public.graphql", "schema-shared.graphql", "schema-admin.graphql", "prisma/schema.prisma", "src/graphql/**/*.graphql", "codegen.ts"],
+      "outputs": ["schema-admin-api.graphql", "schema-client-api.graphql", "prisma/src/**/*", "src/generated/**/*"],
+      "cache": true
     },
     "pretest": {
       "cache": false

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,7 @@
       "cache": true
     },
     "synth": {
-      "dependsOn": ["^build", "build"],
+      "dependsOn": ["@pocket-tools/terraform-modules#build"],
       "inputs": ["src/**/*", "package.json", "cdktf.json", ".terraform-version"],
       "outputs": ["cdktf.out/**/*"]
     },

--- a/turbo.json
+++ b/turbo.json
@@ -28,11 +28,11 @@
     },
     "test": {
       "inputs": ["src/**/*", "package.json", "jest.config.js", "jest.setup.js"],
-      "dependsOn": ["^build", "build"],
+      "dependsOn": ["^build", "prebuild"],
       "cache": true
     },
     "test-integrations": {
-      "dependsOn": ["^build", "build", "pretest"],
+      "dependsOn": ["^build", "prebuild", "pretest"],
       "cache": false
     },
     "dev": {

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,7 @@
     },
     "synth": {
       "dependsOn": ["^build", "build"],
-      "inputs": ["src/**/*", "package.json", "cdktf.json", ".terraform-version"],
+      "inputs": ["src/**/*", "package.json", "cdktf.json", ".terraform-version", "cdktf.out/**/*"],
       "outputs": ["cdktf.out/**"]
     },
     "lint": {


### PR DESCRIPTION
## Goal

Optimize turbo repo so that at least locally we are only building/processing things that actually changed.

This does the following:
* Changes the test/test-integration/lint/format jobs to only need `prebuild` and not `build` which was buiilding all the code unnecessarily
* Removed the concurrency limit on `lint` in CI, still need it on `test` due to OOM in terraform-modules...
* Adds a cache step to pnpm in circleci
* Adds all the possible inputs and outputs to each turbo repo job to calculate cache hashes
* Adds `NODE_ENV` to turbo repo so that its value is considered for all job cache hashes
* Removes just echo tests

What this pr does not do and will be in followup:
* restore and save off the turbo repo cache. This may take some work, or for us to buy [Vercel's remote caching](https://vercel.com/docs/monorepos/remote-caching) or host our own. The issue is not only do we need to cache the turbo repo cache folders, but also all the build output caches. 🤔 


Wins:
* CI Lint job is now 2 minutes down from 8
* CI Test job is now 3 minutes down from 10.
* Local test/lint/build/etc now fully utilizes the cache