### PR TITLE
feat(readerSlug): add reader interstitial data

### DIFF
--- a/infrastructure/list-api/src/main.ts
+++ b/infrastructure/list-api/src/main.ts
@@ -156,6 +156,8 @@ class ListAPI extends TerraformStack {
      */
     let rdsCluster: ApplicationRDSCluster;
 
+    const intMaskSecretArn = `arn:aws:secretsmanager:${region.name}:${caller.accountId}:secret:Shared/IntMask`;
+
     const secretResources = [
       `arn:aws:secretsmanager:${region.name}:${caller.accountId}:secret:Shared`,
       `arn:aws:secretsmanager:${region.name}:${caller.accountId}:secret:Shared/*`,
@@ -164,6 +166,8 @@ class ListAPI extends TerraformStack {
       `arn:aws:secretsmanager:${region.name}:${caller.accountId}:secret:${config.name}/${config.environment}/*`,
       `arn:aws:secretsmanager:${region.name}:${caller.accountId}:secret:${config.prefix}`,
       `arn:aws:secretsmanager:${region.name}:${caller.accountId}:secret:${config.prefix}/*`,
+      `${intMaskSecretArn}*`,
+      `${intMaskSecretArn}/*`,
     ];
 
     // Set out the DB connection details for the production (legacy) database.
@@ -311,6 +315,30 @@ class ListAPI extends TerraformStack {
             {
               name: 'UNLEASH_KEY',
               valueFrom: `arn:aws:secretsmanager:${region.name}:${caller.accountId}:secret:${config.name}/${config.environment}/UNLEASH_KEY`,
+            },
+            {
+              name: 'CHARACTER_MAP',
+              valueFrom: `${intMaskSecretArn}:characterMap::`,
+            },
+            {
+              name: 'POSITION_MAP',
+              valueFrom: `${intMaskSecretArn}:positionMap::`,
+            },
+            {
+              name: 'MD5_RANDOMIZER',
+              valueFrom: `${intMaskSecretArn}:md5Randomizer::`,
+            },
+            {
+              name: 'LETTER_INDEX',
+              valueFrom: `${intMaskSecretArn}:letterIndex::`,
+            },
+            {
+              name: 'SALT_1',
+              valueFrom: `${intMaskSecretArn}:salt1::`,
+            },
+            {
+              name: 'SALT_2',
+              valueFrom: `${intMaskSecretArn}:salt2::`,
             },
           ],
           logGroup: this.createCustomLogGroup('app'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,7 +313,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.3)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.3)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -359,7 +359,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -399,7 +399,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -436,7 +436,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -491,7 +491,7 @@ importers:
         version: 3.1.0
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -543,7 +543,7 @@ importers:
         version: 3.1.0
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -586,7 +586,7 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -620,7 +620,7 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -660,7 +660,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -709,7 +709,7 @@ importers:
         version: 3.1.0
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -746,7 +746,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -789,7 +789,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -832,7 +832,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -905,13 +905,13 @@ importers:
         version: 4.0.2(jest@29.7.0)
       semantic-release:
         specifier: 23.0.7
-        version: 23.0.7(typescript@5.4.5)
+        version: 23.0.7(typescript@5.4.4)
       semantic-release-monorepo:
         specifier: 8.0.2
         version: 8.0.2(semantic-release@23.0.7)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -933,7 +933,7 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -988,7 +988,7 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1016,7 +1016,7 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1040,7 +1040,7 @@ importers:
         version: 14.0.0-beta.5
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1068,7 +1068,7 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1123,13 +1123,13 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
       semantic-release:
         specifier: 23.0.7
-        version: 23.0.7(typescript@5.4.5)
+        version: 23.0.7(typescript@5.4.4)
       semantic-release-monorepo:
         specifier: 8.0.2
         version: 8.0.2(semantic-release@23.0.7)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1196,7 +1196,7 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1224,13 +1224,13 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
       semantic-release:
         specifier: 23.0.7
-        version: 23.0.7(typescript@5.4.5)
+        version: 23.0.7(typescript@5.4.4)
       semantic-release-monorepo:
         specifier: 8.0.2
         version: 8.0.2(semantic-release@23.0.7)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1315,10 +1315,10 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@20.12.7)(typescript@5.4.5)
+        version: 10.9.2(@types/node@20.12.7)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1412,7 +1412,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1491,7 +1491,7 @@ importers:
         version: 3.1.0
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1549,7 +1549,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1571,6 +1571,9 @@ importers:
       '@pocket-tools/apollo-utils':
         specifier: workspace:*
         version: link:../../packages/apollo-utils
+      '@pocket-tools/int-mask':
+        specifier: workspace:*
+        version: link:../../packages/int-mask
       '@pocket-tools/sentry':
         specifier: workspace:*
         version: link:../../packages/sentry
@@ -1673,7 +1676,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1770,7 +1773,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1816,7 +1819,7 @@ importers:
         version: 3.1.0
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1904,7 +1907,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1962,7 +1965,7 @@ importers:
         version: 3.1.0
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -2035,7 +2038,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -2141,7 +2144,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -2184,7 +2187,7 @@ importers:
         version: 5.0.2(graphql@16.8.1)
       '@graphql-codegen/cli':
         specifier: 5.0.2
-        version: 5.0.2(@types/node@20.12.7)(graphql@16.8.1)(typescript@5.4.5)
+        version: 5.0.2(@types/node@20.12.7)(graphql@16.8.1)(typescript@5.4.4)
       '@graphql-codegen/typed-document-node':
         specifier: 5.0.6
         version: 5.0.6(graphql@16.8.1)
@@ -2220,10 +2223,10 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@20.12.7)(typescript@5.4.5)
+        version: 10.9.2(@types/node@20.12.7)(typescript@5.4.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -4962,7 +4965,7 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@graphql-codegen/cli@5.0.2(@types/node@20.12.7)(graphql@16.8.1)(typescript@5.4.5):
+  /@graphql-codegen/cli@5.0.2(@types/node@20.12.7)(graphql@16.8.1)(typescript@5.4.4):
     resolution: {integrity: sha512-MBIaFqDiLKuO4ojN6xxG9/xL9wmfD3ZjZ7RsPjwQnSHBCUXnEkdKvX+JVpx87Pq29Ycn8wTJUguXnTZ7Di0Mlw==}
     hasBin: true
     peerDependencies:
@@ -4990,11 +4993,11 @@ packages:
       '@graphql-tools/utils': 10.0.13(graphql@16.8.1)
       '@whatwg-node/fetch': 0.8.8
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.4.5)
+      cosmiconfig: 8.3.6(typescript@5.4.4)
       debounce: 1.2.1
       detect-indent: 6.1.0
       graphql: 16.8.1
-      graphql-config: 5.0.3(@types/node@20.12.7)(graphql@16.8.1)(typescript@5.4.5)
+      graphql-config: 5.0.3(@types/node@20.12.7)(graphql@16.8.1)(typescript@5.4.4)
       inquirer: 8.2.6
       is-glob: 4.0.3
       jiti: 1.21.0
@@ -7104,7 +7107,7 @@ packages:
       import-from-esm: 1.3.3
       lodash-es: 4.17.21
       micromatch: 4.0.5
-      semantic-release: 23.0.7(typescript@5.4.5)
+      semantic-release: 23.0.7(typescript@5.4.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7135,7 +7138,7 @@ packages:
       lodash-es: 4.17.21
       mime: 4.0.1
       p-filter: 4.1.0
-      semantic-release: 23.0.7(typescript@5.4.5)
+      semantic-release: 23.0.7(typescript@5.4.4)
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -7158,7 +7161,7 @@ packages:
       rc: 1.2.8
       read-pkg: 9.0.1
       registry-auth-token: 5.0.2
-      semantic-release: 23.0.7(typescript@5.4.5)
+      semantic-release: 23.0.7(typescript@5.4.4)
       semver: 7.6.0
       tempy: 3.1.0
     dev: true
@@ -7179,7 +7182,7 @@ packages:
       into-stream: 7.0.0
       lodash-es: 4.17.21
       read-pkg-up: 11.0.0
-      semantic-release: 23.0.7(typescript@5.4.5)
+      semantic-release: 23.0.7(typescript@5.4.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10305,7 +10308,7 @@ packages:
       vary: 1.1.2
     dev: false
 
-  /cosmiconfig@8.3.6(typescript@5.4.5):
+  /cosmiconfig@8.3.6(typescript@5.4.4):
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -10318,10 +10321,10 @@ packages:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
-      typescript: 5.4.5
+      typescript: 5.4.4
     dev: true
 
-  /cosmiconfig@9.0.0(typescript@5.4.5):
+  /cosmiconfig@9.0.0(typescript@5.4.4):
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -10334,7 +10337,7 @@ packages:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
-      typescript: 5.4.5
+      typescript: 5.4.4
     dev: true
 
   /cpu-features@0.0.2:
@@ -12431,7 +12434,7 @@ packages:
       obliterator: 2.0.4
     dev: false
 
-  /graphql-config@5.0.3(@types/node@20.12.7)(graphql@16.8.1)(typescript@5.4.5):
+  /graphql-config@5.0.3(@types/node@20.12.7)(graphql@16.8.1)(typescript@5.4.4):
     resolution: {integrity: sha512-BNGZaoxIBkv9yy6Y7omvsaBUHOzfFcII3UN++tpH8MGOKFPFkCPZuwx09ggANMt8FgyWP1Od8SWPmrUEZca4NQ==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
@@ -12447,7 +12450,7 @@ packages:
       '@graphql-tools/merge': 9.0.2(graphql@16.8.1)
       '@graphql-tools/url-loader': 8.0.1(@types/node@20.12.7)(graphql@16.8.1)
       '@graphql-tools/utils': 10.0.13(graphql@16.8.1)
-      cosmiconfig: 8.3.6(typescript@5.4.5)
+      cosmiconfig: 8.3.6(typescript@5.4.4)
       graphql: 16.8.1
       jiti: 1.21.0
       minimatch: 4.2.3
@@ -13655,7 +13658,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.4.5)
+      ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.4.4)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -17384,7 +17387,7 @@ packages:
       pkg-up: 3.1.0
       ramda: 0.27.2
       read-pkg: 5.2.0
-      semantic-release: 23.0.7(typescript@5.4.5)
+      semantic-release: 23.0.7(typescript@5.4.4)
       semantic-release-plugin-decorators: 4.0.0(semantic-release@23.0.7)
       tempy: 1.0.1
     transitivePeerDependencies:
@@ -17396,10 +17399,10 @@ packages:
     peerDependencies:
       semantic-release: '>20'
     dependencies:
-      semantic-release: 23.0.7(typescript@5.4.5)
+      semantic-release: 23.0.7(typescript@5.4.4)
     dev: true
 
-  /semantic-release@23.0.7(typescript@5.4.5):
+  /semantic-release@23.0.7(typescript@5.4.4):
     resolution: {integrity: sha512-PFxXQE57zrYiCbWKkdsVUF08s0SifEw3WhDhrN47ZEUWQiLl21FI9Dg/H8g7i/lPx0IkF6u7PjJbgxPceXKBeg==}
     engines: {node: '>=20.8.1'}
     hasBin: true
@@ -17410,7 +17413,7 @@ packages:
       '@semantic-release/npm': 12.0.0(semantic-release@23.0.7)
       '@semantic-release/release-notes-generator': 13.0.0(semantic-release@23.0.7)
       aggregate-error: 5.0.0
-      cosmiconfig: 9.0.0(typescript@5.4.5)
+      cosmiconfig: 9.0.0(typescript@5.4.4)
       debug: 4.3.4(supports-color@5.5.0)
       env-ci: 11.0.0
       execa: 8.0.1
@@ -18302,7 +18305,7 @@ packages:
       '@effect/schema': 0.56.1(effect@2.0.0-next.62)(fast-check@3.15.0)
       chalk: 4.1.2
       commander: 11.1.0
-      cosmiconfig: 9.0.0(typescript@5.4.5)
+      cosmiconfig: 9.0.0(typescript@5.4.4)
       effect: 2.0.0-next.62
       enquirer: 2.4.1
       fast-check: 3.15.0
@@ -18588,7 +18591,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: false
 
-  /ts-jest@29.1.2(@babel/core@7.24.3)(jest@29.7.0)(typescript@5.4.5):
+  /ts-jest@29.1.2(@babel/core@7.24.3)(jest@29.7.0)(typescript@5.4.4):
     resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}
     engines: {node: ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -18618,11 +18621,11 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.6.0
-      typescript: 5.4.5
+      typescript: 5.4.4
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-jest@29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5):
+  /ts-jest@29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4):
     resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}
     engines: {node: ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -18652,7 +18655,7 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.6.0
-      typescript: 5.4.5
+      typescript: 5.4.4
       yargs-parser: 21.1.1
     dev: true
 
@@ -18689,38 +18692,6 @@ packages:
       typescript: 5.4.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: false
-
-  /ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.5):
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.12.7
-      acorn: 8.11.3
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.4.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
 
   /ts-pattern@4.3.0:
     resolution: {integrity: sha512-pefrkcd4lmIVR0LA49Imjf9DYLK8vtWhqBPA3Ya1ir8xCW0O2yjL9dsCVvI7pCodLC5q7smNpEtDR2yVulQxOg==}
@@ -19088,12 +19059,6 @@ packages:
     resolution: {integrity: sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  /typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
 
   /typescript@5.5.0-dev.20240410:
     resolution: {integrity: sha512-OvGiFb8iPBHHqR8RuhIeCM+j2W1TtPbTZLuesCEi4gulAxzkOP2B3jDPTWmcOmxvUeJN5pNzlKoi/reRn1BZww==}

--- a/servers/list-api/package.json
+++ b/servers/list-api/package.json
@@ -22,6 +22,7 @@
     "@pocket-tools/sentry": "workspace:*",
     "@pocket-tools/tracing": "workspace:*",
     "@pocket-tools/ts-logger": "workspace:*",
+    "@pocket-tools/int-mask": "workspace:*",
     "@snowplow/node-tracker": "3.23.0",
     "dataloader": "2.2.2",
     "express": "4.19.2",

--- a/servers/list-api/schema.graphql
+++ b/servers/list-api/schema.graphql
@@ -574,6 +574,15 @@ type SavedItemsPage @tag(name: "v3proxy") {
   limit: Int!
 }
 
+type ReaderViewResult @key(fields: "slug") {
+  slug: ID!
+  """
+  The SavedItem referenced by this reader view slug, if it
+  is in the Pocket User's list.
+  """
+  savedItem: SavedItem
+}
+
 type User @key(fields: "id") {
   #Note more properties exist here but are defined in another service.
 

--- a/servers/list-api/src/resolvers/index.ts
+++ b/servers/list-api/src/resolvers/index.ts
@@ -42,6 +42,7 @@ import {
 import { IContext } from '../server/context';
 import { PocketDefaultScalars } from '@pocket-tools/apollo-utils';
 import { GraphQLResolveInfo } from 'graphql';
+import { IntMask } from '@pocket-tools/int-mask';
 
 const resolvers = {
   ...PocketDefaultScalars,
@@ -123,6 +124,16 @@ const resolvers = {
       } else {
         return await context.dataLoaders.savedItemsByUrl.load(savedItem.url);
       }
+    },
+  },
+  ReaderViewResult: {
+    async savedItem(
+      parent: { slug: string },
+      _,
+      context: IContext,
+    ): Promise<SavedItem | null> {
+      const id = IntMask.decode(parent.slug).toString();
+      return await context.dataLoaders.savedItemsById.load(id);
     },
   },
   Tag: {

--- a/servers/list-api/src/test/graphql/queries/readerSlug.integration.ts
+++ b/servers/list-api/src/test/graphql/queries/readerSlug.integration.ts
@@ -1,0 +1,127 @@
+import { ApolloServer } from '@apollo/server';
+import { ContextManager } from '../../../server/context';
+import { readClient, writeClient } from '../../../database/client';
+import { startServer } from '../../../server/apollo';
+import { Application } from 'express';
+import { gql } from 'graphql-tag';
+import { print } from 'graphql';
+import request from 'supertest';
+import { IntMask } from '@pocket-tools/int-mask';
+
+describe('getPocketSaveByItemId', () => {
+  const writeDb = writeClient();
+  const readDb = readClient();
+  const headers = { userid: '1' };
+  const date1 = new Date('2008-10-21 13:57:01');
+
+  let app: Application;
+  let server: ApolloServer<ContextManager>;
+  let url: string;
+
+  const SAVE_FROM_READER = gql`
+    query getSaveFromReader($slug: ID!) {
+      _entities(
+        representations: { slug: $slug, __typename: "ReaderViewResult" }
+      ) {
+        ... on ReaderViewResult {
+          slug
+          savedItem {
+            id
+            url
+            title
+            status
+          }
+        }
+      }
+    }
+  `;
+
+  afterAll(async () => {
+    await writeDb.destroy();
+    await readDb.destroy();
+    await server.stop();
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  beforeAll(async () => {
+    ({ app, server, url } = await startServer(0));
+    await writeDb('list').truncate();
+    await writeDb('list').insert([
+      {
+        api_id: '012',
+        api_id_updated: '012',
+        favorite: 0,
+        given_url: 'https://www.youtube.com/watch?v=ECMMct_jnEM',
+        item_id: 55,
+        resolved_id: 55,
+        status: 0,
+        time_added: date1,
+        time_favorited: '0000-00-00 00:00:00',
+        time_read: '0000-00-00 00:00:00',
+        time_updated: date1,
+        title: 'How to WIN with the London System!',
+        user_id: 1,
+      },
+    ]);
+  });
+
+  it('should return pocket save referenced by reader slug', async () => {
+    jest.spyOn(IntMask, 'decode').mockReturnValueOnce(55);
+    const variables = {
+      slug: 'aninscrutableid',
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({
+        query: print(SAVE_FROM_READER),
+        variables,
+      });
+    const expected = {
+      slug: 'aninscrutableid',
+      savedItem: {
+        id: '55',
+        url: 'https://www.youtube.com/watch?v=ECMMct_jnEM',
+        title: 'How to WIN with the London System!',
+        status: 'UNREAD',
+      },
+    };
+    expect(res.body.data._entities[0]).toEqual(expected);
+  });
+  it(`should return null if the save does not exist in the user's list`, async () => {
+    jest.spyOn(IntMask, 'decode').mockReturnValueOnce(1999999);
+    const variables = {
+      slug: 'aninscrutableid',
+    };
+
+    const res = await request(app)
+      .post(url)
+      .set(headers)
+      .send({
+        query: print(SAVE_FROM_READER),
+        variables,
+      });
+    const expected = {
+      slug: 'aninscrutableid',
+      savedItem: null,
+    };
+    expect(res.body.data._entities[0]).toEqual(expected);
+  });
+  it(`should not return data if the user is not logged in`, async () => {
+    jest.spyOn(IntMask, 'decode').mockReturnValueOnce(55);
+    const variables = {
+      slug: 'aninscrutableid',
+    };
+
+    const res = await request(app)
+      .post(url)
+      .send({
+        query: print(SAVE_FROM_READER),
+        variables,
+      });
+    expect(res.body.data).toBeUndefined();
+    expect(res.body.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+});

--- a/servers/parser-graphql-wrapper/schema.graphql
+++ b/servers/parser-graphql-wrapper/schema.graphql
@@ -12,6 +12,12 @@ extend schema
   )
 "A String representing a date in the format of `yyyy-MM-dd HH:mm:ss`"
 scalar DateString
+"""
+ISOString scalar - all datetimes fields are Typescript Date objects on this server &
+returned as ISO-8601 encoded date strings (e.g. ISOString scalars) to GraphQL clients.
+See Section 5.6 of the RFC 3339 profile of the ISO 8601 standard: https://www.ietf.org/rfc/rfc3339.txt.
+"""
+scalar ISOString
 
 """
 A string formatted with CommonMark markdown,
@@ -410,6 +416,15 @@ type Query {
   Look up Item info by ID.
   """
   itemByItemId(id: ID!): Item @cacheControl(maxAge: 86400) @inaccessible
+
+  """
+  Resolve Reader View links which might point to SavedItems that do not
+  exist, aren't in the Pocket User's list, or are requested by a logged-out
+  user (or user without a Pocket Account).
+  Fetches data to create an interstitial page/modal so the visitor can click
+  through to the shared site.
+  """
+  readerSlug(slug: ID!): ReaderViewResult!
 }
 
 type Mutation {
@@ -438,4 +453,31 @@ extend type Collection @key(fields: "slug") {
   """
   shortUrl: Url @tag(name: "beta")
   slug: String! @external
+}
+
+type ReaderViewResult @key(fields: "slug") {
+  slug: ID!
+  fallbackPage: ReaderFallback
+}
+
+union ReaderFallback = ReaderInterstitial | ItemNotFound
+
+type ItemSummary {
+  image: Image
+  excerpt: String
+  title: String
+  # publisher: Publisher
+  authors: [Author!]
+  domain: DomainMetadata
+  datePublished: ISOString
+  url: Url!
+  item: Item 
+}
+
+type ReaderInterstitial {
+  itemCard: ItemSummary
+}
+
+type ItemNotFound {
+  message: String 
 }

--- a/servers/parser-graphql-wrapper/src/config/index.ts
+++ b/servers/parser-graphql-wrapper/src/config/index.ts
@@ -49,6 +49,7 @@ export default {
     port: 3306,
     username: process.env.DB_USERNAME || 'root',
     password: process.env.DB_PASSWORD || '',
+    tz: process.env.DATABASE_TZ || 'US/Central',
   },
   pocketSharedRds: {
     host: process.env.POCKET_SHARES_DATABASE_WRITE_HOST || 'localhost',

--- a/servers/parser-graphql-wrapper/src/dataLoaders/itemLoader.ts
+++ b/servers/parser-graphql-wrapper/src/dataLoaders/itemLoader.ts
@@ -16,6 +16,7 @@ import {
 import config from '../config';
 import {
   DataLoaderCacheInterface,
+  NotFoundError,
   batchCacheFn,
 } from '@pocket-tools/apollo-utils';
 import { FetchHandler } from '../fetch';
@@ -63,7 +64,7 @@ const internalGetItemByUrl = async (
       message: 'internalGetItemByUrl: parser request',
       data: { originalUrl: url, endpoint, itemId },
     });
-    throw new Error(`No item found for URL`);
+    throw new NotFoundError(`No item found for URL`);
   }
 
   // If the item resolves to 0, that means the item object is going to be empty and we need to refresh it cause of bad parser data..
@@ -77,7 +78,7 @@ const internalGetItemByUrl = async (
         message: 'internalGetItemByUrl: parser request, resolved id is 0',
         data: { originalUrl: url, endpoint, itemId },
       });
-      throw new Error(`No item found for URL`);
+      throw new NotFoundError(`No item found for URL`);
     }
   }
 

--- a/servers/parser-graphql-wrapper/src/model.ts
+++ b/servers/parser-graphql-wrapper/src/model.ts
@@ -107,3 +107,29 @@ export interface Author {
   name?: string;
   url?: string;
 }
+
+export type ItemSummary = {
+  image?: Image;
+  excerpt?: string;
+  title?: string;
+  authors?: Author[];
+  domain?: DomainMetadata;
+  datePublished?: Date;
+  url: string;
+  item: Item;
+};
+
+export type ItemNotFound = {
+  message: string;
+};
+
+export type ReaderInterstitial = {
+  itemCard: ItemSummary;
+};
+
+export type ReaderFallback = ReaderInterstitial | ItemNotFound;
+
+export type ReaderViewResult = {
+  slug: string;
+  fallbackPage: ReaderFallback;
+};

--- a/servers/parser-graphql-wrapper/src/readerView/index.ts
+++ b/servers/parser-graphql-wrapper/src/readerView/index.ts
@@ -1,0 +1,36 @@
+import { IntMask } from '@pocket-tools/int-mask';
+import { IContext } from '../context';
+import { ReaderFallback } from '../model';
+import { DateTime } from 'luxon';
+import config from '../config';
+
+/**
+ * FallbackPage resolver for ReaderViewResult query
+ * @param parent GraphQL root/parent field
+ * @param _ GraphQL args (unused)
+ * @param context GraphQL context
+ * @returns Item, or NotFound result
+ */
+export async function fallbackPage(
+  slug: string,
+  context: IContext,
+): Promise<ReaderFallback> {
+  const id = IntMask.decode(slug).toString();
+  const item = await context.dataLoaders.itemIdLoader.load(id);
+  if (item == null) {
+    return { message: "We couldn't find that page." };
+  }
+  const itemCard = {
+    image: item.topImage ?? item.images?.[0],
+    excerpt: item.excerpt,
+    title: item.title,
+    authors: item.authors,
+    domain: item.domainMetadata,
+    datePublished: DateTime.fromSQL(item.datePublished, {
+      zone: config.mysql.tz,
+    }).toJSDate(),
+    url: item.givenUrl,
+    item,
+  };
+  return { itemCard };
+}

--- a/servers/parser-graphql-wrapper/src/readerView/readerViewResult.integration.ts
+++ b/servers/parser-graphql-wrapper/src/readerView/readerViewResult.integration.ts
@@ -1,0 +1,161 @@
+import nock, { cleanAll } from 'nock';
+import { getRedis } from '../cache';
+import { startServer } from '../server';
+import { ApolloServer } from '@apollo/server';
+import request from 'supertest';
+import { print } from 'graphql';
+import { gql } from 'graphql-tag';
+import { IContext } from '../context';
+import { Application } from 'express';
+import { Connection } from 'typeorm';
+import { getConnection } from '../database/mysql';
+import { ItemResolver } from '../entities/ItemResolver';
+import { IntMask } from '@pocket-tools/int-mask';
+
+describe('readerSlug', () => {
+  let app: Application;
+  let server: ApolloServer<IContext>;
+  let graphQLUrl: string;
+  let connection: Connection;
+
+  const GET_READER_INTERSTITIAL = gql`
+    query readerSlug($slug: ID!) {
+      readerSlug(slug: $slug) {
+        slug
+        fallbackPage {
+          ... on ReaderInterstitial {
+            itemCard {
+              title
+              authors {
+                name
+              }
+              datePublished
+              excerpt
+              domain {
+                name
+              }
+              image {
+                url
+              }
+              url
+              item {
+                givenUrl
+              }
+            }
+          }
+          ... on ItemNotFound {
+            message
+          }
+        }
+      }
+    }
+  `;
+
+  const testUrl = 'https://test.com';
+
+  const item = {
+    itemId: 123,
+    searchHash: '123455sdf',
+    normalUrl: testUrl,
+    resolvedId: 123,
+    hasOldDupes: false,
+  };
+
+  const parserItemId = '123';
+
+  beforeAll(async () => {
+    ({ app, server, url: graphQLUrl } = await startServer(0));
+    connection = await getConnection();
+    //Delete the items
+    const entities = connection.entityMetadatas;
+    for (const entity of entities) {
+      const repository = connection.getRepository(entity.name);
+      await repository.query(`DELETE FROM ${entity.tableName}`);
+    }
+    //Create a seed item
+    const insert = connection.manager.create(ItemResolver, item);
+    await connection.manager.save([insert]);
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    nock('http://example-parser.com')
+      .get('/')
+      .query({
+        url: testUrl,
+        getItem: '1',
+        output: 'regular',
+        enableItemUrlFallback: '1',
+      })
+      .reply(200, {
+        item: {
+          item_id: parserItemId,
+          given_url: testUrl,
+          normal_url: testUrl,
+          title: 'test',
+          authors: [],
+          images: [],
+          videos: [],
+          resolved_id: '16822',
+        },
+      });
+    // flush the redis cache
+    getRedis().clear();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    await getRedis().disconnect();
+    cleanAll();
+    await connection.close();
+    jest.restoreAllMocks();
+  });
+
+  it('should return item card fallback data', async () => {
+    jest.spyOn(IntMask, 'decode').mockReturnValueOnce(123);
+    const variables = {
+      slug: 'inscrutableid',
+    };
+    const expected = {
+      readerSlug: {
+        slug: 'inscrutableid',
+        fallbackPage: {
+          itemCard: {
+            image: null,
+            authors: null,
+            domain: { name: 'test.com' },
+            datePublished: null,
+            excerpt: null,
+            title: 'test',
+            url: testUrl,
+            item: {
+              givenUrl: testUrl,
+            },
+          },
+        },
+      },
+    };
+    const res = await request(app)
+      .post(graphQLUrl)
+      .send({ query: print(GET_READER_INTERSTITIAL), variables });
+    expect(res.body.data).toEqual(expected);
+  });
+  it('should return ItemNotFound if ID is not in the database', async () => {
+    jest.spyOn(IntMask, 'decode').mockReturnValueOnce(11112342323);
+    const variables = {
+      slug: 'inscrutableid',
+    };
+    const expected = {
+      readerSlug: {
+        slug: 'inscrutableid',
+        fallbackPage: {
+          message: "We couldn't find that page.",
+        },
+      },
+    };
+    const res = await request(app)
+      .post(graphQLUrl)
+      .send({ query: print(GET_READER_INTERSTITIAL), variables });
+    expect(res.body.data).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Implementation for contract described [here](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/616726765/Sharing+Reader+View)

list-api: resolve SavedItem on readerSlug query if it exists

parser-graphql-wrapper: resolve interstitial data (fallback page) with item summary if it exists, or basically a 404 message.

[POCKET-9866]

[POCKET-9866]: https://mozilla-hub.atlassian.net/browse/POCKET-9866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ