### PR TITLE
fix(alb): adding in alb access logs

### DIFF
--- a/infrastructure/image-api/src/config/index.ts
+++ b/infrastructure/image-api/src/config/index.ts
@@ -9,12 +9,9 @@ const domain = isDev
   : `${domainPrefix}.readitlater.com`;
 const graphqlVariant = isDev ? 'development' : 'current';
 const releaseSha = process.env.CIRCLE_SHA1;
+const s3LogsBucket = isDev ? 'pocket-data-items-dev' : 'pocket-data-items';
 
 const appPort = 4867;
-
-const cacheNodes = 2;
-// no/low utilization, setting to smallest instance available in dev and prod
-const cacheSize = isDev ? 'cache.t3.micro' : 'cache.t3.micro';
 
 export const config = {
   name,
@@ -23,12 +20,11 @@ export const config = {
   prefix,
   circleCIPrefix: `/${name}/CircleCI/${environment}`,
   shortName: 'IMGAPI',
+  s3LogsBucket,
   appPort,
   environment,
   domain,
   graphqlVariant,
-  cacheNodes,
-  cacheSize,
   releaseSha,
   tags: {
     service: name,

--- a/infrastructure/image-api/src/main.ts
+++ b/infrastructure/image-api/src/main.ts
@@ -163,6 +163,9 @@ class ImageAPI extends TerraformStack {
       tags: config.tags,
       cdn: false,
       domain: config.domain,
+      accessLogs: {
+        existingBucket: config.s3LogsBucket,
+      },
       containerConfigs: [
         {
           name: 'app',

--- a/infrastructure/list-api/src/config/index.ts
+++ b/infrastructure/list-api/src/config/index.ts
@@ -8,6 +8,7 @@ const domain = isDev
   : `${domainPrefix}.readitlater.com`;
 const graphqlVariant = isDev ? 'development' : 'current';
 const releaseSha = process.env.CIRCLE_SHA1;
+const s3LogsBucket = isDev ? 'pocket-data-items-dev' : 'pocket-data-items';
 
 export const config = {
   name,
@@ -17,6 +18,7 @@ export const config = {
   shortName: 'LSTAPI',
   releaseSha,
   environment,
+  s3LogsBucket,
   rds: {
     minCapacity: 1,
     maxCapacity: isDev ? 1 : undefined,

--- a/infrastructure/list-api/src/main.ts
+++ b/infrastructure/list-api/src/main.ts
@@ -202,6 +202,9 @@ class ListAPI extends TerraformStack {
       tags: config.tags,
       cdn: false,
       domain: config.domain,
+      accessLogs: {
+        existingBucket: config.s3LogsBucket,
+      },
       taskSize: {
         cpu: 1024,
         memory: 2048,

--- a/infrastructure/parser-graphql-wrapper/src/config/index.ts
+++ b/infrastructure/parser-graphql-wrapper/src/config/index.ts
@@ -8,9 +8,7 @@ const domain = isDev
   : `${domainPrefix}.readitlater.com`;
 const graphqlVariant = isDev ? 'development' : 'current';
 const releaseSha = process.env.CIRCLE_SHA1;
-
-const cacheNodes = 2;
-const cacheSize = isDev ? 'cache.t3.micro' : 'cache.m6g.large';
+const s3LogsBucket = isDev ? 'pocket-data-items-dev' : 'pocket-data-items';
 
 export const config = {
   name,
@@ -23,8 +21,7 @@ export const config = {
   releaseSha,
   environment,
   domain,
-  cacheNodes,
-  cacheSize,
+  s3LogsBucket,
   tags: {
     service: name,
     environment,

--- a/infrastructure/parser-graphql-wrapper/src/main.ts
+++ b/infrastructure/parser-graphql-wrapper/src/main.ts
@@ -164,6 +164,9 @@ class ParserGraphQLWrapper extends TerraformStack {
       tags: config.tags,
       cdn: false,
       domain: config.domain,
+      accessLogs: {
+        existingBucket: config.s3LogsBucket,
+      },
       taskSize: {
         cpu: 2048,
         memory: 4096,

--- a/infrastructure/shareable-lists-api/src/config/index.ts
+++ b/infrastructure/shareable-lists-api/src/config/index.ts
@@ -14,8 +14,7 @@ const rds = {
 const eventBusName = `PocketEventBridge-${environment}-Shared-Event-Bus`;
 const releaseSha = process.env.CIRCLE_SHA1;
 
-const cacheNodes = isDev ? 2 : 2;
-const cacheSize = isDev ? 'cache.t3.micro' : 'cache.t3.micro';
+const s3LogsBucket = isDev ? 'pocket-data-items-dev' : 'pocket-data-items';
 
 export const config = {
   name,
@@ -29,8 +28,7 @@ export const config = {
   domain,
   graphqlVariant,
   rds,
-  cacheNodes,
-  cacheSize,
+  s3LogsBucket,
   reservedConcurrencyLimit: 1, // A maximum of 1 instance of the Lambda shall be running at whatever time needed.
   tags: {
     service: name,

--- a/infrastructure/shareable-lists-api/src/main.ts
+++ b/infrastructure/shareable-lists-api/src/main.ts
@@ -277,6 +277,9 @@ class ShareableListsAPI extends TerraformStack {
       tags: config.tags,
       cdn: false,
       domain: config.domain,
+      accessLogs: {
+        existingBucket: config.s3LogsBucket,
+      },
       containerConfigs: [
         {
           name: 'app',

--- a/infrastructure/shared-snowplow-consumer/src/config/index.ts
+++ b/infrastructure/shared-snowplow-consumer/src/config/index.ts
@@ -6,10 +6,7 @@ const domain = isDev
   ? `${domainPrefix}.getpocket.dev`
   : `${domainPrefix}.readitlater.com`;
 const releaseSha = process.env.CIRCLE_SHA1;
-
-//Arbitrary size and count for cache. No logic was used in deciding this.
-const cacheNodes = isDev ? 2 : 2;
-const cacheSize = isDev ? 'cache.t2.micro' : 'cache.t3.medium';
+const s3LogsBucket = isDev ? 'pocket-data-items-dev' : 'pocket-data-items';
 
 const snowplowEndpoint = isDev
   ? 'com-getpocket-prod1.mini.snplow.net'
@@ -25,8 +22,7 @@ export const config = {
   releaseSha,
   environment,
   domain,
-  cacheNodes,
-  cacheSize,
+  s3LogsBucket,
   tracing: {
     host: 'localhost',
   },

--- a/infrastructure/shared-snowplow-consumer/src/sharedSnowplowConsumerApp.ts
+++ b/infrastructure/shared-snowplow-consumer/src/sharedSnowplowConsumerApp.ts
@@ -54,6 +54,9 @@ export class SharedSnowplowConsumerApp extends Construct {
       tags: config.tags,
       cdn: false,
       domain: config.domain,
+      accessLogs: {
+        existingBucket: config.s3LogsBucket,
+      },
       containerConfigs: [
         {
           name: 'app',

--- a/infrastructure/user-api/src/config/index.ts
+++ b/infrastructure/user-api/src/config/index.ts
@@ -8,6 +8,7 @@ const domain = isDev
 const graphqlVariant = isDev ? 'development' : 'current';
 const eventBusName = `PocketEventBridge-${environment}-Shared-Event-Bus`;
 const releaseSha = process.env.CIRCLE_SHA1;
+const s3LogsBucket = isDev ? 'pocket-data-items-dev' : 'pocket-data-items';
 
 export const config = {
   name,
@@ -18,6 +19,7 @@ export const config = {
   environment,
   domain,
   graphqlVariant,
+  s3LogsBucket,
   database: {
     port: '3306',
   },

--- a/infrastructure/user-api/src/main.ts
+++ b/infrastructure/user-api/src/main.ts
@@ -131,6 +131,9 @@ class UserAPI extends TerraformStack {
       tags: config.tags,
       cdn: false,
       domain: config.domain,
+      accessLogs: {
+        existingBucket: config.s3LogsBucket,
+      },
       containerConfigs: [
         {
           name: 'app',

--- a/infrastructure/v3-proxy-api/src/config/index.ts
+++ b/infrastructure/v3-proxy-api/src/config/index.ts
@@ -6,11 +6,13 @@ const domain = isDev
   ? `${domainPrefix}.getpocket.dev`
   : `${domainPrefix}.readitlater.com`;
 const port = 4030;
+const s3LogsBucket = isDev ? 'pocket-data-items-dev' : 'pocket-data-items';
 
 export const config = {
   name,
   isDev,
   port,
+  s3LogsBucket,
   prefix: `${name}-${environment}`,
   circleCIPrefix: `/${name}/CircleCI/${environment}`,
   shortName: 'v3Prxy', // max 6 characters

--- a/infrastructure/v3-proxy-api/src/main.ts
+++ b/infrastructure/v3-proxy-api/src/main.ts
@@ -112,6 +112,9 @@ class Stack extends TerraformStack {
       tags: config.tags,
       cdn: false,
       domain: config.domain,
+      accessLogs: {
+        existingBucket: config.s3LogsBucket,
+      },
       containerConfigs: [
         {
           name: 'app',


### PR DESCRIPTION
# Goal

As we roll out the v3-proxy we want as much observability as possible to mitigate any issues.

This enables dumping alb logs to our S3 bucket that can be piped into Athena or Snowflake for quick querying and analysis.