### PR TITLE
fix(tests): making the tests not change the time

### DIFF
--- a/servers/annotations-api/src/test/mutation/highlights-batchwrite.integration.ts
+++ b/servers/annotations-api/src/test/mutation/highlights-batchwrite.integration.ts
@@ -197,7 +197,16 @@ describe('Highlights batchWrite', () => {
 
       jest.useFakeTimers({
         now: updateDate,
-        advanceTimers: true,
+        doNotFake: [
+          'nextTick',
+          'setImmediate',
+          'clearImmediate',
+          'setInterval',
+          'clearInterval',
+          'setTimeout',
+          'clearTimeout',
+        ],
+        advanceTimers: false,
       });
 
       const variables: { input: BatchWriteHighlightsInput } = {

--- a/servers/annotations-api/src/test/mutation/highlights-create.integration.ts
+++ b/servers/annotations-api/src/test/mutation/highlights-create.integration.ts
@@ -202,7 +202,18 @@ describe('Highlights creation', () => {
 
     it('should mark the list item as updated and log the highlight mutation', async () => {
       const updateDate = new Date(2022, 3, 3);
-      jest.useFakeTimers({ advanceTimers: true });
+      jest.useFakeTimers({
+        doNotFake: [
+          'nextTick',
+          'setImmediate',
+          'clearImmediate',
+          'setInterval',
+          'clearInterval',
+          'setTimeout',
+          'clearTimeout',
+        ],
+        advanceTimers: false,
+      });
       jest.setSystemTime(updateDate);
 
       const variables: { input: HighlightInput[] } = {

--- a/servers/annotations-api/src/test/mutation/highlights-delete.integration.ts
+++ b/servers/annotations-api/src/test/mutation/highlights-delete.integration.ts
@@ -53,7 +53,16 @@ describe('Highlights deletion', () => {
 
     jest.useFakeTimers({
       now: updateDate,
-      advanceTimers: true,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
     });
 
     const variables = { id: 'b3a95dd3-dd9b-49b0-bb72-dc6daabd809b' };

--- a/servers/annotations-api/src/test/mutation/highlights-update-deprecated.integration.ts
+++ b/servers/annotations-api/src/test/mutation/highlights-update-deprecated.integration.ts
@@ -47,7 +47,16 @@ describe('Highlights update', () => {
 
     jest.useFakeTimers({
       now: updateDate,
-      advanceTimers: true,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
     });
 
     const input = {

--- a/servers/annotations-api/src/test/mutation/highlights-update.integration.ts
+++ b/servers/annotations-api/src/test/mutation/highlights-update.integration.ts
@@ -47,7 +47,16 @@ describe('Highlights update', () => {
 
     jest.useFakeTimers({
       now: updateDate,
-      advanceTimers: true,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
     });
 
     const input = {

--- a/servers/list-api/src/test/graphql/mutations/clearTags.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/clearTags.integration.ts
@@ -36,7 +36,16 @@ describe('clearTags mutation', () => {
   beforeAll(async () => {
     jest.useFakeTimers({
       now: now,
-      advanceTimers: true,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
     });
     ({ app, server, url } = await startServer(0));
   });

--- a/servers/list-api/src/test/graphql/mutations/replaceTags.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/replaceTags.integration.ts
@@ -36,7 +36,16 @@ describe('clearTags mutation', () => {
   beforeAll(async () => {
     jest.useFakeTimers({
       now: now,
-      advanceTimers: true,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
     });
     ({ app, server, url } = await startServer(0));
   });

--- a/servers/list-api/src/test/graphql/mutations/savedItemById/createSavedItemTagsMutation.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/savedItemById/createSavedItemTagsMutation.integration.ts
@@ -25,7 +25,16 @@ describe('createSavedItemTags mutation', function () {
     // Mock Date.now() to get a consistent date for inserting data
     jest.useFakeTimers({
       now: updateDate,
-      advanceTimers: true,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
     });
   });
 

--- a/servers/list-api/src/test/graphql/mutations/savedItemById/reAdd.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/savedItemById/reAdd.integration.ts
@@ -35,7 +35,19 @@ describe('reAddById mutation', () => {
 
   beforeAll(async () => {
     ({ app, server, url } = await startServer(0));
-    jest.useFakeTimers({ advanceTimers: true, now });
+    jest.useFakeTimers({
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
+      now,
+    });
   });
 
   afterAll(async () => {

--- a/servers/list-api/src/test/graphql/mutations/savedItemById/savedItemsMutationService-delete.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/savedItemById/savedItemsMutationService-delete.integration.ts
@@ -127,7 +127,16 @@ describe('Delete/Undelete SavedItem: ', () => {
     // Mock Date.now() to get a consistent date for inserting data
     jest.useFakeTimers({
       now: updateDate,
-      advanceTimers: true,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
     });
   });
 

--- a/servers/list-api/src/test/graphql/mutations/savedItemById/savedItemsMutationService-updates.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/savedItemById/savedItemsMutationService-updates.integration.ts
@@ -34,7 +34,16 @@ describe('Update Mutation for SavedItem: ', () => {
     // Mock Date.now() to get a consistent date for inserting data
     jest.useFakeTimers({
       now: updateDate,
-      advanceTimers: true,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
     });
 
     await writeDb('list').truncate();

--- a/servers/list-api/src/test/graphql/mutations/savedItemById/savedItemsMutationService-upsert.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/savedItemById/savedItemsMutationService-upsert.integration.ts
@@ -68,7 +68,19 @@ describe('UpsertSavedItem Mutation', () => {
 
   beforeAll(async () => {
     ({ app, server, url } = await startServer(0));
-    jest.useFakeTimers({ advanceTimers: true, now: dateNow });
+    jest.useFakeTimers({
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
+      now: dateNow,
+    });
   });
 
   afterAll(async () => {
@@ -438,7 +450,19 @@ describe('UpsertSavedItem Mutation', () => {
     });
 
     it('should push addItem event to perm lib queue for premium users', async () => {
-      jest.useFakeTimers({ advanceTimers: true, now: dateNow });
+      jest.useFakeTimers({
+        doNotFake: [
+          'nextTick',
+          'setImmediate',
+          'clearImmediate',
+          'setInterval',
+          'clearInterval',
+          'setTimeout',
+          'clearTimeout',
+        ],
+        advanceTimers: false,
+        now: dateNow,
+      });
       const variables = {
         url: 'http://addingtoqueue.com',
       };
@@ -517,7 +541,19 @@ describe('UpsertSavedItem Mutation', () => {
       });
 
       it(`should update an item already in a user's list`, async () => {
-        jest.useFakeTimers({ advanceTimers: true, now: dateNow });
+        jest.useFakeTimers({
+          doNotFake: [
+            'nextTick',
+            'setImmediate',
+            'clearImmediate',
+            'setInterval',
+            'clearInterval',
+            'setTimeout',
+            'clearTimeout',
+          ],
+          advanceTimers: false,
+          now: dateNow,
+        });
         const variables = {
           url: 'http://google.com',
           isFavorite: true,

--- a/servers/list-api/src/test/graphql/mutations/tagsById/tagsMutationService-replaceSavedItemTags.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/tagsById/tagsMutationService-replaceSavedItemTags.integration.ts
@@ -28,7 +28,16 @@ describe('tags mutation: replace savedItem tags', () => {
     // Mock Date.now() to get a consistent date for inserting data
     jest.useFakeTimers({
       now: updateDate,
-      advanceTimers: true,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
     });
   });
 

--- a/servers/list-api/src/test/graphql/mutations/tagsById/tagsMutationService-update.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/tagsById/tagsMutationService-update.integration.ts
@@ -40,7 +40,16 @@ describe('updateTag Mutation: ', () => {
   beforeEach(async () => {
     jest.useFakeTimers({
       now: updateDate,
-      advanceTimers: true,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
     });
     jest.clearAllMocks();
     const baseTag = {

--- a/servers/list-api/src/test/graphql/mutations/tagsById/tagsMutationService-updateSavedItemTags.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/tagsById/tagsMutationService-updateSavedItemTags.integration.ts
@@ -42,7 +42,16 @@ describe('tags mutation update: ', () => {
     // Mock Date.now() to get a consistent date for inserting body.data
     jest.useFakeTimers({
       now: updateDate,
-      advanceTimers: true,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
     });
     await writeDb('item_tags').truncate();
     await writeDb('item_tags').insert([

--- a/servers/list-api/src/test/graphql/mutations/tagsByName/deleteTagByName.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/tagsByName/deleteTagByName.integration.ts
@@ -32,7 +32,16 @@ describe('deleteTagByName mutation', () => {
   beforeAll(async () => {
     jest.useFakeTimers({
       now: now,
-      advanceTimers: true,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
     });
     ({ app, server, url } = await startServer(0));
   });

--- a/servers/list-api/src/test/graphql/mutations/tagsByName/removeTagsByName.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/tagsByName/removeTagsByName.integration.ts
@@ -35,7 +35,16 @@ describe('removeTagsByName mutation', () => {
   beforeAll(async () => {
     jest.useFakeTimers({
       now: now,
-      advanceTimers: true,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
     });
     ({ app, server, url } = await startServer(0));
   });

--- a/servers/list-api/src/test/graphql/mutations/tagsByName/renameTagByName.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/tagsByName/renameTagByName.integration.ts
@@ -36,7 +36,16 @@ describe('deleteTagByName mutation', () => {
   beforeAll(async () => {
     jest.useFakeTimers({
       now: now,
-      advanceTimers: true,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
     });
     ({ app, server, url } = await startServer(0));
   });

--- a/servers/user-api/src/events/eventBus/eventBusHandler.spec.ts
+++ b/servers/user-api/src/events/eventBus/eventBusHandler.spec.ts
@@ -36,7 +36,16 @@ describe('EventBusHandler', () => {
   beforeAll(() => {
     jest.useFakeTimers({
       now: now,
-      advanceTimers: true,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
     });
   });
 

--- a/servers/user-list-search/src/freeSearch.integration.ts
+++ b/servers/user-list-search/src/freeSearch.integration.ts
@@ -101,7 +101,19 @@ describe('free search test', () => {
   });
 
   beforeEach(async () => {
-    jest.useFakeTimers({ now: updateDate, advanceTimers: true });
+    jest.useFakeTimers({
+      now: updateDate,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
+    });
   });
 
   afterAll(async () => {

--- a/servers/user-list-search/src/freeSearchByOffset.integration.ts
+++ b/servers/user-list-search/src/freeSearchByOffset.integration.ts
@@ -105,7 +105,19 @@ describe('free-tier search (offset pagination)', () => {
   });
 
   beforeEach(async () => {
-    jest.useFakeTimers({ now: updateDate, advanceTimers: true });
+    jest.useFakeTimers({
+      now: updateDate,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
+    });
   });
 
   afterAll(async () => {

--- a/servers/v3-proxy-api/src/routes/v3Send.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Send.integration.ts
@@ -23,7 +23,19 @@ describe('v3/send', () => {
     clientSpy = jest
       .spyOn(GraphQLClient.prototype, 'request')
       .mockResolvedValue(true);
-    jest.useFakeTimers({ now: now * 1000, advanceTimers: true });
+    jest.useFakeTimers({
+      now: now * 1000,
+      doNotFake: [
+        'nextTick',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+      ],
+      advanceTimers: false,
+    });
   });
   afterAll(async () => {
     clientSpy.mockRestore();


### PR DESCRIPTION
## Goal

When I moved the list api and other services, I moved them and replaced sinon with pure jest. There was some weird behavior with the new timers behavior in Jest that I could not fully sort out at the time that caused us to have to set `advanceTimers` to `true`.  This had the side effect of causing our tests that check dates to be a bit flakey because the time could increment in the amount of time it took to run the test instead of being 

Upon looking into the behavior `advanceTimers` was needed because the new timer behavior fakes async tick functions that we don't want it to. See https://github.com/nock/nock/issues/2200#issuecomment-1280957462

By telling jest to not fake the async node functions, the clock stays frozen and the rest of the code can execute.