### PR TITLE
fix(logger): removing the large data blob in errors

### DIFF
--- a/packages/ts-logger/src/logger.ts
+++ b/packages/ts-logger/src/logger.ts
@@ -25,7 +25,18 @@ const envDefaultLogLevel = () => {
   return isDevelopment || isLocal ? 'debug' : 'info';
 };
 
+/**
+ * Our graphql resolvers add on a data key that is an entire dump
+ * of the graphql context that is not needed
+ * This removes it to clean up logs
+ */
+const removeBlobsOfRandomData = winstonFormat((info) => {
+  delete info.data;
+  return info;
+});
+
 const format = winstonFormat.combine(
+  removeBlobsOfRandomData(),
   winstonFormat.timestamp({ format: 'YYYY-MM-DD HH:mm:ss:ms' }),
   winstonFormat.json(),
 );


### PR DESCRIPTION
## Goal

Right now when there is an error, and insane blob of json is dumped making the logs unusable.

This removes that data and makes errors usable.