### PR TITLE
fix(sentry): ensure sentry is always same version

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -1,23 +1,42 @@
 {
-    "$schema": "https://unpkg.com/syncpack@12.3.0/dist/schema.json",
-    "dependencyTypes": ["dev", "peer", "prod", "nodeEngine"],
-    "customTypes": {
-        "nodeEngine": {
-          "path": "engines.node",
-          "strategy": "version"
-        }
+  "$schema": "https://unpkg.com/syncpack@12.3.0/dist/schema.json",
+  "dependencyTypes": [
+    "dev",
+    "peer",
+    "prod",
+    "nodeEngine"
+  ],
+  "customTypes": {
+    "nodeEngine": {
+      "path": "engines.node",
+      "strategy": "version"
+    }
+  },
+  "versionGroups": [
+    {
+      "dependencies": [
+        "@aws-sdk/**"
+      ],
+      "label": "AWS SDK Dependencies should all have the same version"
     },
-    "versionGroups": [
-        {
-          "dependencies": ["@aws-sdk/**"],
-          "label": "AWS SDK Dependencies should all have the same version"
-        },
-        {
-            "dependencies": ["@types/**"],
-            "dependencyTypes": ["!dev"],
-            "isBanned": true,
-            "label": "@types packages should only be under devDependencies",
-            "packages": ["!tsconfig"]
-        }
+    {
+      "dependencies": [
+        "@sentry/**"
+      ],
+      "label": "Sentry Dependencies should all have the same version"
+    },
+    {
+      "dependencies": [
+        "@types/**"
+      ],
+      "dependencyTypes": [
+        "!dev"
+      ],
+      "isBanned": true,
+      "label": "@types packages should only be under devDependencies",
+      "packages": [
+        "!tsconfig"
       ]
+    }
+  ]
 }


### PR DESCRIPTION
## Goal

Content folks just hit a bug where sentry was not the same version across the repo. 

This should ensure that we don't encounter this.