### PR TITLE
fix(db): upgrade shareablelists db

### DIFF
--- a/infrastructure/shareable-lists-api/src/main.ts
+++ b/infrastructure/shareable-lists-api/src/main.ts
@@ -209,7 +209,7 @@ class ShareableListsAPI extends TerraformStack {
         masterUsername: 'pkt_slists',
         engine: 'aurora-mysql',
         engineMode: 'provisioned',
-        engineVersion: '8.0.mysql_aurora.3.05.2',
+        engineVersion: '8.0.mysql_aurora.3.06.0',
         serverlessv2ScalingConfiguration: {
           minCapacity: config.rds.minCapacity,
           maxCapacity: config.rds.maxCapacity,

--- a/packages/terraform-modules/src/base/ApplicationRDSCluster.ts
+++ b/packages/terraform-modules/src/base/ApplicationRDSCluster.ts
@@ -147,7 +147,7 @@ export class ApplicationRDSCluster extends Construct {
       vpcSecurityGroupIds: [securityGroupResource.id],
       dbSubnetGroupName: subnetGroup.name,
       lifecycle: {
-        ignoreChanges: ['master_username', 'master_password'],
+        ignoreChanges: ['master_username', 'master_password', 'engine_version'],
       },
       provider: config.provider,
     });
@@ -161,6 +161,9 @@ export class ApplicationRDSCluster extends Construct {
           instanceClass: 'db.serverless',
           engine: this.rds.engine,
           engineVersion: this.rds.engineVersion,
+          lifecycle: {
+            ignoreChanges: ['engine_version'],
+          },
         },
       );
     }

--- a/packages/terraform-modules/src/base/__snapshots__/ApplicationRDSCluster.spec.ts.snap
+++ b/packages/terraform-modules/src/base/__snapshots__/ApplicationRDSCluster.spec.ts.snap
@@ -39,7 +39,8 @@ exports[`ApplicationRDSCluster renders a RDS cluster 1`] = `
         "lifecycle": {
           "ignore_changes": [
             "master_username",
-            "master_password"
+            "master_password",
+            "engine_version"
           ]
         },
         "master_password": "bowling",
@@ -159,7 +160,8 @@ exports[`ApplicationRDSCluster renders a RDS cluster with a database URL 1`] = `
         "lifecycle": {
           "ignore_changes": [
             "master_username",
-            "master_password"
+            "master_password",
+            "engine_version"
           ]
         },
         "master_password": "bowling",
@@ -277,7 +279,8 @@ exports[`ApplicationRDSCluster renders a RDS cluster without a name 1`] = `
         "lifecycle": {
           "ignore_changes": [
             "master_username",
-            "master_password"
+            "master_password",
+            "engine_version"
           ]
         },
         "master_password": "bowling",


### PR DESCRIPTION
## Goal

Upgrade Shareabelist database for 2 reasons:
* There is a new Aurora version
* We need to blue/green deploy to update the RDS certificate which expires in August.

This PR will be a no-op pr when done. The actual update will be done via a click ops bluegreen deploy.