### PR TITLE
fix(item): resolve item by givenUrl from list-api

### DIFF
--- a/servers/list-api/src/resolvers/savedItem.ts
+++ b/servers/list-api/src/resolvers/savedItem.ts
@@ -29,13 +29,13 @@ export async function suggestedTags(
  * Resolve Item entity using the givenUrl
  * @param parent
  */
-export async function item(parent: SavedItem): Promise<Item | PendingItem> {
+export async function item(
+  parent: SavedItem,
+): Promise<Pick<Item, 'givenUrl'> | PendingItem> {
   if (parseInt(parent.resolvedId)) {
     return {
       __typename: 'Item',
-      itemId: parent.id,
       givenUrl: parent.url,
-      resolvedId: parent.resolvedId,
     };
   }
   return {


### PR DESCRIPTION
parser-graphql wrapper prefers itemId, which does
not always return the itemId which was saved in a
user's list (the originating data source) due to
vagaries of resolvedId/itemId/normalUrl lookup.