### PR TITLE
chore(upgrade): upgrading feature flag database

### DIFF
--- a/infrastructure/feature-flags/src/main.ts
+++ b/infrastructure/feature-flags/src/main.ts
@@ -91,11 +91,12 @@ class FeatureFlags extends TerraformStack {
         databaseName: 'featureflags',
         masterUsername: 'pkt_fflags',
         engine: 'aurora-postgresql',
-        engineMode: 'serverless',
-        scalingConfiguration: {
+        engineMode: 'provisioned',
+        engineVersion: '16.1',
+        createServerlessV2Instance: true,
+        serverlessv2ScalingConfiguration: {
           minCapacity: config.rds.minCapacity,
           maxCapacity: config.rds.maxCapacity,
-          autoPause: false,
         },
       },
 

--- a/scripts/convert-auroraV1-to-V2-postgres.sh
+++ b/scripts/convert-auroraV1-to-V2-postgres.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+set -xe
+# Script to convert a serverless v1 mysql to serverless v2
+# Steps from https://aws.amazon.com/blogs/database/upgrade-from-amazon-aurora-serverless-v1-to-v2-with-minimal-downtime/
+
+DATABASE_IDENTIFIER=
+GREEN_DATABASE_IDENTIFIER=
+SMALL_DATABASE_IDENTITER=
+ACCOUNT_ID=
+REGION=us-east-1
+
+# Set AWS_PAGER to an empty string to disable the pager
+export AWS_PAGER=""
+
+echo 'creating new replication param groups'
+aws rds create-db-cluster-parameter-group \
+ --db-cluster-parameter-group-name aurora-postgres-with-replication \
+ --description 'Aurora Postgres 11 With Replication Enabled' \
+ --db-parameter-group-family aurora-postgresql11 \
+ --no-paginate
+
+aws rds modify-db-cluster-parameter-group \
+ --db-cluster-parameter-group-name aurora-postgres-with-replication \
+ --parameters 'ParameterName=rds.logical_replication,ParameterValue=1,ApplyMethod=pending-reboot' \
+ --no-paginate
+
+echo 'attaching new param group'
+
+aws rds modify-db-cluster \
+ --db-cluster-identifier $DATABASE_IDENTIFIER \
+ --db-cluster-parameter-group-name aurora-postgres-with-replication \
+ --apply-immediately \
+ --no-paginate
+
+echo "According to Amazon there needs to be a more then 10 minute delay between these too operations, so we wait 15 minutes now to be safe."
+sleep 900
+
+
+echo 'mopdifiying to provisioned'
+output=$(aws rds modify-db-cluster --db-cluster-identifier $DATABASE_IDENTIFIER -engine-mode provisioned --allow-engine-mode-change --db-cluster-instance-class db.r5.xlarge --apply-immediately --no-paginate )
+PROVISINED_INSTANCE_IDENTIFIER=$(echo $output | jq -r '.DBCluster.DBClusterMembers[0].DBInstanceIdentifier')
+
+ aws rds wait db-instance-available \
+ --db-instance-identifier $PROVISINED_INSTANCE_IDENTIFIER \
+ --no-paginate
+
+aws rds wait db-cluster-available \
+ --db-cluster-identifier $DATABASE_IDENTIFIER \
+ --no-paginate
+
+# # Execute the create-blue-green-deployment command
+deployment_output=$(aws rds create-blue-green-deployment \
+  --source arn:aws:rds:$REGION:$ACCOUNT_ID:cluster:$DATABASE_IDENTIFIER \
+  --blue-green-deployment-name $GREEN_DATABASE_IDENTIFIER \
+  --target-engine-version 16.1 \
+  --target-db-cluster-parameter-group-name default.aurora-postgresql16 \
+  --no-paginate)
+
+# Extract the DB cluster identifier from the output
+blue_green_deployment_id=$(echo $deployment_output | jq -r '.BlueGreenDeployment.BlueGreenDeploymentIdentifier')
+
+# Function to check the status of the blue-green deployment
+check_green_deployment_status() {
+    blue_green_check=$(aws rds describe-blue-green-deployments --filters Name=blue-green-deployment-identifier,Values=$blue_green_deployment_id)
+    status=$(echo $blue_green_check | jq -r '.BlueGreenDeployments[0].Status')
+    echo "Deployment Status: $status"
+}
+
+# Wait for the blue-green deployment to be in a desired state (e.g., "available")
+while true; do
+    check_green_deployment_status
+    if [ "$status" == "AVAILABLE" ]; then
+        echo "Blue-Green Deployment Complete!"
+        green_cluster_id=$(echo $blue_green_check | jq -r '.BlueGreenDeployments[0].Target' | sed "s/arn:aws:rds:$REGION:$ACCOUNT_ID:cluster://g")
+        break
+    fi
+    sleep 30  # Adjust the sleep duration as needed
+done
+
+echo 'enabling v2 scaling'
+aws rds modify-db-cluster \
+ --db-cluster-identifier $green_cluster_id \
+ --serverless-v2-scaling-configuration MinCapacity=4,MaxCapacity=32 \
+ --no-paginate
+
+echo 'creating v2 instance'
+ aws rds create-db-instance \
+ --db-instance-identifier $SMALL_DATABASE_IDENTITER-serverless \
+ --db-instance-class db.serverless \
+ --engine aurora-mysql \
+ --db-cluster-identifier $green_cluster_id \
+ --no-paginate
+
+aws rds wait db-instance-available \
+ --db-instance-identifier $SMALL_DATABASE_IDENTITER-serverless \
+ --no-paginate
+
+echo 'failing green database over' 
+aws rds failover-db-cluster \
+ --db-cluster-identifier $green_cluster_id \
+ --target-db-instance-identifier $SMALL_DATABASE_IDENTITER-serverless \
+ --no-paginate
+
+aws rds wait db-cluster-available \
+ --db-cluster-identifier $green_cluster_id \
+ --no-paginate
+
+echo 'Go ahead and remove the first instance'
+echo 'Ready! switch over in the console!'

--- a/scripts/convert-auroraV1-to-V2-postgres.sh
+++ b/scripts/convert-auroraV1-to-V2-postgres.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -xe
-# Script to convert a serverless v1 mysql to serverless v2
+# Script to convert a serverless v1 postgresql to serverless v2
 # Steps from https://aws.amazon.com/blogs/database/upgrade-from-amazon-aurora-serverless-v1-to-v2-with-minimal-downtime/
 
 DATABASE_IDENTIFIER=
-GREEN_DATABASE_IDENTIFIER=
-SMALL_DATABASE_IDENTITER=
+GREEN_DATABASE_IDENTIFIER=featureflags-dev-green
+SMALL_DATABASE_IDENTITER=featureflags-dev
 ACCOUNT_ID=
 REGION=us-east-1
 
@@ -15,8 +15,8 @@ export AWS_PAGER=""
 echo 'creating new replication param groups'
 aws rds create-db-cluster-parameter-group \
  --db-cluster-parameter-group-name aurora-postgres-with-replication \
- --description 'Aurora Postgres 11 With Replication Enabled' \
- --db-parameter-group-family aurora-postgresql11 \
+ --description 'Aurora Postgres 13 With Replication Enabled' \
+ --db-parameter-group-family aurora-postgresql13 \
  --no-paginate
 
 aws rds modify-db-cluster-parameter-group \
@@ -37,7 +37,7 @@ sleep 900
 
 
 echo 'mopdifiying to provisioned'
-output=$(aws rds modify-db-cluster --db-cluster-identifier $DATABASE_IDENTIFIER -engine-mode provisioned --allow-engine-mode-change --db-cluster-instance-class db.r5.xlarge --apply-immediately --no-paginate )
+output=$(aws rds modify-db-cluster --db-cluster-identifier $DATABASE_IDENTIFIER --engine-mode provisioned --allow-engine-mode-change --db-cluster-instance-class db.r5.xlarge --apply-immediately --no-paginate )
 PROVISINED_INSTANCE_IDENTIFIER=$(echo $output | jq -r '.DBCluster.DBClusterMembers[0].DBInstanceIdentifier')
 
  aws rds wait db-instance-available \
@@ -87,7 +87,7 @@ echo 'creating v2 instance'
  aws rds create-db-instance \
  --db-instance-identifier $SMALL_DATABASE_IDENTITER-serverless \
  --db-instance-class db.serverless \
- --engine aurora-mysql \
+ --engine aurora-postgresql \
  --db-cluster-identifier $green_cluster_id \
  --no-paginate
 

--- a/scripts/convert-auroraV1-to-V2-postgres.sh
+++ b/scripts/convert-auroraV1-to-V2-postgres.sh
@@ -5,7 +5,7 @@ set -xe
 
 DATABASE_IDENTIFIER=
 GREEN_DATABASE_IDENTIFIER=featureflags-dev-green
-SMALL_DATABASE_IDENTITER=featureflags-dev
+SMALL_DATABASE_IDENTIFIER=featureflags-dev
 ACCOUNT_ID=
 REGION=us-east-1
 
@@ -38,10 +38,10 @@ sleep 900
 
 echo 'mopdifiying to provisioned'
 output=$(aws rds modify-db-cluster --db-cluster-identifier $DATABASE_IDENTIFIER --engine-mode provisioned --allow-engine-mode-change --db-cluster-instance-class db.r5.xlarge --apply-immediately --no-paginate )
-PROVISINED_INSTANCE_IDENTIFIER=$(echo $output | jq -r '.DBCluster.DBClusterMembers[0].DBInstanceIdentifier')
+PROVISIONED_INSTANCE_IDENTIFIER=$(echo $output | jq -r '.DBCluster.DBClusterMembers[0].DBInstanceIdentifier')
 
  aws rds wait db-instance-available \
- --db-instance-identifier $PROVISINED_INSTANCE_IDENTIFIER \
+ --db-instance-identifier $PROVISIONED_INSTANCE_IDENTIFIER \
  --no-paginate
 
 aws rds wait db-cluster-available \
@@ -85,20 +85,20 @@ aws rds modify-db-cluster \
 
 echo 'creating v2 instance'
  aws rds create-db-instance \
- --db-instance-identifier $SMALL_DATABASE_IDENTITER-serverless \
+ --db-instance-identifier $SMALL_DATABASE_IDENTIFIER-serverless \
  --db-instance-class db.serverless \
  --engine aurora-postgresql \
  --db-cluster-identifier $green_cluster_id \
  --no-paginate
 
 aws rds wait db-instance-available \
- --db-instance-identifier $SMALL_DATABASE_IDENTITER-serverless \
+ --db-instance-identifier $SMALL_DATABASE_IDENTIFIER-serverless \
  --no-paginate
 
 echo 'failing green database over' 
 aws rds failover-db-cluster \
  --db-cluster-identifier $green_cluster_id \
- --target-db-instance-identifier $SMALL_DATABASE_IDENTITER-serverless \
+ --target-db-instance-identifier $SMALL_DATABASE_IDENTIFIER-serverless \
  --no-paginate
 
 aws rds wait db-cluster-available \


### PR DESCRIPTION
## Goal

Postgres 13 (current db for Feature Flags) will be EOL and incurring extra AWS charges this month.

This converts it to Postgres 16 and will move it to serverless V2. 


## Testing

The script has already been ran on Dev and after it was run, all we needed to do was import the new serverless instance.

```
terraform import aws_rds_cluster_instance.rds_rds-instance_6675FA88 featureflags-dev-serverless
```

## Deployment

1. Block all merges to `main`
2. Execute convert script.
3. Execute Blue-Green cutover
4. Delete extra reader instance that our conversion created.
5. Synth the state locally, and import the serverless instance into terraform
6. Merge the pr to `main`
7. Destroy the blue green deployment
8. Destroy the old blue cluster

## Downtime

In testing there is at most 10 seconds of downtime for the feature flag service during the cutover