### PR TITLE
chore(circleci): optimizing costs

### DIFF
--- a/.circleci/common.yml
+++ b/.circleci/common.yml
@@ -174,11 +174,7 @@ commands:
             - .pnpm-store
   install_infrastructure_pnpm:
     steps:
-      - restore_cache:
-          name: Restore pnpm Package Cache
-          keys:
-            - pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
-      - run: 
+      - run:
           name: Install and setup node
           command: |
             nvm install
@@ -186,11 +182,6 @@ commands:
             npm install -g pnpm
             pnpm config set store-dir .pnpm-store
             pnpm install    
-      - save_cache:
-          name: Save pnpm Package Cache
-          key: pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
-          paths:
-            - .pnpm-store 
   install_codebuild_secrets:
     steps:
       - run: 
@@ -295,22 +286,6 @@ jobs:
       - exit-early-if-irrelevant:
           for: << parameters.for >>
       - checkout
-      - unless:
-          # When it is not raw hcl, the stack output path is 3 folders away from our .terraform-version
-          condition: <<parameters.uses_raw_hcl>>
-          steps:
-            - restore_cache:
-                name: Restore Terraform
-                keys:
-                  - terraform-version-{{ checksum "<< parameters.stack-output-path >>/../../../.terraform-version" }}
-      - when:
-          # When it is hcl, the stack output path is the same as our .terraform-version
-          condition: <<parameters.uses_raw_hcl>>
-          steps:
-            - restore_cache:
-                name: Restore Terraform
-                keys:
-                  - terraform-version-{{ checksum "<< parameters.stack-output-path >>/.terraform-version" }}
       - run:
           name: Install tfcmt
           command: |
@@ -396,24 +371,6 @@ jobs:
                 command: |
                   cd << parameters.stack-output-path >>
                   tfcmt --var target:<< parameters.scope >><<#parameters.dev>>-dev<</parameters.dev>> plan --skip-no-changes --patch -- terraform plan -lock-timeout=10m
-      - unless:
-          # When it is not raw hcl, the stack output path is 3 folders away from our .terraform-version
-          condition: <<parameters.uses_raw_hcl>>
-          steps:
-            - save_cache:
-                key: terraform-version-{{ checksum "<< parameters.stack-output-path >>/../../../.terraform-version" }}
-                paths:
-                  - /home/circleci/.tfenv/versions/*
-                  - /home/circleci/.tfenv/bin/terraform-*
-      - when:
-          # When it is hcl, the stack output path is the same as our .terraform-version
-          condition: <<parameters.uses_raw_hcl>>
-          steps:
-            - save_cache:
-                key: terraform-version-{{ checksum "<< parameters.stack-output-path >>/.terraform-version" }}
-                paths:
-                  - /home/circleci/.tfenv/versions/*
-                  - /home/circleci/.tfenv/bin/terraform-*
 
   code_deploy_ecs:
     parameters:


### PR DESCRIPTION
## Goal

It looks like we are using 1.1 TB of egress network costs due to caching within our hosted runner. This removes all caching within the CircleCI hosted runner for now to save on egress network costs which make up more then half the circleci bill.

This also disables docker layer caching which is also way above our maximum for now as well.