### PR TITLE
feat(v3proxy): enable requesting annotations on fetch

### DIFF
--- a/servers/v3-proxy-api/src/graph/get/toRest.ts
+++ b/servers/v3-proxy-api/src/graph/get/toRest.ts
@@ -425,9 +425,10 @@ export function savedItemsCompleteToRest(
 export function savedItemsFetchToRest(
   passthrough: PassthroughResponse,
   response: SavedItemsCompleteQuery,
+  options?: { withAnnotations?: boolean },
 ): FetchResponse {
   return {
-    ...savedItemsCompleteTotalToRest(response),
+    ...savedItemsCompleteTotalToRest(response, options),
     passthrough,
   };
 }
@@ -439,10 +440,11 @@ export function savedItemsFetchToRest(
 export function savedItemsFetchSharesToRest(
   passthrough: PassthroughResponse,
   response: SavedItemsCompleteQuery,
+  options?: { withAnnotations?: boolean },
 ): FetchResponse & GetSharesResponse {
   return {
     ...staticV3ShareResponseDefaults,
-    ...savedItemsCompleteTotalToRest(response),
+    ...savedItemsCompleteTotalToRest(response, options),
     passthrough,
   };
 }

--- a/servers/v3-proxy-api/src/routes/v3Fetch.ts
+++ b/servers/v3-proxy-api/src/routes/v3Fetch.ts
@@ -69,7 +69,7 @@ export async function processV3call(
   if (data.offset == 0) {
     data.count = 25; // set the intial page size to a smaller value to allow the user to see something as quickly as possible
   }
-
+  const options = { withAnnotations: data.annotations };
   //do sometthing to count here for page size.
   const params: V3GetParams = {
     detailType: 'complete',
@@ -79,7 +79,7 @@ export async function processV3call(
     count: data.count,
     offset: data.offset,
     sort: 'newest',
-    annotations: false,
+    annotations: data.annotations,
   };
 
   // Otherwise call SavedItems list api
@@ -90,6 +90,7 @@ export async function processV3call(
     consumerKey,
     headers,
     variables,
+    options,
   );
 
   const nextChunkSize = '250'; // Every chunk after the first one is always 250. This informs the client how many to download next.
@@ -102,6 +103,7 @@ export async function processV3call(
         chunk: data.chunk.toFixed(),
       },
       response,
+      options,
     );
   }
 
@@ -112,6 +114,7 @@ export async function processV3call(
       chunk: data.chunk.toFixed(),
     },
     response,
+    options,
   );
 }
 

--- a/servers/v3-proxy-api/src/routes/validations/FetchSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/FetchSchema.ts
@@ -7,6 +7,7 @@ import { Schema } from 'express-validator';
 export type V3FetchParams = {
   access_token: string;
   consumer_key: string;
+  annotations: boolean;
   chunk?: number;
   count: number;
   offset: number;
@@ -88,6 +89,17 @@ export const V3FetchSchema: Schema = {
     },
   },
   shares: {
+    default: {
+      options: '0',
+    },
+    isIn: {
+      options: [['0', '1']],
+    },
+    customSanitizer: {
+      options: (value) => (value === '1' ? true : false),
+    },
+  },
+  annotations: {
     default: {
       options: '0',
     },


### PR DESCRIPTION
This is possible on the current /v3/fetch endpoint but was previously only implemented on /v3/get on the proxy.