### PR TITLE
feat(shares): federate PocketShare.preview field

### DIFF
--- a/servers/parser-graphql-wrapper/src/preview/preview.ts
+++ b/servers/parser-graphql-wrapper/src/preview/preview.ts
@@ -10,6 +10,14 @@ import { merge } from 'lodash';
 // We skip these domains for opengraph data because the parser grabs it from their APIs which is more accurate.
 const openGraphDomainsToSkip = ['reddit.com', 'youtube.com'];
 
+export const itemSummaryFromUrl = async (
+  url: string,
+  context: IContext,
+): Promise<ItemSummary> => {
+  const item = await context.dataLoaders.itemUrlLoader.load(url);
+  return await deriveItemSummary(item, context);
+};
+
 export const deriveItemSummary = async (
   item: Item,
   context: IContext,

--- a/servers/parser-graphql-wrapper/src/resolvers.ts
+++ b/servers/parser-graphql-wrapper/src/resolvers.ts
@@ -14,7 +14,7 @@ import { generateSSML } from './ssml/ssml';
 import { serverLogger } from '@pocket-tools/ts-logger';
 import { fallbackPage } from './readerView';
 import { PocketDefaultScalars } from '@pocket-tools/apollo-utils';
-import { deriveItemSummary } from './preview/preview';
+import { deriveItemSummary, itemSummaryFromUrl } from './preview/preview';
 
 export const resolvers = {
   ...PocketDefaultScalars,
@@ -260,6 +260,15 @@ export const resolvers = {
         resolvedId: parseInt(item.resolvedId),
         givenUrl: item.givenUrl,
       });
+    },
+  },
+  PocketShare: {
+    preview: async (
+      parent: { targetUrl: string },
+      _,
+      context: IContext,
+    ): Promise<ItemSummary> => {
+      return await itemSummaryFromUrl(parent.targetUrl, context);
     },
   },
   Mutation: {


### PR DESCRIPTION
No tests???? I know, I know... but it is such an absolutely huge PITA to make the mocks for this data, and I'm basically adding one additional line that uses an already-tested function... we're discussing making this repo more developer friendly :) 

And I'd mock the federated entity for a graph query test, so I don't see much benefit for doing all the work it would take to just test the entity federation on PocketShare.

[POCKET-9870]

[POCKET-9870]: https://mozilla-hub.atlassian.net/browse/POCKET-9870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ