### PR TITLE
feat(list:tagslist): support v3 tag list query

### DIFF
--- a/servers/list-api/schema.graphql
+++ b/servers/list-api/schema.graphql
@@ -606,6 +606,19 @@ type User @key(fields: "id") {
   tags(pagination: PaginationInput): TagConnection
 
   """
+  Get all tag names for a user.
+  If syncSince is passed, it will only return tags if changes
+  to a user's tags have occurred after syncSince. It will return
+  all of the user's tags (not just the changes).
+
+  Yes, this is bad graphql design. It's serving a specific
+  REST API which has unlimited SQL queries, and we do not want to
+  make it possible to request every associated SavedItem
+  node on a tag object. Just biting the bullet on this one.
+  """
+  tagsList(syncSince: ISOString): [String!] @tag(name: "v3proxy")
+
+  """
   Get a SavedItem by its id
   """
   savedItemById(id: ID!): SavedItem @deprecated(reason: "Use saveById instead")

--- a/servers/list-api/src/models/tag.ts
+++ b/servers/list-api/src/models/tag.ts
@@ -446,6 +446,10 @@ export class TagModel {
   private async getItemIdAssociations(tag: string): Promise<string[]> {
     return await this.tagService.fetchItemIdAssociations(tag);
   }
+
+  public async tagsList(syncSince?: Date): Promise<string[] | undefined> {
+    return await this.tagService.tagsList(syncSince);
+  }
 }
 
 /**

--- a/servers/list-api/src/resolvers/index.ts
+++ b/servers/list-api/src/resolvers/index.ts
@@ -72,6 +72,13 @@ const resolvers = {
     savedItems,
     savedItemsByOffset: savedItemsPage,
     tags: userTags,
+    async tagsList(
+      _,
+      args: { syncSince?: Date },
+      context: IContext,
+    ): Promise<string[] | undefined> {
+      return await context.models.tag.tagsList(args.syncSince);
+    },
   },
   Item: {
     savedItem: async (item: Item, args, context: IContext) => {

--- a/servers/list-api/src/test/graphql/queries/tagsList.integration.ts
+++ b/servers/list-api/src/test/graphql/queries/tagsList.integration.ts
@@ -1,0 +1,147 @@
+import { readClient, writeClient } from '../../../database/client';
+import { ContextManager } from '../../../server/context';
+import { startServer } from '../../../server/apollo';
+import { Application } from 'express';
+import { ApolloServer } from '@apollo/server';
+import request from 'supertest';
+import Chance from 'chance';
+import { gql } from 'graphql-tag';
+import { print } from 'graphql';
+
+describe('tagsList query', () => {
+  const writeDb = writeClient();
+  const readDb = readClient();
+  const headers = { userid: '1' };
+  let app: Application;
+  let url: string;
+  let server: ApolloServer<ContextManager>;
+  const chance = new Chance();
+
+  const tagSet = Array(8)
+    .fill(0)
+    .map((_) => chance.word());
+
+  const TAGS_LIST = gql`
+    query tagsList($userId: ID!, $since: ISOString) {
+      _entities(representations: { id: $userId, __typename: "User" }) {
+        ... on User {
+          tagsList(syncSince: $since)
+        }
+      }
+    }
+  `;
+
+  beforeAll(async () => {
+    ({ app, server, url } = await startServer(0));
+    await writeDb('list').truncate();
+    await writeDb('item_tags').truncate();
+  });
+
+  afterAll(async () => {
+    await writeDb.destroy();
+    await readDb.destroy();
+    await server.stop();
+  });
+  describe('without tags', () => {
+    it('returns an empty list', async () => {
+      const variables = {
+        userId: '1',
+      };
+      const res = await request(app)
+        .post(url)
+        .set(headers)
+        .send({
+          query: print(TAGS_LIST),
+          variables,
+        });
+      const expected = {
+        tagsList: [],
+      };
+      expect(res.body.errors).toBeUndefined();
+      expect(res.body.data._entities[0]).toEqual(expected);
+    });
+  });
+  describe('with tags', () => {
+    beforeAll(async () => {
+      const tags = Array(20)
+        .fill(0)
+        .map((_, ix) => tagSet[ix % tagSet.length]);
+      const insertTags = tags.map((tag) => ({
+        user_id: 1,
+        item_id: chance.natural(),
+        tag,
+        status: 1,
+        time_added: chance.date(),
+        time_updated: chance.date(),
+        api_id: 'apiid',
+        api_id_updated: 'updated_api_id',
+      }));
+      await writeDb('item_tags').insert(insertTags).onConflict().ignore();
+    });
+    it('returns a list of all tags for a user (no syncSince)', async () => {
+      const variables = {
+        userId: '1',
+      };
+      const res = await request(app)
+        .post(url)
+        .set(headers)
+        .send({
+          query: print(TAGS_LIST),
+          variables,
+        });
+      const expected = {
+        tagsList: expect.toIncludeSameMembers(tagSet),
+      };
+      expect(res.body.errors).toBeUndefined();
+      expect(res.body.data._entities[0]).toEqual(expected);
+    });
+    describe('with syncSince', () => {
+      beforeAll(async () => await writeDb('users_meta').truncate());
+      afterEach(async () => await writeDb('users_meta').truncate());
+      it('does not return data if tags data has not changed since syncSince', async () => {
+        const variables = {
+          userId: '1',
+          since: new Date().toISOString(),
+        };
+        await writeDb('users_meta').insert({
+          user_id: 1,
+          property: 18,
+          value: '2010-03-05 00:00:00',
+        });
+        const res = await request(app)
+          .post(url)
+          .set(headers)
+          .send({
+            query: print(TAGS_LIST),
+            variables,
+          });
+        expect(res.body.errors).toBeUndefined();
+        expect(res.body.data._entities[0].tagsList).toBeNull();
+      });
+
+      it('does return data if data has changed since syncSince', async () => {
+        await writeDb('users_meta').insert({
+          user_id: 1,
+          property: 18,
+          value: '2024-03-05 00:00:00',
+        });
+        const variables = {
+          userId: '1',
+          since: '2023-01-01T00:00:00.000Z',
+        };
+        const res = await request(app)
+          .post(url)
+          .set(headers)
+          .send({
+            query: print(TAGS_LIST),
+            variables,
+          });
+        const expected = {
+          tagsList: expect.toIncludeSameMembers(tagSet),
+        };
+        expect(res.body.errors).toBeUndefined();
+        expect(res.body.data._entities[0]).toEqual(expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
I don't like doing stuff like this but I'd rather have it separate than provide an unpaginated way to potentially retrieve every saved item connection.

[POCKET-9913]

[POCKET-9913]: https://mozilla-hub.atlassian.net/browse/POCKET-9913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ