### PR TITLE
fix(sort): adding in longest and shortest sort no-op

### DIFF
--- a/servers/v3-proxy-api/src/routes/v3Get.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Get.integration.ts
@@ -441,6 +441,32 @@ describe('v3Get', () => {
         sort: 'newest',
         since: '12345',
       },
+      {
+        consumer_key: 'test',
+        access_token: 'test',
+        detailType: 'complete',
+        contentType: 'article',
+        count: '10',
+        offset: '10',
+        state: 'read',
+        favorite: '0',
+        tag: 'tag',
+        sort: 'longest',
+        since: '12345',
+      },
+      {
+        consumer_key: 'test',
+        access_token: 'test',
+        detailType: 'complete',
+        contentType: 'article',
+        count: '10',
+        offset: '10',
+        state: 'read',
+        favorite: '0',
+        tag: 'tag',
+        sort: 'shortest',
+        since: '12345',
+      },
     ])('should work with valid query parameters (GET)', async (params) => {
       jest
         .spyOn(GraphQLCalls, 'callSavedItemsByOffsetComplete')

--- a/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
@@ -134,6 +134,8 @@ export const V3GetSchema: Schema = {
     toLowerCase: true,
     customSanitizer: {
       options: (value, { req }) => {
+        // Android sends in shortest and longest, but this is not supported by legacy v3/get.
+        if (['shortest', 'longest'].includes(value)) return 'newest';
         if (value) return value;
         if (req.body.search || req.query.search) {
           return 'relevance';
@@ -142,7 +144,7 @@ export const V3GetSchema: Schema = {
       },
     },
     isIn: {
-      options: [['newest', 'oldest', 'relevance']],
+      options: [['newest', 'oldest', 'relevance', 'longest', 'shortest']],
     },
     custom: {
       options: (value, { req }) => {


### PR DESCRIPTION
## goal

Allow android requests on get for shortest and longest sort order to succeed