### PR TITLE
feat(list): add tag mutations accessed by name

### DIFF
--- a/servers/list-api/schema.graphql
+++ b/servers/list-api/schema.graphql
@@ -912,7 +912,7 @@ type Mutation {
 
 """
 We don't have official oneOf support, but this will
-throw if one of these fields is not set and not null.
+throw if both `id` and `url` are unset/null.
 Don't provide both... but if both are provided, it will
 default to using ID.
 """

--- a/servers/list-api/schema.graphql
+++ b/servers/list-api/schema.graphql
@@ -871,6 +871,51 @@ type Mutation {
     timestamp: ISOString!
     title: String! @constraint(minLength: 1, maxLength: 75)
   ): SavedItem
+
+  """
+  Remove all tags associated to a SavedItem (included for v3 proxy).
+  """
+  clearTags(savedItem: SavedItemRef!, timestamp: ISOString): SavedItem
+    @tag(name: "v3proxy")
+  """
+  Rename a tag identified by name (rather than ID), to support v3 proxy.
+  """
+  renameTagByName(tagName: String!, timestamp: ISOString): Tag
+    @tag(name: "v3proxy")
+  """
+  Delete a tag entity identified by name (rather than ID), to support v3 proxy.
+  Disassociates this tag from all SavedItems.
+  """
+  deleteTagByName(tagName: String!, timestamp: ISOString): String
+    @tag(name: "v3proxy")
+  """
+  Removes specific tags associated to a SavedItem,
+  referenced by name, to support v3 proxy.
+  """
+  removeTagsByName(
+    savedItem: SavedItemRef!
+    tagNames: [String!]!
+    timestamp: ISOString
+  ): SavedItem @tag(name: "v3proxy")
+  """
+  Replace specific tags associated to a SavedItem, to support v3 proxy.
+  """
+  replaceTags(
+    savedItem: SavedItemRef!
+    tagNames: [String!]!
+    timestamp: ISOString
+  ): SavedItem @tag(name: "v3proxy")
+}
+
+"""
+We don't have official oneOf support, but this will
+throw if one of these fields is not set and not null.
+Don't provide both... but if both are provided, it will
+default to using ID.
+"""
+input SavedItemRef { # @oneOf
+  id: ID
+  url: Url
 }
 
 # """

--- a/servers/list-api/schema.graphql
+++ b/servers/list-api/schema.graphql
@@ -567,7 +567,7 @@ type SavedItemTagAssociation {
 """
 A page of SavedItems, retrieved by offset-based pagination.
 """
-type SavedItemsPage @tag(name: "internal") {
+type SavedItemsPage @tag(name: "v3proxy") {
   entries: [SavedItem!]!
   totalCount: Int!
   offset: Int!
@@ -598,7 +598,7 @@ type User @key(fields: "id") {
     filter: SavedItemsFilter
     sort: SavedItemsSort
     pagination: OffsetPaginationInput
-  ): SavedItemsPage @tag(name: "internal")
+  ): SavedItemsPage @tag(name: "v3proxy")
 
   """
   Get a paginated listing of all a user's Tags
@@ -880,8 +880,11 @@ type Mutation {
   """
   Rename a tag identified by name (rather than ID), to support v3 proxy.
   """
-  renameTagByName(tagName: String!, timestamp: ISOString): Tag
-    @tag(name: "v3proxy")
+  renameTagByName(
+    oldName: String!
+    newName: String!
+    timestamp: ISOString
+  ): Tag @tag(name: "v3proxy")
   """
   Delete a tag entity identified by name (rather than ID), to support v3 proxy.
   Disassociates this tag from all SavedItems.

--- a/servers/list-api/src/dataService/tagDataService.ts
+++ b/servers/list-api/src/dataService/tagDataService.ts
@@ -287,15 +287,25 @@ export class TagDataService {
    * associations it has to a user's SavedItems
    * @param tagName the name of the Tag to delete
    */
-  public async deleteTagObject(tagName: string): Promise<void> {
+  public async deleteTagObject(
+    tagName: string,
+    timestamp?: Date,
+  ): Promise<void> {
     const affectedItems = await this.db('item_tags')
       .where({ user_id: this.userId, tag: tagName })
       .pluck('item_id');
     if (affectedItems.length > 0) {
       await this.db.transaction(async (trx: Knex.Transaction) => {
         await this.deleteTagsByName(tagName).transacting(trx);
-        await this.savedItemService.updateListItemMany(affectedItems, trx);
-        await this.usersMetaService.logTagMutation(new Date(), trx);
+        await this.savedItemService.updateListItemMany(
+          affectedItems,
+          trx,
+          timestamp,
+        );
+        await this.usersMetaService.logTagMutation(
+          timestamp ?? new Date(),
+          trx,
+        );
       });
     }
   }
@@ -309,6 +319,7 @@ export class TagDataService {
     oldName: string,
     newName: string,
     itemIds: string[],
+    timestamp?: Date,
   ): Promise<void> {
     await this.db.transaction(async (trx: Knex.Transaction) => {
       await trx.raw(
@@ -319,12 +330,15 @@ export class TagDataService {
           newTagName: newName,
           userId: this.userId,
           oldTagName: oldName,
-          _updatedAt: mysqlTimeString(new Date(), config.database.tz),
+          _updatedAt: mysqlTimeString(
+            timestamp ?? new Date(),
+            config.database.tz,
+          ),
         },
       );
-      await this.savedItemService.updateListItemMany(itemIds, trx);
+      await this.savedItemService.updateListItemMany(itemIds, trx, timestamp);
       await this.deleteTagsByName(oldName).transacting(trx);
-      await this.usersMetaService.logTagMutation(new Date(), trx);
+      await this.usersMetaService.logTagMutation(timestamp ?? new Date(), trx);
     });
   }
 
@@ -374,13 +388,18 @@ export class TagDataService {
   ): Promise<any> {
     //clear first, so we can get rid of noisy data if savedItem doesn't exist.
     await this.db.transaction(async (trx: Knex.Transaction) => {
-      await this.deleteTagsByItemId(savedItemId).transacting(trx);
-      await this.savedItemService.updateListItemOne(
-        savedItemId,
-        trx,
-        timestamp,
-      );
-      await this.usersMetaService.logTagMutation(timestamp ?? new Date(), trx);
+      const count = await this.deleteTagsByItemId(savedItemId).transacting(trx);
+      if (count) {
+        await this.savedItemService.updateListItemOne(
+          savedItemId,
+          trx,
+          timestamp,
+        );
+        await this.usersMetaService.logTagMutation(
+          timestamp ?? new Date(),
+          trx,
+        );
+      }
     });
     return await this.savedItemService.getSavedItemById(savedItemId);
   }
@@ -393,7 +412,11 @@ export class TagDataService {
     tagInputs: TagSaveAssociation[],
     timestamp?: Date,
   ): Promise<SavedItem[]> {
-    const savedItemIds = tagInputs.map((input) => input.savedItemId);
+    const savedItemIds = Array.from(
+      new Set(tagInputs.map((input) => input.savedItemId)),
+    );
+
+    // const savedItemIds = tagInputs.map((input) => input.savedItemId);
 
     await this.db.transaction(async (trx) => {
       await Promise.all(
@@ -454,6 +477,25 @@ export class TagDataService {
       .where({ tag, user_id: this.userId })
       .pluck('item_id');
     return res as string[];
+  }
+
+  /**
+   * Delete tag associations from a single saved item, by the tag name(s).
+   */
+  public async deleteItemTagsByName(
+    tagNames: string[],
+    itemId: string,
+    timestamp?: Date,
+  ): Promise<Knex.QueryBuilder> {
+    await this.db.transaction(async (trx) => {
+      await trx('item_tags')
+        .whereIn('tag', tagNames)
+        .andWhere({ user_id: this.userId, item_id: itemId })
+        .del();
+      await this.savedItemService.updateListItemOne(itemId, trx, timestamp);
+      await this.usersMetaService.logTagMutation(timestamp ?? new Date(), trx);
+    });
+    return await this.savedItemService.getSavedItemById(itemId);
   }
 
   private deleteTagsByItemId(itemId: string): Knex.QueryBuilder {

--- a/servers/list-api/src/dataService/tagDataService.ts
+++ b/servers/list-api/src/dataService/tagDataService.ts
@@ -415,9 +415,6 @@ export class TagDataService {
     const savedItemIds = Array.from(
       new Set(tagInputs.map((input) => input.savedItemId)),
     );
-
-    // const savedItemIds = tagInputs.map((input) => input.savedItemId);
-
     await this.db.transaction(async (trx) => {
       await Promise.all(
         savedItemIds.map(async (id) => {

--- a/servers/list-api/src/resolvers/index.ts
+++ b/servers/list-api/src/resolvers/index.ts
@@ -6,11 +6,14 @@ import {
 } from './user';
 import { item, suggestedTags as savedItemSuggestedTags } from './savedItem';
 import {
+  clearTags,
   createSavedItemTags,
   deleteSavedItem,
   deleteSavedItemTags,
   deleteTag,
+  removeTagsByName,
   replaceSavedItemTags,
+  replaceTags,
   updateSavedItemArchive,
   updateSavedItemFavorite,
   updateSavedItemRemoveTags,
@@ -138,6 +141,19 @@ const resolvers = {
     deleteTag,
     createSavedItemTags,
     replaceSavedItemTags,
+    clearTags,
+    replaceTags,
+    removeTagsByName,
+    deleteTagByName: async (
+      _,
+      args: { tagName: string; timestamp?: Date },
+      context: IContext,
+    ): Promise<string> => {
+      return await context.models.tag.deleteTagByName(
+        args.tagName,
+        args.timestamp,
+      );
+    },
     saveArchive: async (
       _,
       args: SaveMutationInput,
@@ -297,6 +313,17 @@ const resolvers = {
         args.id,
         args.timestamp,
         args.title,
+      );
+    },
+    renameTagByName: async (
+      _,
+      args: { oldName: string; newName: string; timestamp?: Date },
+      context: IContext,
+    ): Promise<Tag | null> => {
+      return await context.models.tag.renameTagByName(
+        args.oldName,
+        args.newName,
+        args.timestamp,
       );
     },
   },

--- a/servers/list-api/src/resolvers/utils.spec.ts
+++ b/servers/list-api/src/resolvers/utils.spec.ts
@@ -1,5 +1,9 @@
 import { SavedItemTagsInput, Tag } from '../types';
-import { getSavedItemMapFromTags, getSavedItemTagsMap } from './utils';
+import {
+  atLeastOneOf,
+  getSavedItemMapFromTags,
+  getSavedItemTagsMap,
+} from './utils';
 
 describe('getSavedItemMapFromTags', () => {
   it('should return a savedItem map from a list of tags', () => {
@@ -10,6 +14,29 @@ describe('getSavedItemMapFromTags', () => {
     const expected = { '1': [tagA, tagB], '2': [tagA], '3': [tagB] };
     const actual = getSavedItemMapFromTags(input);
     expect(actual).toEqual(expected);
+  });
+});
+describe('atLeastOneOf', () => {
+  it('returns false if no keys are included', () => {
+    const hasAtLeastOne = atLeastOneOf({ spell: undefined, level: undefined }, [
+      'spell',
+      'level',
+    ]);
+    expect(hasAtLeastOne).toBeFalse();
+  });
+  it('returns false if there are other keys but not the ones you want', () => {
+    const hasAtLeastOne = atLeastOneOf(
+      { spell: undefined, level: undefined, range: '3m' },
+      ['spell', 'level'],
+    );
+    expect(hasAtLeastOne).toBeFalse();
+  });
+  it('passes if at least one key is included', () => {
+    const hasAtLeastOne = atLeastOneOf(
+      { spell: 'Speak With Dead', level: 2, range: '3m' },
+      ['spell', 'level'],
+    );
+    expect(hasAtLeastOne).toBeTrue();
   });
 });
 

--- a/servers/list-api/src/resolvers/utils.ts
+++ b/servers/list-api/src/resolvers/utils.ts
@@ -87,3 +87,20 @@ export async function lazyParentLoad<T extends object, K, A extends keyof T>(
     return fetched[attr];
   }
 }
+
+/**
+ * Returns true if the object has at least one property, accessed by a
+ * key in the list 'keys', with non-null data.
+ * @param obj
+ * @param keys
+ * @returns
+ */
+export function atLeastOneOf<T extends object, K extends keyof T>(
+  obj: T,
+  keys: K[],
+) {
+  for (const key of keys) {
+    if (obj[key] != null) return true;
+  }
+  return false;
+}

--- a/servers/list-api/src/test/graphql/mutations/clearTags.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/clearTags.integration.ts
@@ -1,0 +1,191 @@
+import { readClient, writeClient } from '../../../database/client';
+import { ContextManager } from '../../../server/context';
+import { startServer } from '../../../server/apollo';
+import { Application } from 'express';
+import { ApolloServer } from '@apollo/server';
+import request from 'supertest';
+import { mockParserGetItemIdRequest } from '../../utils/parserMocks';
+
+describe('clearTags mutation', () => {
+  //using write client as mutation will use write client to read as well.
+  const writeDb = writeClient();
+  const readDb = readClient();
+  const eventSpy = jest.spyOn(ContextManager.prototype, 'emitItemEvent');
+  const date = new Date(1711470611 * 1000); // 2024-03-26 16:30:11.000Z
+  const now = Math.round(Date.now() / 1000) * 1000;
+  let app: Application;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+  const headers = {
+    userid: '1',
+  };
+
+  const clearTagsMutation = `
+      mutation clearTags($saveRef: SavedItemRef!, $timestamp: ISOString) {
+        clearTags(savedItem: $saveRef, timestamp: $timestamp) {
+          id
+          url
+          tags {
+            name
+          }
+          _updatedAt
+        }
+      }
+    `;
+
+  beforeAll(async () => {
+    jest.useFakeTimers({
+      now: now,
+      advanceTimers: true,
+    });
+    ({ app, server, url } = await startServer(0));
+  });
+  beforeEach(async () => {
+    // Seed data - with tags (0) and without (1)
+    await writeDb('list').truncate();
+    const listData = [
+      { item_id: 0, status: 0, favorite: 0 },
+      { item_id: 1, status: 1, favorite: 0 },
+    ].map((row) => {
+      return {
+        ...row,
+        user_id: 1,
+        resolved_id: row.item_id,
+        given_url: `http://${row.item_id}`,
+        title: `title ${row.item_id}`,
+        time_added: date,
+        time_updated: date,
+        time_read: date,
+        time_favorited: date,
+        api_id: 'apiid',
+        api_id_updated: 'apiid',
+      };
+    });
+    await writeDb('list').insert(listData);
+    await writeDb('item_tags').truncate();
+    const tagData = [
+      { item_id: 0, tag: 'simon' },
+      { item_id: 0, tag: 'garfunkel' },
+    ].map((row) => {
+      return {
+        ...row,
+        user_id: 1,
+        status: 1,
+        time_added: date,
+        time_updated: date,
+        api_id: 'apiid',
+        api_id_updated: 'updated_api_id',
+      };
+    });
+    await writeDb('item_tags').insert(tagData);
+  });
+  afterAll(async () => {
+    await writeDb.destroy();
+    await readDb.destroy();
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+    await server.stop();
+  });
+  afterEach(() => eventSpy.mockClear());
+  it('clears tags associated to a SavedItem, referenced by ID', async () => {
+    const variables = { saveRef: { id: '0' } };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: clearTagsMutation, variables });
+    const expected = {
+      id: '0',
+      tags: [],
+      _updatedAt: Math.round(now / 1000),
+    };
+    expect(res.body.data.clearTags).toMatchObject(expected);
+    expect(eventSpy).toHaveBeenCalledOnce();
+    expect(eventSpy.mock.calls[0][0]).toEqual('CLEAR_TAGS');
+    expect(eventSpy.mock.calls[0][2]).toIncludeSameMembers([
+      'garfunkel',
+      'simon',
+    ]);
+  });
+  it('clears tags associated to a SavedItem, referenced by url', async () => {
+    const givenUrl = 'http://whatever.com';
+    mockParserGetItemIdRequest(givenUrl, '0');
+    const variables = { saveRef: { url: givenUrl } };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: clearTagsMutation, variables });
+    const expected = {
+      id: '0',
+      tags: [],
+      _updatedAt: Math.round(now / 1000),
+    };
+    expect(res.body.data.clearTags).toMatchObject(expected);
+    expect(eventSpy).toHaveBeenCalledOnce();
+    expect(eventSpy.mock.calls[0][0]).toEqual('CLEAR_TAGS');
+    expect(eventSpy.mock.calls[0][2]).toIncludeSameMembers([
+      'garfunkel',
+      'simon',
+    ]);
+  });
+  it('accepts a timestamp to clear tags and sets _updatedAt to it', async () => {
+    const givenUrl = 'http://whatever.com';
+    mockParserGetItemIdRequest(givenUrl, '0');
+    const variables = {
+      saveRef: { url: givenUrl },
+      timestamp: '2024-03-26T16:41:25.000Z',
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: clearTagsMutation, variables });
+    const expected = {
+      id: '0',
+      tags: [],
+      _updatedAt: 1711471285,
+    };
+    expect(res.body.data.clearTags).toMatchObject(expected);
+    expect(eventSpy).toHaveBeenCalledOnce();
+    expect(eventSpy.mock.calls[0][0]).toEqual('CLEAR_TAGS');
+    expect(eventSpy.mock.calls[0][2]).toIncludeSameMembers([
+      'garfunkel',
+      'simon',
+    ]);
+  });
+  it('throws bad user input error if neither ID nor Url are passed', async () => {
+    const variables = { saveRef: {} };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: clearTagsMutation, variables });
+    const error = res.body.errors?.[0];
+    expect(error).not.toBeUndefined();
+    expect(error.message).toContain(
+      'SavedItemRef must have one of `id` or `url`',
+    );
+    expect(error.extensions.code).toEqual('BAD_USER_INPUT');
+  });
+  it('does not throw error for a SavedItem with no tags, but does not emit event or update timestamp', async () => {
+    const variables = { saveRef: { id: '1' } };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: clearTagsMutation, variables });
+    const expected = {
+      id: '1',
+      tags: [],
+      _updatedAt: 1711470611,
+    };
+    expect(res.body.data.clearTags).toMatchObject(expected);
+    expect(eventSpy).not.toHaveBeenCalled();
+  });
+  it('throws error if SavedItem does not exist', async () => {
+    const variables = { saveRef: { id: '1233828328328123' } };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: clearTagsMutation, variables });
+    const error = res.body.errors?.[0];
+    expect(error).not.toBeUndefined();
+    expect(error.extensions.code).toEqual('NOT_FOUND');
+  });
+});

--- a/servers/list-api/src/test/graphql/mutations/replaceTags.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/replaceTags.integration.ts
@@ -1,0 +1,189 @@
+import { readClient, writeClient } from '../../../database/client';
+import { ContextManager } from '../../../server/context';
+import { startServer } from '../../../server/apollo';
+import { Application } from 'express';
+import { ApolloServer } from '@apollo/server';
+import request from 'supertest';
+import { mockParserGetItemIdRequest } from '../../utils/parserMocks';
+
+describe('clearTags mutation', () => {
+  //using write client as mutation will use write client to read as well.
+  const writeDb = writeClient();
+  const readDb = readClient();
+  const eventSpy = jest.spyOn(ContextManager.prototype, 'emitItemEvent');
+  const date = new Date(1711470611 * 1000); // 2024-03-26 16:30:11.000Z
+  const now = Math.round(Date.now() / 1000) * 1000;
+  let app: Application;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+  const headers = {
+    userid: '1',
+  };
+
+  const replaceTagsMutation = `
+      mutation replaceTags($saveRef: SavedItemRef!, $tagNames: [String!]!, $timestamp: ISOString) {
+        replaceTags(savedItem: $saveRef, tagNames: $tagNames, timestamp: $timestamp) {
+          id
+          url
+          tags {
+            name
+          }
+          _updatedAt
+        }
+      }
+    `;
+
+  beforeAll(async () => {
+    jest.useFakeTimers({
+      now: now,
+      advanceTimers: true,
+    });
+    ({ app, server, url } = await startServer(0));
+  });
+  beforeEach(async () => {
+    // Seed data - with tags (0) and without (1)
+    await writeDb('list').truncate();
+    const listData = [
+      { item_id: 0, status: 0, favorite: 0 },
+      { item_id: 1, status: 1, favorite: 0 },
+    ].map((row) => {
+      return {
+        ...row,
+        user_id: 1,
+        resolved_id: row.item_id,
+        given_url: `http://${row.item_id}`,
+        title: `title ${row.item_id}`,
+        time_added: date,
+        time_updated: date,
+        time_read: date,
+        time_favorited: date,
+        api_id: 'apiid',
+        api_id_updated: 'apiid',
+      };
+    });
+    await writeDb('list').insert(listData);
+    await writeDb('item_tags').truncate();
+    const tagData = [
+      { item_id: 0, tag: 'simon' },
+      { item_id: 0, tag: 'garfunkel' },
+    ].map((row) => {
+      return {
+        ...row,
+        user_id: 1,
+        status: 1,
+        time_added: date,
+        time_updated: date,
+        api_id: 'apiid',
+        api_id_updated: 'updated_api_id',
+      };
+    });
+    await writeDb('item_tags').insert(tagData);
+  });
+  afterAll(async () => {
+    await writeDb.destroy();
+    await readDb.destroy();
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+    await server.stop();
+  });
+  afterEach(() => eventSpy.mockClear());
+  it('replaces tags associated to a SavedItem, referenced by ID', async () => {
+    const variables = { saveRef: { id: '0' }, tagNames: ['hall', 'oates'] };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: replaceTagsMutation, variables });
+    const expected = {
+      id: '0',
+      tags: expect.toIncludeSameMembers([{ name: 'hall' }, { name: 'oates' }]),
+      _updatedAt: Math.round(now / 1000),
+    };
+    expect(res.body.data.replaceTags).toMatchObject(expected);
+    expect(eventSpy).toHaveBeenCalledOnce();
+    expect(eventSpy.mock.calls[0][0]).toEqual('REPLACE_TAGS');
+    expect(eventSpy.mock.calls[0][2]).toIncludeSameMembers(['hall', 'oates']);
+  });
+  it('replaces tags associated to a SavedItem, referenced by url', async () => {
+    const givenUrl = 'http://whatever.com';
+    mockParserGetItemIdRequest(givenUrl, '0');
+    const variables = {
+      saveRef: { url: givenUrl },
+      tagNames: ['hall', 'oates'],
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: replaceTagsMutation, variables });
+    const expected = {
+      id: '0',
+      tags: expect.toIncludeSameMembers([{ name: 'hall' }, { name: 'oates' }]),
+      _updatedAt: Math.round(now / 1000),
+    };
+    expect(res.body.data.replaceTags).toMatchObject(expected);
+    expect(eventSpy).toHaveBeenCalledOnce();
+    expect(eventSpy.mock.calls[0][0]).toEqual('REPLACE_TAGS');
+    expect(eventSpy.mock.calls[0][2]).toIncludeSameMembers(['hall', 'oates']);
+  });
+  it('accepts a timestamp to replace tags and sets _updatedAt to it', async () => {
+    const givenUrl = 'http://whatever.com';
+    mockParserGetItemIdRequest(givenUrl, '0');
+    const variables = {
+      saveRef: { url: givenUrl },
+      tagNames: ['hall', 'oates'],
+      timestamp: '2024-03-26T16:41:25.000Z',
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: replaceTagsMutation, variables });
+    const expected = {
+      id: '0',
+      tags: expect.toIncludeSameMembers([{ name: 'hall' }, { name: 'oates' }]),
+      _updatedAt: 1711471285,
+    };
+    expect(res.body.data.replaceTags).toMatchObject(expected);
+    expect(eventSpy).toHaveBeenCalledOnce();
+    expect(eventSpy.mock.calls[0][0]).toEqual('REPLACE_TAGS');
+    expect(eventSpy.mock.calls[0][2]).toIncludeSameMembers(['hall', 'oates']);
+  });
+  it('throws bad user input error if neither ID nor Url are passed', async () => {
+    const variables = { saveRef: {}, tagNames: ['hall', 'oates'] };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: replaceTagsMutation, variables });
+    const error = res.body.errors?.[0];
+    expect(error).not.toBeUndefined();
+    expect(error.message).toContain(
+      'SavedItemRef must have one of `id` or `url`',
+    );
+    expect(error.extensions.code).toEqual('BAD_USER_INPUT');
+  });
+  it('deletes all tags if an empty array is passed', async () => {
+    const variables = { saveRef: { id: '0' }, tagNames: [] };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: replaceTagsMutation, variables });
+    const expected = {
+      id: '0',
+      tags: [],
+    };
+    expect(res.body.data.replaceTags).toMatchObject(expected);
+    expect(eventSpy).toHaveBeenCalledOnce();
+    expect(eventSpy.mock.calls[0][0]).toEqual('CLEAR_TAGS');
+  });
+  it('throws error if SavedItem does not exist', async () => {
+    const variables = {
+      saveRef: { id: '1233828328328123' },
+      tagNames: ['hall', 'oates'],
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: replaceTagsMutation, variables });
+    const error = res.body.errors?.[0];
+    expect(error).not.toBeUndefined();
+    expect(error.extensions.code).toEqual('NOT_FOUND');
+  });
+});

--- a/servers/list-api/src/test/graphql/mutations/tagsByName/deleteTagByName.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/tagsByName/deleteTagByName.integration.ts
@@ -1,0 +1,138 @@
+import { readClient, writeClient } from '../../../../database/client';
+import { ContextManager } from '../../../../server/context';
+import { startServer } from '../../../../server/apollo';
+import { Application } from 'express';
+import { ApolloServer } from '@apollo/server';
+import request from 'supertest';
+
+describe('deleteTagByName mutation', () => {
+  //using write client as mutation will use write client to read as well.
+  const writeDb = writeClient();
+  const readDb = readClient();
+  const tagQueryStub = readDb('item_tags').count().first();
+  const listUpdatedStub = readDb('list')
+    .select()
+    .andWhere('user_id', '1')
+    .pluck('time_updated');
+  const date = new Date(1711470611 * 1000); // 2024-03-26 16:30:11.000Z
+  const now = Math.round(Date.now() / 1000) * 1000;
+  let app: Application;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+  const headers = {
+    userid: '1',
+  };
+
+  const renameTagMutation = `
+      mutation renameTagByName($oldName: String!, $newName: String!, $timestamp: ISOString) {
+        renameTagByName(oldName: $oldName, newName: $newName, timestamp: $timestamp) {
+          name
+          savedItems {
+            edges {
+              node {
+                _updatedAt
+              }
+            }
+          }
+        }
+      }
+    `;
+
+  beforeAll(async () => {
+    jest.useFakeTimers({
+      now: now,
+      advanceTimers: true,
+    });
+    ({ app, server, url } = await startServer(0));
+  });
+  beforeEach(async () => {
+    // Seed data - with tags (0) and without (1)
+    await writeDb('list').truncate();
+    const listData = [
+      { item_id: 0, status: 0, favorite: 0 },
+      { item_id: 1, status: 1, favorite: 0 },
+    ].map((row) => {
+      return {
+        ...row,
+        user_id: 1,
+        resolved_id: row.item_id,
+        given_url: `http://${row.item_id}`,
+        title: `title ${row.item_id}`,
+        time_added: date,
+        time_updated: date,
+        time_read: date,
+        time_favorited: date,
+        api_id: 'apiid',
+        api_id_updated: 'apiid',
+      };
+    });
+    await writeDb('list').insert(listData);
+    await writeDb('item_tags').truncate();
+    const tagData = [
+      { item_id: 0, tag: 'ketheric' },
+      { item_id: 0, tag: 'gortash' },
+      { item_id: 1, tag: 'ketheric' },
+    ].map((row) => {
+      return {
+        ...row,
+        user_id: 1,
+        status: 1,
+        time_added: date,
+        time_updated: date,
+        api_id: 'apiid',
+        api_id_updated: 'updated_api_id',
+      };
+    });
+    await writeDb('item_tags').insert(tagData);
+  });
+  afterAll(async () => {
+    await writeDb.destroy();
+    await readDb.destroy();
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+    await server.stop();
+  });
+  it('should rename a tag and update associated saves', async () => {
+    const variables = {
+      oldName: 'ketheric',
+      newName: 'tav',
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: renameTagMutation, variables });
+    expect(res.body.data.renameTagByName.name).toEqual('tav');
+    const updatedDates = res.body.data.renameTagByName.savedItems.edges.map(
+      (edge) => edge.node._updatedAt,
+    );
+    expect(updatedDates).toEqual([now / 1000, now / 1000]);
+  });
+  it('accepts a timestamp to rename tag and sets _updatedAt to it for associated Saves', async () => {
+    const timestamp = '2024-03-26T16:41:25.000Z';
+    const variables = {
+      oldName: 'ketheric',
+      newName: 'tav',
+      timestamp,
+    };
+    const expectedDate = new Date(timestamp).getTime() / 1000;
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: renameTagMutation, variables });
+    expect(res.body.data.renameTagByName.name).toEqual('tav');
+    const updatedDates = res.body.data.renameTagByName.savedItems.edges.map(
+      (edge) => edge.node._updatedAt,
+    );
+    expect(updatedDates).toEqual([expectedDate, expectedDate]);
+  });
+  it('throws NotFoundError if the tag does not exist', async () => {
+    const variables = { oldName: 'durge', newName: 'tav' };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: renameTagMutation, variables });
+    const error = res.body.errors?.[0];
+    expect(error).not.toBeUndefined();
+    expect(error.extensions.code).toEqual('NOT_FOUND');
+  });
+});

--- a/servers/list-api/src/test/graphql/mutations/tagsByName/deleteTagByName.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/tagsByName/deleteTagByName.integration.ts
@@ -9,8 +9,6 @@ describe('deleteTagByName mutation', () => {
   //using write client as mutation will use write client to read as well.
   const writeDb = writeClient();
   const readDb = readClient();
-  const tagQueryStub = readDb('item_tags').count().first();
-  const listUpdatedStub = readDb('list')
     .select()
     .andWhere('user_id', '1')
     .pluck('time_updated');

--- a/servers/list-api/src/test/graphql/mutations/tagsByName/deleteTagByName.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/tagsByName/deleteTagByName.integration.ts
@@ -9,6 +9,8 @@ describe('deleteTagByName mutation', () => {
   //using write client as mutation will use write client to read as well.
   const writeDb = writeClient();
   const readDb = readClient();
+  const tagQueryStub = readDb('item_tags').count().first();
+  const listUpdatedStub = readDb('list')
     .select()
     .andWhere('user_id', '1')
     .pluck('time_updated');
@@ -21,18 +23,9 @@ describe('deleteTagByName mutation', () => {
     userid: '1',
   };
 
-  const renameTagMutation = `
-      mutation renameTagByName($oldName: String!, $newName: String!, $timestamp: ISOString) {
-        renameTagByName(oldName: $oldName, newName: $newName, timestamp: $timestamp) {
-          name
-          savedItems {
-            edges {
-              node {
-                _updatedAt
-              }
-            }
-          }
-        }
+  const deleteTagMutation = `
+      mutation deleteTagByName($tagName: String!, $timestamp: ISOString) {
+        deleteTagByName(tagName: $tagName, timestamp: $timestamp)
       }
     `;
 
@@ -90,47 +83,47 @@ describe('deleteTagByName mutation', () => {
     jest.useRealTimers();
     await server.stop();
   });
-  it('should rename a tag and update associated saves', async () => {
-    const variables = {
-      oldName: 'ketheric',
-      newName: 'tav',
-    };
+  it('should completely remove an existing tag from all associated items', async () => {
+    const variables = { tagName: 'ketheric' };
     const res = await request(app)
       .post(url)
       .set(headers)
-      .send({ query: renameTagMutation, variables });
-    expect(res.body.data.renameTagByName.name).toEqual('tav');
-    const updatedDates = res.body.data.renameTagByName.savedItems.edges.map(
-      (edge) => edge.node._updatedAt,
-    );
-    expect(updatedDates).toEqual([now / 1000, now / 1000]);
+      .send({ query: deleteTagMutation, variables });
+    const expectedDate = new Date(now);
+    expect(res.body.data.deleteTagByName).toEqual('ketheric');
+    const kethericCount = (await tagQueryStub.where('tag', 'ketheric'))[
+      'count(*)'
+    ];
+    expect(kethericCount).toEqual(0);
+    const updatedTimes = await listUpdatedStub.whereIn('item_id', ['0', '1']);
+    expect(updatedTimes).toEqual([expectedDate, expectedDate]);
   });
-  it('accepts a timestamp to rename tag and sets _updatedAt to it for associated Saves', async () => {
+  it('accepts a timestamp to delete tags and sets _updatedAt to it for associated Saves', async () => {
     const timestamp = '2024-03-26T16:41:25.000Z';
     const variables = {
-      oldName: 'ketheric',
-      newName: 'tav',
+      tagName: 'ketheric',
       timestamp,
     };
-    const expectedDate = new Date(timestamp).getTime() / 1000;
+    const expectedDate = new Date(timestamp);
     const res = await request(app)
       .post(url)
       .set(headers)
-      .send({ query: renameTagMutation, variables });
-    expect(res.body.data.renameTagByName.name).toEqual('tav');
-    const updatedDates = res.body.data.renameTagByName.savedItems.edges.map(
-      (edge) => edge.node._updatedAt,
-    );
-    expect(updatedDates).toEqual([expectedDate, expectedDate]);
+      .send({ query: deleteTagMutation, variables });
+    expect(res.body.data.deleteTagByName).toEqual('ketheric');
+    const kethericCount = (await tagQueryStub.where('tag', 'ketheric'))[
+      'count(*)'
+    ];
+    expect(kethericCount).toEqual(0);
+    const updatedTimes = await listUpdatedStub.whereIn('item_id', ['0', '1']);
+    expect(updatedTimes).toEqual([expectedDate, expectedDate]);
   });
-  it('throws NotFoundError if the tag does not exist', async () => {
-    const variables = { oldName: 'durge', newName: 'tav' };
+  it('do nothing if the tag does not exist, and not throw error', async () => {
+    const variables = { tagName: 'orin' };
     const res = await request(app)
       .post(url)
       .set(headers)
-      .send({ query: renameTagMutation, variables });
-    const error = res.body.errors?.[0];
-    expect(error).not.toBeUndefined();
-    expect(error.extensions.code).toEqual('NOT_FOUND');
+      .send({ query: deleteTagMutation, variables });
+    const expected = 'orin';
+    expect(res.body.data.deleteTagByName).toEqual(expected);
   });
 });

--- a/servers/list-api/src/test/graphql/mutations/tagsByName/removeTagsByName.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/tagsByName/removeTagsByName.integration.ts
@@ -1,0 +1,166 @@
+import { readClient, writeClient } from '../../../../database/client';
+import { ContextManager } from '../../../../server/context';
+import { startServer } from '../../../../server/apollo';
+import { Application } from 'express';
+import { ApolloServer } from '@apollo/server';
+import request from 'supertest';
+
+describe('removeTagsByName mutation', () => {
+  //using write client as mutation will use write client to read as well.
+  const writeDb = writeClient();
+  const readDb = readClient();
+  const eventSpy = jest.spyOn(ContextManager.prototype, 'emitItemEvent');
+  const date = new Date(1711470611 * 1000); // 2024-03-26 16:30:11.000Z
+  const now = Math.round(Date.now() / 1000) * 1000;
+  let app: Application;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+  const headers = {
+    userid: '1',
+  };
+
+  const removeTagsMutation = `
+      mutation removeTagsByName($saveRef: SavedItemRef!, $tagNames: [String!]!, $timestamp: ISOString) {
+        removeTagsByName(savedItem: $saveRef, tagNames: $tagNames, timestamp: $timestamp) {
+          id
+          url
+          tags {
+            name
+          }
+          _updatedAt
+        }
+      }
+    `;
+
+  beforeAll(async () => {
+    jest.useFakeTimers({
+      now: now,
+      advanceTimers: true,
+    });
+    ({ app, server, url } = await startServer(0));
+  });
+  beforeEach(async () => {
+    // Seed data - with tags (0) and without (1)
+    await writeDb('list').truncate();
+    const listData = [
+      { item_id: 0, status: 0, favorite: 0 },
+      { item_id: 1, status: 1, favorite: 0 },
+    ].map((row) => {
+      return {
+        ...row,
+        user_id: 1,
+        resolved_id: row.item_id,
+        given_url: `http://${row.item_id}`,
+        title: `title ${row.item_id}`,
+        time_added: date,
+        time_updated: date,
+        time_read: date,
+        time_favorited: date,
+        api_id: 'apiid',
+        api_id_updated: 'apiid',
+      };
+    });
+    await writeDb('list').insert(listData);
+    await writeDb('item_tags').truncate();
+    const tagData = [
+      { item_id: 0, tag: 'ketheric' },
+      { item_id: 0, tag: 'gortash' },
+      { item_id: 1, tag: 'ketheric' },
+    ].map((row) => {
+      return {
+        ...row,
+        user_id: 1,
+        status: 1,
+        time_added: date,
+        time_updated: date,
+        api_id: 'apiid',
+        api_id_updated: 'updated_api_id',
+      };
+    });
+    await writeDb('item_tags').insert(tagData);
+  });
+  afterEach(() => eventSpy.mockClear());
+  afterAll(async () => {
+    await writeDb.destroy();
+    await readDb.destroy();
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+    await server.stop();
+  });
+  it('should remove existing tags from all associated items', async () => {
+    const variables = {
+      saveRef: { id: '0' },
+      tagNames: ['ketheric', 'gortash'],
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: removeTagsMutation, variables });
+    const expected = {
+      _updatedAt: now / 1000,
+      id: '0',
+      tags: [],
+    };
+    expect(res.body.data.removeTagsByName).toMatchObject(expected);
+    expect(eventSpy).toHaveBeenCalledOnce();
+    expect(eventSpy.mock.calls[0][0]).toEqual('REMOVE_TAGS');
+    expect(eventSpy.mock.calls[0][2]).toIncludeSameMembers([
+      'ketheric',
+      'gortash',
+    ]);
+  });
+  it('accepts a timestamp to delete tags and sets _updatedAt to it for associated Saves', async () => {
+    const timestamp = '2024-03-26T16:41:25.000Z';
+    const variables = {
+      saveRef: { id: '0' },
+      tagNames: ['ketheric'],
+      timestamp,
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: removeTagsMutation, variables });
+    const expected = {
+      _updatedAt: new Date(timestamp).getTime() / 1000,
+      id: '0',
+      tags: [{ name: 'gortash' }],
+    };
+    expect(res.body.data.removeTagsByName).toMatchObject(expected);
+    expect(eventSpy).toHaveBeenCalledOnce();
+    expect(eventSpy.mock.calls[0][0]).toEqual('REMOVE_TAGS');
+    expect(eventSpy.mock.calls[0][2]).toIncludeSameMembers(['ketheric']);
+  });
+  it('remove tags that do exist when passed an array containing tags that do not', async () => {
+    const variables = { saveRef: { id: '1' }, tagNames: ['orin', 'ketheric'] };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: removeTagsMutation, variables });
+    const expected = {
+      id: '1',
+      tags: [],
+    };
+    expect(res.body.data.removeTagsByName).toMatchObject(expected);
+    // The event still contains both tags requested to remove, since we don't
+    // check before attempting to delete (it just is a no-op if doesn't exist)
+    expect(eventSpy).toHaveBeenCalledOnce();
+    expect(eventSpy.mock.calls[0][0]).toEqual('REMOVE_TAGS');
+    expect(eventSpy.mock.calls[0][2]).toIncludeSameMembers([
+      'orin',
+      'ketheric',
+    ]);
+  });
+  it('throws error if SavedItem does not exist', async () => {
+    const variables = {
+      saveRef: { id: '1233828328328123' },
+      tagNames: ['orin', 'ketheric', 'gortash'],
+    };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: removeTagsMutation, variables });
+    const error = res.body.errors?.[0];
+    expect(error).not.toBeUndefined();
+    expect(error.extensions.code).toEqual('NOT_FOUND');
+  });
+});

--- a/servers/list-api/src/test/graphql/mutations/tagsByName/renameTagByName.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/tagsByName/renameTagByName.integration.ts
@@ -1,0 +1,129 @@
+import { readClient, writeClient } from '../../../../database/client';
+import { ContextManager } from '../../../../server/context';
+import { startServer } from '../../../../server/apollo';
+import { Application } from 'express';
+import { ApolloServer } from '@apollo/server';
+import request from 'supertest';
+
+describe('renameTagByName mutation', () => {
+  //using write client as mutation will use write client to read as well.
+  const writeDb = writeClient();
+  const readDb = readClient();
+  const tagQueryStub = readDb('item_tags').count().first();
+  const listUpdatedStub = readDb('list')
+    .select()
+    .andWhere('user_id', '1')
+    .pluck('time_updated');
+  const date = new Date(1711470611 * 1000); // 2024-03-26 16:30:11.000Z
+  const now = Math.round(Date.now() / 1000) * 1000;
+  let app: Application;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+  const headers = {
+    userid: '1',
+  };
+
+  const deleteTagMutation = `
+      mutation deleteTagByName($tagName: String!, $timestamp: ISOString) {
+        deleteTagByName(tagName: $tagName, timestamp: $timestamp)
+      }
+    `;
+
+  beforeAll(async () => {
+    jest.useFakeTimers({
+      now: now,
+      advanceTimers: true,
+    });
+    ({ app, server, url } = await startServer(0));
+  });
+  beforeEach(async () => {
+    // Seed data - with tags (0) and without (1)
+    await writeDb('list').truncate();
+    const listData = [
+      { item_id: 0, status: 0, favorite: 0 },
+      { item_id: 1, status: 1, favorite: 0 },
+    ].map((row) => {
+      return {
+        ...row,
+        user_id: 1,
+        resolved_id: row.item_id,
+        given_url: `http://${row.item_id}`,
+        title: `title ${row.item_id}`,
+        time_added: date,
+        time_updated: date,
+        time_read: date,
+        time_favorited: date,
+        api_id: 'apiid',
+        api_id_updated: 'apiid',
+      };
+    });
+    await writeDb('list').insert(listData);
+    await writeDb('item_tags').truncate();
+    const tagData = [
+      { item_id: 0, tag: 'ketheric' },
+      { item_id: 0, tag: 'gortash' },
+      { item_id: 1, tag: 'ketheric' },
+    ].map((row) => {
+      return {
+        ...row,
+        user_id: 1,
+        status: 1,
+        time_added: date,
+        time_updated: date,
+        api_id: 'apiid',
+        api_id_updated: 'updated_api_id',
+      };
+    });
+    await writeDb('item_tags').insert(tagData);
+  });
+  afterAll(async () => {
+    await writeDb.destroy();
+    await readDb.destroy();
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+    await server.stop();
+  });
+  it('should completely remove an existing tag from all associated items', async () => {
+    const variables = { tagName: 'ketheric' };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: deleteTagMutation, variables });
+    const expectedDate = new Date(now);
+    expect(res.body.data.deleteTagByName).toEqual('ketheric');
+    const kethericCount = (await tagQueryStub.where('tag', 'ketheric'))[
+      'count(*)'
+    ];
+    expect(kethericCount).toEqual(0);
+    const updatedTimes = await listUpdatedStub.whereIn('item_id', ['0', '1']);
+    expect(updatedTimes).toEqual([expectedDate, expectedDate]);
+  });
+  it('accepts a timestamp to delete tags and sets _updatedAt to it for associated Saves', async () => {
+    const timestamp = '2024-03-26T16:41:25.000Z';
+    const variables = {
+      tagName: 'ketheric',
+      timestamp,
+    };
+    const expectedDate = new Date(timestamp);
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: deleteTagMutation, variables });
+    expect(res.body.data.deleteTagByName).toEqual('ketheric');
+    const kethericCount = (await tagQueryStub.where('tag', 'ketheric'))[
+      'count(*)'
+    ];
+    expect(kethericCount).toEqual(0);
+    const updatedTimes = await listUpdatedStub.whereIn('item_id', ['0', '1']);
+    expect(updatedTimes).toEqual([expectedDate, expectedDate]);
+  });
+  it('do nothing if the tag does not exist, and not throw error', async () => {
+    const variables = { tagName: 'orin' };
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({ query: deleteTagMutation, variables });
+    const expected = 'orin';
+    expect(res.body.data.deleteTagByName).toEqual(expected);
+  });
+});

--- a/servers/list-api/src/types/index.ts
+++ b/servers/list-api/src/types/index.ts
@@ -282,3 +282,5 @@ export type SaveUpdateTagsInputDb = {
 };
 
 export type SaveByIdResult = NotFound | PocketSave;
+
+export type SavedItemRefInput = { id?: string; url?: string };


### PR DESCRIPTION
To support v3 proxy /send endpoint, which can identify a SavedItem either by URL or ID interchangeably, and uses tag names instead of tag IDs.

Adds:
* clearTags - clear all tags from a saved item referenced by id or url
* renameTagByName - rename a tag by its name (not id)
* deleteTagByName - delete a tag by its name (not id)
* removeTagsByName - remove tags from a saved item by names, not ids; saveditem referenced by id or url
* replaceTags - replace all tags on a saved item referenced by id or url