### PR TITLE
feat(v3proxy:send): return error data for invalid /send actions

### DIFF
--- a/servers/v3-proxy-api/src/errors/InvalidActionError.ts
+++ b/servers/v3-proxy-api/src/errors/InvalidActionError.ts
@@ -1,0 +1,12 @@
+/**
+ * Class for handling rejected queries due to failed validation.
+ */
+export class InvalidActionError extends Error {
+  status: 405;
+  constructor(action: string) {
+    super(`Invalid Action: '${action}'`);
+    this.status = 405;
+    // Set prototype chain for instance checks
+    Object.setPrototypeOf(this, InvalidActionError.prototype);
+  }
+}

--- a/servers/v3-proxy-api/src/routes/validations/SendActionValidators.ts
+++ b/servers/v3-proxy-api/src/routes/validations/SendActionValidators.ts
@@ -40,12 +40,17 @@ export type TagDeleteAction = {
   time: number;
 };
 
+export type UnimplementedAction = {
+  action: string;
+};
+
 export type SendAction =
   | ItemAction
   | ItemAddAction
   | ItemTagAction
   | TagDeleteAction
-  | TagRenameAction;
+  | TagRenameAction
+  | UnimplementedAction;
 
 type ItemActionNames =
   | 'archive'
@@ -64,7 +69,8 @@ type ActionNames =
   | AddActionName
   | TagRenameActionName
   | TagDeleteActionName
-  | ItemTagActionNames;
+  | ItemTagActionNames
+  | string;
 
 export type MaybeAction = { action: ActionNames; [key: string]: string };
 
@@ -659,13 +665,7 @@ export function ActionSanitizer(input: MaybeAction): SendAction {
         action: input.action,
       }).validate();
     default:
-      // Should never reach this due to earlier validations
-      // but just in case...
-      throw new InputValidationError({
-        type: 'array_field',
-        path: 'action',
-        msg: `Invalid action`,
-        value: input.action,
-      });
+      // This is an action that we do not support
+      return { action: input.action };
   }
 }

--- a/servers/v3-proxy-api/src/routes/validations/SendSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/SendSchema.ts
@@ -33,25 +33,7 @@ export const V3SendSchema: Schema = {
     notEmpty: true,
   },
   'actions[*].action': {
-    isIn: {
-      options: [
-        [
-          'add',
-          'readd',
-          'archive',
-          'favorite',
-          'unfavorite',
-          'delete',
-          'tags_add',
-          'tags_remove',
-          'tags_replace',
-          'tags_clear',
-          'tag_rename',
-          'tag_delete',
-        ],
-      ],
-      bail: true,
-      errorMessage: `Invalid action`,
-    },
+    isString: true,
+    notEmpty: true,
   },
 };


### PR DESCRIPTION
Rather than rejecting requests that contain unsupported send actions, treat them as though they returned errors.

To support android client which sends actions that are no longer used, but we don't want the API to reject.

[POCKET-9822]

[POCKET-9822]: https://mozilla-hub.atlassian.net/browse/POCKET-9822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ