### PR TITLE
fix(fetch): default annotations to on for fetch

### DIFF
--- a/servers/v3-proxy-api/src/routes/validations/FetchSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/FetchSchema.ts
@@ -101,7 +101,7 @@ export const V3FetchSchema: Schema = {
   },
   annotations: {
     default: {
-      options: '0',
+      options: '1',
     },
     isIn: {
       options: [['0', '1']],


### PR DESCRIPTION
## Goal

Android does not fetch annotations by default on initial login, but should so users get their highlights.

https://mozilla-hub.atlassian.net/browse/POCKET-9924