### PR TITLE
fix(reader): adding in a reader url resolver

### DIFF
--- a/servers/parser-graphql-wrapper/src/__generated__/resolvers-types.ts
+++ b/servers/parser-graphql-wrapper/src/__generated__/resolvers-types.ts
@@ -37,7 +37,6 @@ export type Scalars = {
   Markdown: { input: any; output: any; }
   /** A String in the format of a url. */
   Url: { input: any; output: any; }
-  /** Also a string in the format of a URL, but actually validated... */
   ValidUrl: { input: any; output: any; }
   _FieldSet: { input: any; output: any; }
 };

--- a/servers/parser-graphql-wrapper/src/readerView/readerSlug.spec.ts
+++ b/servers/parser-graphql-wrapper/src/readerView/readerSlug.spec.ts
@@ -1,0 +1,53 @@
+import { extractSlugFromReadUrl } from './readersSlug';
+
+describe('Reader slug utils', () => {
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    {
+      url: 'https://getpocket.com/read/fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7eb5D66B8DccAd6E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70',
+      expected:
+        'fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7eb5D66B8DccAd6E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70',
+    },
+    {
+      url: 'https://getpocket.com/fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7eb5D66B8DccAd6E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70',
+      expected: undefined,
+    },
+    {
+      url: 'https://getpocket.com/reader/fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7eb5D66B8DccAd6E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70',
+      expected: undefined,
+    },
+    {
+      url: 'http://getpocket.com/read/fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70',
+      expected:
+        'fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70',
+    },
+    {
+      url: 'http://getpocket.com/explore/item/123',
+      expected: undefined,
+    },
+    {
+      // old slug pattern
+      url: 'https://getpocket.com/read/12345789',
+      expected: undefined,
+    },
+    {
+      url: 'http://getpocket.com/read/12345123123123123789asdasdasdasdasdasd',
+      expected: undefined,
+    },
+    {
+      url: 'http://getpocket.com/read/fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70?124=fa',
+      expected:
+        'fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70',
+    },
+    {
+      url: 'http://getpocket.com/read/fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70?utm_source=pocket-saves',
+      expected:
+        'fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70',
+    },
+  ])('extracts slug from read links', ({ url, expected }) => {
+    expect(extractSlugFromReadUrl(url)).toBe(expected);
+  });
+});

--- a/servers/parser-graphql-wrapper/src/readerView/readerSlug.spec.ts
+++ b/servers/parser-graphql-wrapper/src/readerView/readerSlug.spec.ts
@@ -47,6 +47,26 @@ describe('Reader slug utils', () => {
       expected:
         'fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70',
     },
+    {
+      url: 'getpocket.com/read/fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70?utm_source=pocket-saves',
+      expected:
+        'fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70',
+    },
+    {
+      url: 'getpocket.com/read/fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70?utm_source=pocket-saves',
+      expected:
+        'fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70',
+    },
+    {
+      url: 'http://getpocket.com/read/fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70?utm_source=pocket-saves&testing=1234',
+      expected:
+        'fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70',
+    },
+    {
+      url: 'http://getpocket.com/read/fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70/',
+      expected:
+        'fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70',
+    },
   ])('extracts slug from read links', ({ url, expected }) => {
     expect(extractSlugFromReadUrl(url)).toBe(expected);
   });

--- a/servers/parser-graphql-wrapper/src/readerView/readersSlug.ts
+++ b/servers/parser-graphql-wrapper/src/readerView/readersSlug.ts
@@ -27,7 +27,7 @@ export async function urlFromReaderSlug(
  */
 export function extractSlugFromReadUrl(url: string): string | undefined {
   const regex =
-    /^(?:https?:\/\/)?getpocket\.com\/read\/([A-Za-z\d]+_[A-Za-z\d]+)(?:(?:\/?)|(?:\?[A-Za-z_\-\d]+=[A-Za-z_\-\d]+)(?:\\&[A-Za-z_\-\d]+=[A-Za-z_\-\d]+)*)$/;
+    /^(?:https?:\/\/)?getpocket\.com\/read\/([A-Za-z\d]+_[A-Za-z\d]+)(?:(?:\/?)|(?:\?[A-Za-z_\-\d]+=[A-Za-z_\-\d]+)(?:&[A-Za-z_\-\d]+=[A-Za-z_\-\d]+)*)$/;
   const match = url.match(regex);
   return match ? match[1] : undefined;
 }

--- a/servers/parser-graphql-wrapper/src/readerView/readersSlug.ts
+++ b/servers/parser-graphql-wrapper/src/readerView/readersSlug.ts
@@ -1,0 +1,33 @@
+import { itemIdFromSlug } from './idUtils';
+import DataLoader from 'dataloader';
+import { ItemLoaderType } from '../dataLoaders';
+
+export async function urlFromReaderSlug(
+  slug: string,
+  itemIdLoader: DataLoader<string, ItemLoaderType>,
+): Promise<string | null> {
+  const id = itemIdFromSlug(slug);
+  if (id == null) {
+    return null;
+  }
+  const itemLoaderResult = await itemIdLoader.load(id);
+
+  if (itemLoaderResult == null || itemLoaderResult.url == null) {
+    return null;
+  }
+
+  return itemLoaderResult.url;
+}
+
+/**
+ * Extract the e code from a URL. If the URL is a valid reader sharable link URL,
+ * return the encoded item id. Otherwise return undefined (e.g. if the URL is not a pocket reader URL).
+ * @param url the url to attempt to extract the encoded item id from
+ * @returns undefined if there is no slug to get or the encoded item id if it is a reader url
+ */
+export function extractSlugFromReadUrl(url: string): string | undefined {
+  const regex =
+    /^(?:https?:\/\/)?getpocket\.com\/read\/([A-Za-z\d]+_[A-Za-z\d]+)(?:(?:\/?)|(?:\?[A-Za-z_\-\d]+=[A-Za-z_\-\d]+)(?:\\&[A-Za-z_\-\d]+=[A-Za-z_\-\d]+)*)$/;
+  const match = url.match(regex);
+  return match ? match[1] : undefined;
+}

--- a/servers/parser-graphql-wrapper/src/test/queries/readerUrl.integration.ts
+++ b/servers/parser-graphql-wrapper/src/test/queries/readerUrl.integration.ts
@@ -1,0 +1,146 @@
+import { ApolloServer } from '@apollo/server';
+import { IContext } from '../../apollo/context';
+import { startServer } from '../../apollo/server';
+import { print } from 'graphql/index';
+import { gql } from 'graphql-tag';
+import request from 'supertest';
+import { Application } from 'express';
+import { nockResponseForParser } from '../utils/parserResponse';
+import { getRedis } from '../../cache';
+import { ParserResponse } from '../../datasources/ParserAPITypes';
+import { Kysely } from 'kysely';
+import { DB } from '../../__generated__/readitlab';
+import { conn } from '../../databases/readitlab';
+
+describe('referenceResolver', () => {
+  const readerUrl =
+    'https://getpocket.com/read/fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7eb5D66B8DccAd6E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70';
+  const readerDirectUrl = 'https://someurlyoushouldsee.com';
+
+  let app: Application;
+  let server: ApolloServer<IContext>;
+  let graphQLUrl: string;
+  let readitlabDB: Kysely<DB>;
+
+  const parserItem: Partial<ParserResponse> = {
+    given_url: readerDirectUrl,
+    normal_url: readerDirectUrl,
+    item_id: '123',
+    resolved_id: '123',
+    domainMetadata: {
+      name: 'domain',
+      logo: 'logo',
+    },
+    authors: [],
+    images: [],
+    videos: [],
+    time_to_read: 5,
+  };
+
+  beforeAll(async () => {
+    // port 0 tells express to dynamically assign an available port
+    ({ app, server, url: graphQLUrl } = await startServer(0));
+    //Setup our db connection
+    readitlabDB = conn();
+
+    // flush the redis cache
+    getRedis().clear();
+  });
+
+  beforeEach(async () => {
+    //Delete the items
+    await readitlabDB.deleteFrom('items_resolver').execute();
+    await getRedis().clear();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    await readitlabDB.destroy();
+  });
+
+  it('should return resolved item for reader url', async () => {
+    const mockData = nockResponseForParser(readerDirectUrl, {
+      data: parserItem,
+    });
+    //Create a seed item
+    await readitlabDB
+      .insertInto('items_resolver')
+      .values([
+        {
+          item_id: parseInt(mockData.data.item_id),
+          search_hash: '123455sdf',
+          normal_url: mockData.data.given_url,
+          resolved_id: parseInt(mockData.data.item_id),
+          has_old_dupes: 0,
+        },
+      ])
+      .execute();
+
+    const itemByItemId = gql`
+      query referenceResolver($url: String) {
+        _entities(representations: { givenUrl: $url, __typename: "Item" }) {
+          ... on Item {
+            title
+            itemId
+            readerSlug
+            givenUrl
+          }
+        }
+      }
+    `;
+
+    const res = await request(app)
+      .post(graphQLUrl)
+      .send({ query: print(itemByItemId), variables: { url: readerUrl } });
+    expect(res.body).not.toBeNull();
+    expect(res.body.data._entities[0].title).toBe(mockData.data.title);
+    expect(res.body.data._entities[0].givenUrl).toBe(readerDirectUrl);
+    expect(res.body.data._entities[0].readerSlug).toBe(
+      'fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7eb5D66B8DccAd6E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70',
+    );
+    expect(res.body.data._entities[0].itemId).toBe('123');
+  });
+
+  it('should return resolved item for reader url in itemByUrl', async () => {
+    const mockData = nockResponseForParser(readerDirectUrl, {
+      data: parserItem,
+    });
+    //Create a seed item
+    await readitlabDB
+      .insertInto('items_resolver')
+      .values([
+        {
+          item_id: parseInt(mockData.data.item_id),
+          search_hash: '123455sdf',
+          normal_url: mockData.data.given_url,
+          resolved_id: parseInt(mockData.data.item_id),
+          has_old_dupes: 0,
+        },
+      ])
+      .execute();
+
+    const itemByItemId = gql`
+      query itemByUrl($url: String!) {
+        itemByUrl(url: $url) {
+          ... on Item {
+            title
+            itemId
+            readerSlug
+            givenUrl
+          }
+        }
+      }
+    `;
+
+    const res = await request(app)
+      .post(graphQLUrl)
+      .send({ query: print(itemByItemId), variables: { url: readerUrl } });
+    expect(res.body).not.toBeNull();
+    expect(res.body.data.itemByUrl.title).toBe(mockData.data.title);
+    expect(res.body.data.itemByUrl.givenUrl).toBe(readerDirectUrl);
+    expect(res.body.data.itemByUrl.readerSlug).toBe(
+      'fe562f9c5BCfC1eeQ9AffKeCaiD2a190J7eb5D66B8DccAd6E6a1f247B54Egd22_202cb962ac59075b964b07152d234b70',
+    );
+    expect(res.body.data.itemByUrl.itemId).toBe('123');
+  });
+});

--- a/servers/v3-proxy-api/src/generated/graphql/types.ts
+++ b/servers/v3-proxy-api/src/generated/graphql/types.ts
@@ -24,8 +24,8 @@ export type Scalars = {
   Max300CharString: { input: any; output: any; }
   NonNegativeInt: { input: any; output: any; }
   Timestamp: { input: any; output: any; }
-  URL: { input: any; output: any; }
   Url: { input: any; output: any; }
+  ValidUrl: { input: any; output: any; }
 };
 
 /**
@@ -717,6 +717,8 @@ export type Item = {
   originDomainId?: Maybe<Scalars['String']['output']>;
   /** The client preview/display logic for this url */
   preview?: Maybe<ItemSummary>;
+  /** A server generated unique reader slug for this item based on itemId */
+  readerSlug: Scalars['String']['output'];
   /** Recommend similar articles to show in the bottom of an article. */
   relatedAfterArticle: Array<CorpusRecommendation>;
   /** Recommend similar articles after saving. */
@@ -1235,7 +1237,7 @@ export type MutationCreateSavedItemTagsArgs = {
 /** Default Mutation Type */
 export type MutationCreateShareLinkArgs = {
   context?: InputMaybe<ShareContextInput>;
-  target: Scalars['URL']['input'];
+  target: Scalars['ValidUrl']['input'];
 };
 
 
@@ -1748,9 +1750,9 @@ export type PocketShare = {
   context?: Maybe<ShareContext>;
   createdAt?: Maybe<Scalars['ISOString']['output']>;
   preview?: Maybe<ItemSummary>;
-  shareUrl: Scalars['URL']['output'];
+  shareUrl: Scalars['ValidUrl']['output'];
   slug: Scalars['ID']['output'];
-  targetUrl: Scalars['URL']['output'];
+  targetUrl: Scalars['ValidUrl']['output'];
 };
 
 export enum PremiumFeature {


### PR DESCRIPTION
# Goal

When a `getpocket.com/read/[slug]` is requested from the parser, we should attempt to resolve it to the original item object. This will ensure that iOS, Android and Web get the right metadata in the saves view and all other item queries.

https://mozilla-hub.atlassian.net/browse/POCKET-10000