### PR TITLE
feat(v3proxy): add hasAnnotations option

### DIFF
--- a/servers/v3-proxy-api/src/graph/get/toGraphQL.spec.ts
+++ b/servers/v3-proxy-api/src/graph/get/toGraphQL.spec.ts
@@ -57,6 +57,16 @@ describe('toGraphQL', () => {
             },
           },
         },
+        {
+          params: {
+            hasAnnotations: true,
+          },
+          expected: {
+            filter: {
+              isHighlighted: true,
+            },
+          },
+        },
       ])(
         'maps filters appropriately, including combos',
         ({ params, expected }) => {

--- a/servers/v3-proxy-api/src/graph/get/toGraphQL.ts
+++ b/servers/v3-proxy-api/src/graph/get/toGraphQL.ts
@@ -127,6 +127,7 @@ export function SavedItemsFilterFactory(params: V3GetParams) {
     },
     since: (val: number) => ({ updatedSince: val }),
     tag: (val: string) => ({ tagNames: [val] }),
+    hasAnnotations: (val: boolean) => ({ isHighlighted: val }),
   };
 
   const filter: SavedItemsFilter = Object.entries(params).reduce(

--- a/servers/v3-proxy-api/src/routes/v3Fetch.ts
+++ b/servers/v3-proxy-api/src/routes/v3Fetch.ts
@@ -92,6 +92,7 @@ export async function processV3call(
     state: 'unread',
     taglist: data.taglist,
     forcetaglist: data.forcetaglist,
+    hasAnnotations: data.hasAnnotations,
   };
 
   // Otherwise call SavedItems list api

--- a/servers/v3-proxy-api/src/routes/validations/FetchSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/FetchSchema.ts
@@ -16,6 +16,7 @@ export type V3FetchParams = {
   taglist: boolean;
   forcetaglist: boolean;
   since?: number;
+  hasAnnotations?: boolean;
 };
 
 /**
@@ -143,5 +144,14 @@ export const V3FetchSchema: Schema = {
       },
     },
     toInt: true,
+  },
+  hasAnnotations: {
+    optional: true,
+    isIn: {
+      options: [['0', '1']],
+    },
+    customSanitizer: {
+      options: (value) => (value === '1' ? true : false),
+    },
   },
 };

--- a/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
@@ -21,6 +21,7 @@ export type V3GetParams = {
   annotations: boolean;
   taglist: boolean;
   forcetaglist: boolean;
+  hasAnnotations?: boolean;
 };
 
 /**
@@ -196,6 +197,15 @@ export const V3GetSchema: Schema = {
     default: {
       options: '0',
     },
+    isIn: {
+      options: [['0', '1']],
+    },
+    customSanitizer: {
+      options: (value) => (value === '1' ? true : false),
+    },
+  },
+  hasAnnotations: {
+    optional: true,
     isIn: {
       options: [['0', '1']],
     },


### PR DESCRIPTION
Optional field, if true returns only Saves which
have annotations. Used for android fetching
Archive, which do not cache annotations on device.

Is ignored if a search term is passed.

[POCKET-9929]

[POCKET-9929]: https://mozilla-hub.atlassian.net/browse/POCKET-9929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ