### PR TITLE
fix(v3proxy:send): parse send request actions

### DIFF
--- a/servers/v3-proxy-api/src/routes/v3Send.ts
+++ b/servers/v3-proxy-api/src/routes/v3Send.ts
@@ -1,6 +1,11 @@
 import { NextFunction, Request, Response, Router } from 'express';
 import { checkSchema, validationResult, matchedData } from 'express-validator';
-import { V3SendSchema, ActionSanitizer, V3SendParams } from './validations';
+import {
+  ActionSanitizer,
+  V3SendParams,
+  V3SendSchemaGet,
+  V3SendSchemaPost,
+} from './validations';
 import { InputValidationError } from '../errors/InputValidationError';
 import { SendAction } from './validations/SendActionValidators';
 import { ActionsRouter } from './ActionsRouter';
@@ -48,7 +53,7 @@ const v3SendController = async (
   }
 };
 
-router.get('/', checkSchema(V3SendSchema, ['query']), v3SendController);
-router.post('/', checkSchema(V3SendSchema, ['body']), v3SendController);
+router.get('/', checkSchema(V3SendSchemaGet, ['query']), v3SendController);
+router.post('/', checkSchema(V3SendSchemaPost, ['body']), v3SendController);
 
 export default router;

--- a/servers/v3-proxy-api/src/routes/validations/SendSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/SendSchema.ts
@@ -15,7 +15,7 @@ export type V3SendParams = {
  * This gives us some safety from bad user input values
  * and limits the cases we have to handle downstream.
  */
-export const V3SendSchema: Schema = {
+export const V3SendSchemaPost: Schema = {
   access_token: {
     isString: true,
     notEmpty: {
@@ -35,5 +35,43 @@ export const V3SendSchema: Schema = {
   'actions[*].action': {
     isString: true,
     notEmpty: true,
+  },
+};
+
+/**
+ * Schema for valid V3 GET/POST requests.
+ * Depending on the method, checkSchema looks
+ * for the data in the query or the body.
+ *
+ * This gives us some safety from bad user input values
+ * and limits the cases we have to handle downstream.
+ */
+export const V3SendSchemaGet: Schema = {
+  access_token: {
+    isString: true,
+    notEmpty: {
+      errorMessage: '`access_token` cannot be empty',
+    },
+  },
+  consumer_key: {
+    isString: true,
+    notEmpty: {
+      errorMessage: '`consumer_key` cannot be empty',
+    },
+  },
+  actions: {
+    isString: true,
+    notEmpty: true,
+    customSanitizer: {
+      options: (value) => JSON.parse(decodeURIComponent(value)),
+    },
+    custom: {
+      options: (arr) =>
+        arr.length > 0 &&
+        arr.filter((action) => !(action.action && action.action !== ''))
+          .length === 0
+          ? true
+          : false,
+    },
   },
 };


### PR DESCRIPTION
Android sends URI-encoded stringified JSON actions to v3/send via GET verb. This update validates and parses this string and serializes it correctly into actions array.

[POCKET-9822]

[POCKET-9822]: https://mozilla-hub.atlassian.net/browse/POCKET-9822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ