### PR TITLE
feat(shares): return entire entity for createShareLink

### DIFF
--- a/servers/shares-api/schema.graphql
+++ b/servers/shares-api/schema.graphql
@@ -84,5 +84,5 @@ type Mutation {
   Create a Pocket Share for a provided target URL, optionally
   with additional share context.
   """
-  createShareLink(target: URL!, context: ShareContextInput): URL
+  createShareLink(target: URL!, context: ShareContextInput): PocketShare
 }

--- a/servers/shares-api/src/__generated__/types.ts
+++ b/servers/shares-api/src/__generated__/types.ts
@@ -30,7 +30,7 @@ export type Mutation = {
    * Create a Pocket Share for a provided target URL, optionally
    * with additional share context.
    */
-  createShareLink?: Maybe<Scalars['URL']['output']>;
+  createShareLink?: Maybe<PocketShare>;
 };
 
 
@@ -236,7 +236,7 @@ export interface Max300CharStringScalarConfig extends GraphQLScalarTypeConfig<Re
 }
 
 export type MutationResolvers<ContextType = IContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = ResolversObject<{
-  createShareLink?: Resolver<Maybe<ResolversTypes['URL']>, ParentType, ContextType, RequireFields<MutationCreateShareLinkArgs, 'target'>>;
+  createShareLink?: Resolver<Maybe<ResolversTypes['PocketShare']>, ParentType, ContextType, RequireFields<MutationCreateShareLinkArgs, 'target'>>;
 }>;
 
 export type PocketShareResolvers<ContextType = IContext, ParentType extends ResolversParentTypes['PocketShare'] = ResolversParentTypes['PocketShare']> = ResolversObject<{

--- a/servers/shares-api/src/models/PocketShare.ts
+++ b/servers/shares-api/src/models/PocketShare.ts
@@ -61,13 +61,13 @@ export class PocketShareModel {
   async createShareLink(
     target: URL,
     context: ShareContextInput,
-  ): Promise<string> {
+  ): Promise<PocketShare> {
     const input = this.toEntity(target, context);
     const res = await this.db.createShare(input);
     if (res instanceof Error) {
       throw res;
     }
-    return this.shareUrl(res.shareId);
+    return this.fromEntity(res);
   }
   /**
    * Look up a share record by the URL slug

--- a/servers/shares-api/src/test/Max300CharString.integration.ts
+++ b/servers/shares-api/src/test/Max300CharString.integration.ts
@@ -51,7 +51,7 @@ describe('CreateShareLink', () => {
       .set(headers)
       .send({ query: CREATE_SHARE, variables });
     expect(res.body.data).toEqual({
-      createShareLink: `https://pocket.co/share/${uuidMock}`,
+      createShareLink: { shareUrl: `https://pocket.co/share/${uuidMock}` },
     });
     const roundtrip = await request(app)
       .post(graphQLUrl)

--- a/servers/shares-api/src/test/createShareLink.integration.ts
+++ b/servers/shares-api/src/test/createShareLink.integration.ts
@@ -58,7 +58,7 @@ describe('CreateShareLink', () => {
       .set(headers)
       .send({ query: CREATE_SHARE, variables });
     expect(res.body.data).toEqual({
-      createShareLink: `https://pocket.co/share/${uuidMock}`,
+      createShareLink: { shareUrl: `https://pocket.co/share/${uuidMock}` },
     });
     const roundtrip = await request(app)
       .post(graphQLUrl)

--- a/servers/shares-api/src/test/queries.ts
+++ b/servers/shares-api/src/test/queries.ts
@@ -3,7 +3,9 @@ import { print } from 'graphql';
 
 export const CREATE_SHARE = print(gql`
   mutation CreateShareLink($target: URL!, $context: ShareContextInput) {
-    createShareLink(target: $target, context: $context)
+    createShareLink(target: $target, context: $context) {
+      shareUrl
+    }
   }
 `);
 


### PR DESCRIPTION
Previously returned only the shareUrl. Return the
entire entity for future flexibility on server-generated data.

Helps mobile clients with their internal storage.

[POCKET-9984]

[POCKET-9984]: https://mozilla-hub.atlassian.net/browse/POCKET-9984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ