### PR TITLE
chore(cleanup): removing deploy params

### DIFF
--- a/.circleci/account-data-deleter.yml
+++ b/.circleci/account-data-deleter.yml
@@ -185,20 +185,6 @@ workflows:
             - account-data-deleter_batch-delete_code_deploy_dev
             - account-data-deleter_code_deploy_ecs_dev
 
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: account-data-deleter_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: AccountDataDeleter
-          requires:
-            - account-data-deleter_events_code_deploy_dev
-            - account-data-deleter_batch-delete_code_deploy_dev
-            - account-data-deleter_code_deploy_ecs_dev
-
       ######
       # Main Branch Deployment (Prod Environment)
       ######
@@ -306,20 +292,6 @@ workflows:
           sentry_project_name: account-data-deleter
           sentry_env: prodelopment
           sentry_org: pocket
-          requires:
-            - account-data-deleter_events_code_deploy_prod
-            - account-data-deleter_batch-delete_code_deploy_prod
-            - account-data-deleter_code_deploy_ecs_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: account-data-deleter_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: AccountDataDeleter
           requires:
             - account-data-deleter_events_code_deploy_prod
             - account-data-deleter_batch-delete_code_deploy_prod

--- a/.circleci/account-delete-monitor.yml
+++ b/.circleci/account-delete-monitor.yml
@@ -93,18 +93,6 @@ workflows:
           requires:
             - account-delete-monitor_code_deploy_lambda_dev
 
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: account-delete-monitor_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: AccountDeleteMonitor
-          requires:
-            - account-delete-monitor_code_deploy_lambda_dev
-
       ######
       # Main Branch Deployment (Prod Environment)
       ######
@@ -157,17 +145,5 @@ workflows:
           sentry_project_name: account-delete-monitor
           sentry_env: production
           sentry_org: pocket
-          requires:
-            - account-delete-monitor_code_deploy_lambda_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: account-delete-monitor_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: AccountDeleteMonitor
           requires:
             - account-delete-monitor_code_deploy_lambda_prod

--- a/.circleci/annotations-api.yml
+++ b/.circleci/annotations-api.yml
@@ -142,19 +142,6 @@ workflows:
             - annotations-api_code_deploy_ecs_dev
             - annotations-api_events_code_deploy_lambda_dev
 
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: annotations-api_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: AnnotationsAPI
-          requires:
-            - annotations-api_code_deploy_ecs_dev
-            - annotations-api_events_code_deploy_lambda_dev
-
       ######
       # Main Branch Deployment (Prod Environment)
       ######
@@ -232,19 +219,6 @@ workflows:
           sentry_project_name: annotations-api
           sentry_env: production
           sentry_org: pocket
-          requires:
-            - annotations-api_code_deploy_ecs_prod
-            - annotations-api_events_code_deploy_lambda_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: annotations-api_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: AnnotationsAPI
           requires:
             - annotations-api_code_deploy_ecs_prod
             - annotations-api_events_code_deploy_lambda_prod

--- a/.circleci/common.yml
+++ b/.circleci/common.yml
@@ -939,38 +939,3 @@ jobs:
           command: |
             source "$BASH_ENV"
             sentry-cli releases deploys "$CIRCLE_SHA1" new -e "<< parameters.sentry_env >>"
-
-  setup_deploy_params:
-    description: Sets up the CircleCI variables in AWS using the service name and env that is passed
-    parameters:
-      service_name:
-        description: Service Name
-        type: string
-      env:
-        description: Environment of the service
-        type: string
-      aws_access_key_id:
-        type: env_var_name
-        default: AWS_ACCESS_KEY_ID
-        description: AWS access key id for IAM role
-      aws_secret_access_key:
-        type: env_var_name
-        default: AWS_SECRET_ACCESS_KEY
-        description: AWS secret key for IAM role
-    docker:
-      - image: amazon/aws-cli:latest@sha256:1ac1d86b8b03082fa47fd89ebc624f9720aa68e4fe9ac36a71a4d6541a5e76b8
-        auth:
-          username: $DOCKER_LOGIN
-          password: $DOCKER_PASSWORD
-        environment:
-          TERM: xterm
-
-    steps:
-      - run:
-          name: Put SSM Parameters
-          command: |
-            export AWS_ACCESS_KEY_ID="${<< parameters.aws_access_key_id >>}"
-            export AWS_SECRET_ACCESS_KEY="${<< parameters.aws_secret_access_key >>}"
-            aws ssm put-parameter --name "/<< parameters.service_name >>/CircleCI/<< parameters.env >>/BUILD_BRANCH" --type "SecureString" --value "${CIRCLE_BRANCH}" --overwrite
-            aws ssm put-parameter --name "/<< parameters.service_name >>/CircleCI/<< parameters.env >>/SERVICE_VERSION" --type "SecureString" --value "${CIRCLE_BUILD_NUM}" --overwrite
-            aws ssm put-parameter --name "/<< parameters.service_name >>/CircleCI/<< parameters.env >>/SERVICE_HASH" --type "SecureString" --value "${CIRCLE_SHA1}" --overwrite

--- a/.circleci/feature-flags.yml
+++ b/.circleci/feature-flags.yml
@@ -90,19 +90,6 @@ workflows:
           sentry_org: pocket
           requires:
             - feature-flags_code_deploy_ecs_dev
-     
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: feature-flags_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: FeatureFlags
-          requires:
-            - feature-flags_code_deploy_ecs_dev
-
 
       ######
       # Main Branch Deployment (Prod Environment)
@@ -152,17 +139,5 @@ workflows:
           sentry_project_name: feature-flags
           sentry_env: production
           sentry_org: pocket
-          requires:
-            - feature-flags_code_deploy_ecs_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: feature-flags_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: FeatureFlags
           requires:
             - feature-flags_code_deploy_ecs_prod

--- a/.circleci/fxa-webhook-proxy.yml
+++ b/.circleci/fxa-webhook-proxy.yml
@@ -130,19 +130,6 @@ workflows:
             - fxa-webhook-proxy_sqs_code_deploy_lambda_dev
             - fxa-webhook-proxy_gateway_code_deploy_lambda_dev
 
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: fxa-webhook-proxy_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: FxAWebhookProxy
-          requires:
-            - fxa-webhook-proxy_sqs_code_deploy_lambda_dev
-            - fxa-webhook-proxy_gateway_code_deploy_lambda_dev
-
       ######
       # Main Branch Deployment (Prod Environment)
       ######
@@ -225,19 +212,6 @@ workflows:
           sentry_project_name: fxa-webhook-proxy
           sentry_env: prodelopment
           sentry_org: pocket
-          requires:
-            - fxa-webhook-proxy_sqs_code_deploy_lambda_prod
-            - fxa-webhook-proxy_gateway_code_deploy_lambda_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: fxa-webhook-proxy_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: FxAWebhookProxy
           requires:
             - fxa-webhook-proxy_sqs_code_deploy_lambda_prod
             - fxa-webhook-proxy_gateway_code_deploy_lambda_prod

--- a/.circleci/image-api.yml
+++ b/.circleci/image-api.yml
@@ -106,19 +106,6 @@ workflows:
           sentry_org: pocket
           requires:
             - image-api_code_deploy_ecs_dev
-     
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: image-api_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: ImageAPI
-          requires:
-            - image-api_code_deploy_ecs_dev
-
 
       ######
       # Main Branch Deployment (Prod Environment)
@@ -168,17 +155,5 @@ workflows:
           sentry_project_name: image-api
           sentry_env: production
           sentry_org: pocket
-          requires:
-            - image-api_code_deploy_ecs_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: image-api_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: ImageAPI
           requires:
             - image-api_code_deploy_ecs_prod

--- a/.circleci/list-api.yml
+++ b/.circleci/list-api.yml
@@ -99,19 +99,6 @@ workflows:
           sentry_org: pocket
           requires:
             - list-api_code_deploy_ecs_dev
-     
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: list-api_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: ListAPI
-          requires:
-            - list-api_code_deploy_ecs_dev
-
 
       ######
       # Main Branch Deployment (Prod Environment)
@@ -161,17 +148,5 @@ workflows:
           sentry_project_name: list-api
           sentry_env: production
           sentry_org: pocket
-          requires:
-            - list-api_code_deploy_ecs_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: list-api_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: ListAPI
           requires:
             - list-api_code_deploy_ecs_prod

--- a/.circleci/parser-graphql-wrapper.yml
+++ b/.circleci/parser-graphql-wrapper.yml
@@ -106,19 +106,6 @@ workflows:
           sentry_org: pocket
           requires:
             - parser-graphql-wrapper_code_deploy_ecs_dev
-     
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: parser-graphql-wrapper_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: ParserGraphQLWrapper
-          requires:
-            - parser-graphql-wrapper_code_deploy_ecs_dev
-
 
       ######
       # Main Branch Deployment (Prod Environment)
@@ -168,17 +155,5 @@ workflows:
           sentry_project_name: parser-graphql-wrapper
           sentry_env: production
           sentry_org: pocket
-          requires:
-            - parser-graphql-wrapper_code_deploy_ecs_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: parser-graphql-wrapper_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: ParserGraphQLWrapper
           requires:
             - parser-graphql-wrapper_code_deploy_ecs_prod

--- a/.circleci/push-server.yml
+++ b/.circleci/push-server.yml
@@ -80,19 +80,6 @@ workflows:
           sentry_org: pocket
           requires:
             - push-server_infrastructure_apply_dev
-     
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: push-server_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: Push
-          requires:
-            - push-server_infrastructure_apply_dev
-
 
       ######
       # Main Branch Deployment (Prod Environment)
@@ -133,17 +120,5 @@ workflows:
           sentry_project_name: push-server
           sentry_env: production
           sentry_org: pocket
-          requires:
-            - push-server_infrastructure_apply_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: push-server_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: Push
           requires:
             - push-server_infrastructure_apply_prod

--- a/.circleci/sendgrid-data.yml
+++ b/.circleci/sendgrid-data.yml
@@ -87,18 +87,6 @@ workflows:
           requires:
             - sendgrid-data_code_deploy_lambda_dev
 
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: sendgrid-data_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: SendGridData
-          requires:
-            - sendgrid-data_code_deploy_lambda_dev
-
       ######
       # Main Branch Deployment (Prod Environment)
       ######
@@ -151,17 +139,5 @@ workflows:
           sentry_project_name: sendgrid-data
           sentry_env: prodelopment
           sentry_org: pocket
-          requires:
-            - sendgrid-data_code_deploy_lambda_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: sendgrid-data_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: SendGridData
           requires:
             - sendgrid-data_code_deploy_lambda_prod

--- a/.circleci/shareable-lists-api.yml
+++ b/.circleci/shareable-lists-api.yml
@@ -152,19 +152,6 @@ workflows:
             - shareable-lists-api_code_deploy_ecs_dev
             - shareable-lists-api_events_code_deploy_lambda_dev
 
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: shareable-lists-api_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: ShareableListsApi
-          requires:
-            - shareable-lists-api_code_deploy_ecs_dev
-            - shareable-lists-api_events_code_deploy_lambda_dev
-
       ######
       # Main Branch Deployment (Prod Environment)
       ######
@@ -242,19 +229,6 @@ workflows:
           sentry_project_name: shareable-lists-api
           sentry_env: production
           sentry_org: pocket
-          requires:
-            - shareable-lists-api_code_deploy_ecs_prod
-            - shareable-lists-api_events_code_deploy_lambda_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: shareable-lists-api_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: ShareableListsApi
           requires:
             - shareable-lists-api_code_deploy_ecs_prod
             - shareable-lists-api_events_code_deploy_lambda_prod

--- a/.circleci/shared-snowplow-consumer.yml
+++ b/.circleci/shared-snowplow-consumer.yml
@@ -90,19 +90,6 @@ workflows:
           sentry_org: pocket
           requires:
             - shared-snowplow-consumer_code_deploy_ecs_dev
-     
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: shared-snowplow-consumer_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: SharedSnowplowConsumer
-          requires:
-            - shared-snowplow-consumer_code_deploy_ecs_dev
-
 
       ######
       # Main Branch Deployment (Prod Environment)
@@ -152,17 +139,5 @@ workflows:
           sentry_project_name: shared-snowplow-consumer
           sentry_env: production
           sentry_org: pocket
-          requires:
-            - shared-snowplow-consumer_code_deploy_ecs_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: shared-snowplow-consumer_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: SharedSnowplowConsumer
           requires:
             - shared-snowplow-consumer_code_deploy_ecs_prod

--- a/.circleci/transactional-emails.yml
+++ b/.circleci/transactional-emails.yml
@@ -86,18 +86,6 @@ workflows:
           requires:
             - transactional-emails_events_code_deploy_lambda_dev
 
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: transactional-emails_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: TransactionalEmails
-          requires:
-            - transactional-emails_events_code_deploy_lambda_dev
-
       ######
       # Main Branch Deployment (Prod Environment)
       ######
@@ -150,17 +138,5 @@ workflows:
           sentry_project_name: transactional-emails
           sentry_env: production
           sentry_org: pocket
-          requires:
-            - transactional-emails_events_code_deploy_lambda_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: transactional-emails_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: TransactionalEmails
           requires:
             - transactional-emails_events_code_deploy_lambda_prod

--- a/.circleci/user-api.yml
+++ b/.circleci/user-api.yml
@@ -97,19 +97,6 @@ workflows:
           sentry_org: pocket
           requires:
             - user-api_code_deploy_ecs_dev
-     
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: user-api_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: UserAPI
-          requires:
-            - user-api_code_deploy_ecs_dev
-
 
       ######
       # Main Branch Deployment (Prod Environment)
@@ -159,17 +146,5 @@ workflows:
           sentry_project_name: user-api
           sentry_env: production
           sentry_org: pocket
-          requires:
-            - user-api_code_deploy_ecs_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: user-api_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: UserAPI
           requires:
             - user-api_code_deploy_ecs_prod

--- a/.circleci/user-list-search.yml
+++ b/.circleci/user-list-search.yml
@@ -296,27 +296,6 @@ workflows:
             - user-list-search_user-list-import_code_deploy_lambda_dev
             - user-list-search_user-list-import-backfill_code_deploy_lambda_dev
 
-     
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: user-list-search_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: UserListSearch
-          requires:
-            - user-list-search_code_deploy_ecs_dev
-            - user-list-search_events_code_deploy_lambda_dev
-            - user-list-search_kinesis_code_deploy_lambda_dev
-            - user-list-search_item-update_code_deploy_lambda_dev
-            - user-list-search_item-delete_code_deploy_lambda_dev
-            - user-list-search_item-update-backfill_code_deploy_lambda_dev
-            - user-list-search_user-list-import_code_deploy_lambda_dev
-            - user-list-search_user-list-import-backfill_code_deploy_lambda_dev
-
-
       ######
       # Main Branch Deployment (Prod Environment)
       ######
@@ -515,25 +494,6 @@ workflows:
           sentry_project_name: user-list-search
           sentry_env: production
           sentry_org: pocket
-          requires:
-            - user-list-search_code_deploy_ecs_prod
-            - user-list-search_events_code_deploy_lambda_prod
-            - user-list-search_kinesis_code_deploy_lambda_prod
-            - user-list-search_item-update_code_deploy_lambda_prod
-            - user-list-search_item-delete_code_deploy_lambda_prod
-            - user-list-search_item-update-backfill_code_deploy_lambda_prod
-            - user-list-search_user-list-import_code_deploy_lambda_prod
-            - user-list-search_user-list-import-backfill_code_deploy_lambda_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: user-list-search_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: UserListSearch
           requires:
             - user-list-search_code_deploy_ecs_prod
             - user-list-search_events_code_deploy_lambda_prod

--- a/.circleci/v3-proxy-api.yml
+++ b/.circleci/v3-proxy-api.yml
@@ -89,19 +89,6 @@ workflows:
           sentry_org: pocket
           requires:
             - v3-proxy-api_code_deploy_ecs_dev
-     
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_dev
-          name: v3-proxy-api_deploy-params-dev
-          aws_access_key_id: Dev_AWS_ACCESS_KEY
-          aws_secret_access_key: Dev_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Dev
-          service_name: V3ProxyApi
-          requires:
-            - v3-proxy-api_code_deploy_ecs_dev
-
 
       ######
       # Main Branch Deployment (Prod Environment)
@@ -151,17 +138,5 @@ workflows:
           sentry_project_name: v3-proxy-api
           sentry_env: production
           sentry_org: pocket
-          requires:
-            - v3-proxy-api_code_deploy_ecs_prod
-
-      # Setup params we may use in Lambdas
-      - setup_deploy_params:
-          <<: *only_main
-          name: v3-proxy-api_deploy-params-prod
-          aws_access_key_id: Prod_AWS_ACCESS_KEY
-          aws_secret_access_key: Prod_AWS_SECRET_ACCESS_KEY
-          context: pocket
-          env: Prod
-          service_name: V3ProxyApi
           requires:
             - v3-proxy-api_code_deploy_ecs_prod


### PR DESCRIPTION
## Goal

Lambda's used to rely on CircleCI pushing parameters to SSM.  With our new deploy setup these are no longer needed since CodeDeploy will set these when needed.