### PR TITLE
fix(v3proxy:search): ignore empty search term instead of rejecting query

### DIFF
--- a/servers/v3-proxy-api/src/routes/v3Get.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Get.integration.ts
@@ -172,7 +172,7 @@ describe('v3Get', () => {
         consumer_key: 'test',
         access_token: 'test',
         search: '',
-        detailType: 'simpe',
+        detailType: 'simple',
       });
       expect(response.status).toEqual(200);
       expect(nonSearchApi).toHaveBeenCalledTimes(1);

--- a/servers/v3-proxy-api/src/routes/v3Get.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Get.integration.ts
@@ -164,6 +164,32 @@ describe('v3Get', () => {
       expect(response.headers['x-source']).toBe(expectedHeaders['X-Source']);
       expect(searchApi).toHaveBeenCalledTimes(1);
     });
+    it('ignores empty search term and does not call search (simple)', async () => {
+      const nonSearchApi = jest
+        .spyOn(GraphQLCalls, 'callSavedItemsByOffsetSimple')
+        .mockImplementation(() => Promise.resolve(mockGraphGetSimple));
+      const response = await request(app).get('/v3/get').query({
+        consumer_key: 'test',
+        access_token: 'test',
+        search: '',
+        detailType: 'simpe',
+      });
+      expect(response.status).toEqual(200);
+      expect(nonSearchApi).toHaveBeenCalledTimes(1);
+    });
+    it('ignores empty search term and does not call search (complete)', async () => {
+      const nonSearchApi = jest
+        .spyOn(GraphQLCalls, 'callSavedItemsByOffsetComplete')
+        .mockImplementation(() => Promise.resolve(mockGraphGetComplete));
+      const response = await request(app).get('/v3/get').query({
+        consumer_key: 'test',
+        access_token: 'test',
+        search: '',
+        detailType: 'complete',
+      });
+      expect(response.status).toEqual(200);
+      expect(nonSearchApi).toHaveBeenCalledTimes(1);
+    });
   });
   describe('with annotations option', () => {
     let clientSpy;

--- a/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
@@ -127,9 +127,7 @@ export const V3GetSchema: Schema = {
     optional: true,
     isString: true,
     customSanitizer: {
-      options: (value) => {
-        if (value === '') return undefined;
-      },
+      options: (value) => (value === '' ? undefined : value),
     },
   },
   sort: {

--- a/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
@@ -126,7 +126,11 @@ export const V3GetSchema: Schema = {
   search: {
     optional: true,
     isString: true,
-    notEmpty: true,
+    customSanitizer: {
+      options: (value) => {
+        if (value === '') return undefined;
+      },
+    },
   },
   sort: {
     toLowerCase: true,


### PR DESCRIPTION
Existing android versions sometimes pass search term that is empty (not intending to search, just there)

[POCKET-9898]

[POCKET-9898]: https://mozilla-hub.atlassian.net/browse/POCKET-9898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ