### PR TITLE
fix(errors): cleanup the error logs

### DIFF
--- a/packages/apollo-utils/src/sentry/apolloSentryPlugin.ts
+++ b/packages/apollo-utils/src/sentry/apolloSentryPlugin.ts
@@ -82,7 +82,6 @@ export const sentryPlugin: ApolloServerPlugin<BaseContext> = {
             data: errorData,
             error: err,
             message: err.message,
-            stack: err.stack, // parity with Sentry setup
           });
 
           const scope = Sentry.getCurrentScope();

--- a/servers/parser-graphql-wrapper/src/dataLoaders/articleLoader.ts
+++ b/servers/parser-graphql-wrapper/src/dataLoaders/articleLoader.ts
@@ -41,7 +41,12 @@ export const getArticleByUrl = async (
   const data = await new FetchHandler().fetchJSON(endpoint);
   // check if there's an item
   if (!data || (data && !data.item)) {
-    Sentry.captureException(new Error(`No item found for URL: ${url}`));
+    Sentry.addBreadcrumb({
+      level: 'debug',
+      message: 'article loader parser request',
+      data: { originalUrl: url, endpoint },
+    });
+    Sentry.captureException(new Error(`No item found for URL`));
     return null;
   }
 


### PR DESCRIPTION
## Goal

Our logs are filled with unhelpful stack traces that provide too much data.

This removes the stack from the server logs.

## Parser
Separately we need some more data on the parser to better debug issues we are currently seeing.