### PR TITLE
feat(parser:listen): add listen duration estimate

### DIFF
--- a/servers/parser-graphql-wrapper/schema.graphql
+++ b/servers/parser-graphql-wrapper/schema.graphql
@@ -1,7 +1,14 @@
 extend schema
   @link(
     url: "https://specs.apollo.dev/federation/v2.0"
-    import: ["@key", "@shareable", "@requires", "@external", "@tag", "@inaccessible"]
+    import: [
+      "@key"
+      "@shareable"
+      "@requires"
+      "@external"
+      "@tag"
+      "@inaccessible"
+    ]
   )
 "A String representing a date in the format of `yyyy-MM-dd HH:mm:ss`"
 scalar DateString
@@ -42,7 +49,7 @@ type Item
   @cacheControl(maxAge: 86400) {
   "A server generated unique id for this item. Item's whose normalUrl are the same will have the same item_id. Most likely numeric, but to ensure future proofing this can be treated as a String in apps."
   itemId: String!
-  "A server generated unique id for this item based on itemId" 
+  "A server generated unique id for this item based on itemId"
   id: ID!
   """
   A normalized value of the givenUrl.
@@ -104,6 +111,8 @@ type Item
   language: String
   "How long it will take to read the article (TODO in what time unit? and by what calculation?)"
   timeToRead: Int
+  "Estimated time to listen to the article, in seconds"
+  listenDuration: Int
   """
   The url as provided by the user when saving. Only http or https schemes allowed.
 
@@ -256,7 +265,7 @@ enum Videoness {
 }
 
 union MarticleComponent =
-    MarticleText
+  | MarticleText
   | Image
   | MarticleDivider
   | MarticleTable

--- a/servers/parser-graphql-wrapper/src/dataLoaders/itemLoader.ts
+++ b/servers/parser-graphql-wrapper/src/dataLoaders/itemLoader.ts
@@ -22,6 +22,7 @@ import { FetchHandler } from '../fetch';
 import { serverLogger } from '@pocket-tools/ts-logger';
 import { IntMask } from '@pocket-tools/int-mask';
 import { getRedisCache } from '../cache';
+import { ListenModel } from '../listen/ListenModel';
 
 /**
  * Gets an item by its id by using the Item Resolvers table
@@ -136,6 +137,7 @@ const internalGetItemByUrl = async (
     excerpt: item.excerpt,
     wordCount: item.word_count,
     timeToRead: item.time_to_read,
+    listenDuration: ListenModel.estimateDuration(item.word_count),
     images: images,
     videos: videos,
     authors: authors,

--- a/servers/parser-graphql-wrapper/src/listen/ListenModel.spec.ts
+++ b/servers/parser-graphql-wrapper/src/listen/ListenModel.spec.ts
@@ -1,0 +1,17 @@
+import { ListenModel } from './ListenModel';
+
+describe('Listen', () => {
+  it.each([
+    [155, 60],
+    [300, 116],
+    [0, 0],
+    [null, null],
+    [undefined, null],
+    [-100, null],
+  ])(
+    'computes estimated listen duration from word count',
+    (words, expected) => {
+      expect(ListenModel.estimateDuration(words)).toEqual(expected);
+    },
+  );
+});

--- a/servers/parser-graphql-wrapper/src/listen/ListenModel.ts
+++ b/servers/parser-graphql-wrapper/src/listen/ListenModel.ts
@@ -1,0 +1,14 @@
+export class ListenModel {
+  // Estimated words per minute when listening (pulled from Web)
+  private static wordsPerMinute = 155;
+  /**
+   * Compute estimated listen time (in seconds) for an article.
+   * @param words number of words in article body
+   * @returns estimated seconds of listening time, or null if
+   * invalid input (negative number, nullish)
+   */
+  public static estimateDuration(words: number | null): number | null {
+    if (words == null || words < 0) return null;
+    return Math.round((words / ListenModel.wordsPerMinute) * 60);
+  }
+}

--- a/servers/parser-graphql-wrapper/src/model.ts
+++ b/servers/parser-graphql-wrapper/src/model.ts
@@ -19,6 +19,7 @@ export interface Item {
   excerpt?: string;
   wordCount?: number;
   timeToRead?: number;
+  listenDuration?: number;
   images?: Image[];
   videos?: Video[];
   authors: Author[];


### PR DESCRIPTION
Pull the estimated words per minute constant value from web repo, and estimate listen duration based on word count of article body.

[POCKET-9647]

[POCKET-9647]: https://mozilla-hub.atlassian.net/browse/POCKET-9647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ