### PR TITLE
fix(lambda-layer): native fetch & retries

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -37,6 +37,15 @@
       "packages": [
         "!tsconfig"
       ]
+    },
+    {
+      "dependencies": [
+        "nock"
+      ],
+      "label": "Nock should be the same version except for lambda-secrets because of native fetch",
+      "packages": [
+        "!@pocket-tools/lambda-secrets"
+      ]
     }
   ]
 }

--- a/packages/lambda-secrets/package.json
+++ b/packages/lambda-secrets/package.json
@@ -25,11 +25,9 @@
     "jest": "29.7.0",
     "ts-jest": "29.1.2",
     "tsconfig": "workspace:*",
-    "@types/node-fetch": "2.6.11"
+    "nock": "14.0.0-beta.5"
   },
-  "dependencies": {
-    "node-fetch": "2.7.0"
-  },
+  "dependencies": {},
   "files": [
     "dist",
     "package.json"

--- a/packages/lambda-secrets/src/secret.spec.ts
+++ b/packages/lambda-secrets/src/secret.spec.ts
@@ -50,6 +50,18 @@ describe('lambda secrets', () => {
       .get(`/secretsmanager/get?secretId=${encodeURIComponent(secretName)}`)
       .matchHeader('X-Aws-Parameters-Secrets-Token', session)
       .reply(500);
+    nock(`http://localhost:2773`)
+      .get(`/secretsmanager/get?secretId=${encodeURIComponent(secretName)}`)
+      .matchHeader('X-Aws-Parameters-Secrets-Token', session)
+      .reply(500);
+    nock(`http://localhost:2773`)
+      .get(`/secretsmanager/get?secretId=${encodeURIComponent(secretName)}`)
+      .matchHeader('X-Aws-Parameters-Secrets-Token', session)
+      .reply(500);
+    nock(`http://localhost:2773`)
+      .get(`/secretsmanager/get?secretId=${encodeURIComponent(secretName)}`)
+      .matchHeader('X-Aws-Parameters-Secrets-Token', session)
+      .reply(500);
     try {
       await fetchSecret(secretName);
     } catch (e) {
@@ -105,6 +117,24 @@ describe('lambda parameters', () => {
     process.env.AWS_SESSION_TOKEN = session;
     expect.assertions(1);
     cleanAll();
+    nock(`http://localhost:2773`)
+      .get(
+        `/systemsmanager/parameters/get?name=${encodeURIComponent(secretName)}`,
+      )
+      .matchHeader('X-Aws-Parameters-Secrets-Token', session)
+      .reply(500);
+    nock(`http://localhost:2773`)
+      .get(
+        `/systemsmanager/parameters/get?name=${encodeURIComponent(secretName)}`,
+      )
+      .matchHeader('X-Aws-Parameters-Secrets-Token', session)
+      .reply(500);
+    nock(`http://localhost:2773`)
+      .get(
+        `/systemsmanager/parameters/get?name=${encodeURIComponent(secretName)}`,
+      )
+      .matchHeader('X-Aws-Parameters-Secrets-Token', session)
+      .reply(500);
     nock(`http://localhost:2773`)
       .get(
         `/systemsmanager/parameters/get?name=${encodeURIComponent(secretName)}`,

--- a/packages/lambda-secrets/src/secrets.ts
+++ b/packages/lambda-secrets/src/secrets.ts
@@ -9,7 +9,7 @@ export const fetchSecret = async (
   secretName: string,
 ): Promise<Record<string, string>> => {
   const secretExtensionEndpoint: string = `/secretsmanager/get?secretId=${encodeURIComponent(secretName)}`;
-  const secret = await fetchFromLambda(secretExtensionEndpoint);
+  const secret = await fetchFromLambda(secretExtensionEndpoint, 3);
   // Secret string is itself a JSON string that needs to be decoded
   return JSON.parse(secret.SecretString);
 };
@@ -23,11 +23,14 @@ export const fetchParameter = async (
   parameterName: string,
 ): Promise<string> => {
   const secretExtensionEndpoint: string = `/systemsmanager/parameters/get?name=${encodeURIComponent(parameterName)}`;
-  const secret = await fetchFromLambda(secretExtensionEndpoint);
+  const secret = await fetchFromLambda(secretExtensionEndpoint, 3);
   return secret.Parameter.Value;
 };
 
-const fetchFromLambda = async (url: string): Promise<Record<string, any>> => {
+const fetchFromLambda = async (
+  url: string,
+  tries: number,
+): Promise<Record<string, any>> => {
   if (
     !process.env.AWS_SESSION_TOKEN ||
     process.env.AWS_SESSION_TOKEN == 'undefined'
@@ -59,7 +62,12 @@ const fetchFromLambda = async (url: string): Promise<Record<string, any>> => {
     // endpoint does not return json headers, so we grab the text and then parse it.
     return JSON.parse(await secret.text());
   } catch (err) {
-    console.error(err);
-    throw err;
+    if (tries == 0) {
+      console.error(err);
+      throw err;
+    }
+    // adding some retry logic because lambda layer seems to have some socket issues
+    tries = tries - 1;
+    return await fetchFromLambda(url, tries);
   }
 };

--- a/packages/lambda-secrets/src/secrets.ts
+++ b/packages/lambda-secrets/src/secrets.ts
@@ -1,5 +1,3 @@
-import fetch from 'node-fetch';
-
 const debug = process.env.PARAMETERS_SECRETS_EXTENSION_LOG_LEVEL == 'debug';
 
 /**
@@ -54,9 +52,10 @@ const fetchFromLambda = async (url: string): Promise<Record<string, any>> => {
         headers: secret.headers,
       });
     }
-    if (!secret.ok) {
+    if (secret.status != 200) {
       throw new Error(`Failed fetching ${url} from lambda secret layer`);
     }
+
     // endpoint does not return json headers, so we grab the text and then parse it.
     return JSON.parse(await secret.text());
   } catch (err) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,7 +313,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
+        version: 29.1.2(@babel/core@7.24.3)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1022,10 +1022,6 @@ importers:
         version: link:../tsconfig
 
   packages/lambda-secrets:
-    dependencies:
-      node-fetch:
-        specifier: 2.7.0
-        version: 2.7.0
     devDependencies:
       '@jest/globals':
         specifier: 29.7.0
@@ -1033,15 +1029,15 @@ importers:
       '@types/jest':
         specifier: 29.5.12
         version: 29.5.12
-      '@types/node-fetch':
-        specifier: 2.6.11
-        version: 2.6.11
       eslint-config-custom:
         specifier: workspace:*
         version: link:../eslint-config-custom
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@20.12.5)(ts-node@10.9.2)
+      nock:
+        specifier: 14.0.0-beta.5
+        version: 14.0.0-beta.5
       ts-jest:
         specifier: 29.1.2
         version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
@@ -10801,7 +10797,7 @@ packages:
     dependencies:
       semver: 7.6.0
       shelljs: 0.8.5
-      typescript: 5.5.0-dev.20240408
+      typescript: 5.5.0-dev.20240409
     dev: false
 
   /dreamopt@0.8.0:
@@ -15411,6 +15407,14 @@ packages:
       - supports-color
     dev: true
 
+  /nock@14.0.0-beta.5:
+    resolution: {integrity: sha512-u255tf4DYvyErTlPZA9uTfXghiZZy+NflUOFONPVKZ5tP0yaHwKig28zyFOLhu8y5YcCRC+V5vDk4HHileh2iw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      json-stringify-safe: 5.0.1
+      propagate: 2.0.1
+    dev: true
+
   /node-abi@3.55.0:
     resolution: {integrity: sha512-uPEjtyh2tFEvWYt4Jw7McOD5FPcHkcxm/tHZc5PWaDB3JYq0rGFUbgaAK+CT5pYpQddBfsZVWI08OwoRfdfbcQ==}
     engines: {node: '>=10'}
@@ -18548,6 +18552,40 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: false
 
+  /ts-jest@29.1.2(@babel/core@7.24.3)(jest@29.7.0)(typescript@5.4.4):
+    resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}
+    engines: {node: ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.24.3
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@20.12.5)(ts-node@10.9.2)
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.6.0
+      typescript: 5.4.4
+      yargs-parser: 21.1.1
+    dev: true
+
   /ts-jest@29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4):
     resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}
     engines: {node: ^16.10.0 || ^18.0.0 || >=20.0.0}
@@ -18983,8 +19021,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.5.0-dev.20240408:
-    resolution: {integrity: sha512-WCqFA68PbE0+khOu6x2LPxePy0tKdWuNO2m2K4A/L+OPqua1Qmck9OXUQ/5nUd4B/8UlBuhkhuulQbr2LHO9vA==}
+  /typescript@5.5.0-dev.20240409:
+    resolution: {integrity: sha512-nQUzu2O0eRlESMnU/Xd9a2CD7MAvKPI1bCLB4Iu5aNA+cUymUnBAq8P3xaWipea0a3zRabE1UqwwxswMKp3X8g==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false


### PR DESCRIPTION
## Goal

The lambda secret layer can have hang up issues, so to combat this we are adding some retry logic. 

Seperately node-fetch seems to be a bit hit or miss with http requests. In testing it seems native fetch works better for this use case.