### PR TITLE
feat(shares): edit share context after creation

### DIFF
--- a/infrastructure/shares-api/src/main.ts
+++ b/infrastructure/shares-api/src/main.ts
@@ -155,6 +155,8 @@ class SharesAPI extends TerraformStack {
     const { region, caller, secretsManagerKmsAlias, snsTopic, dynamodb } =
       dependencies;
 
+    const UserContextSaltArn = `arn:aws:secretsmanager:${region.name}:${caller.accountId}:secret:${config.name}/${config.environment}/USER_CONTEXT_SALT`;
+
     return new PocketALBApplication(this, 'application', {
       internal: true,
       prefix: config.prefix,
@@ -211,6 +213,14 @@ class SharesAPI extends TerraformStack {
             {
               name: 'SENTRY_DSN',
               valueFrom: `arn:aws:ssm:${region.name}:${caller.accountId}:parameter/${config.name}/${config.environment}/SENTRY_DSN`,
+            },
+            {
+              name: 'USERID_SALT',
+              valueFrom: `${UserContextSaltArn}:userid_salt::`,
+            },
+            {
+              name: 'GUID_SALT',
+              valueFrom: `${UserContextSaltArn}:guid_salt::`,
             },
           ],
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,7 +372,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -412,7 +412,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -449,7 +449,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -504,7 +504,7 @@ importers:
         version: 3.1.0
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -556,7 +556,7 @@ importers:
         version: 3.1.0
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -599,7 +599,7 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -633,7 +633,7 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -673,7 +673,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -722,7 +722,7 @@ importers:
         version: 3.1.0
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -759,7 +759,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -802,7 +802,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -845,7 +845,7 @@ importers:
         version: 13.5.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -924,7 +924,7 @@ importers:
         version: 8.0.2(semantic-release@23.0.7)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -946,7 +946,7 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1001,7 +1001,7 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1029,7 +1029,7 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1053,7 +1053,7 @@ importers:
         version: 14.0.0-beta.5
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1081,7 +1081,7 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1142,7 +1142,7 @@ importers:
         version: 8.0.2(semantic-release@23.0.7)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1215,7 +1215,7 @@ importers:
         version: 8.0.2(semantic-release@23.0.7)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1249,7 +1249,7 @@ importers:
         version: 8.0.2(semantic-release@23.0.7)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1334,7 +1334,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@types/node@20.12.7)(typescript@5.4.5)
@@ -1431,7 +1431,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1473,7 +1473,7 @@ importers:
         version: 5.5.2
       unleash-server:
         specifier: 5.11.2
-        version: 5.11.2(core-js@3.37.0)(mobx@6.12.3)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.8)
+        version: 5.11.2(core-js@3.37.0)(mobx@6.12.3)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.9)
     devDependencies:
       '@types/cors':
         specifier: ^2.8.17
@@ -1510,7 +1510,7 @@ importers:
         version: 3.1.0
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1568,7 +1568,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1695,7 +1695,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1792,7 +1792,7 @@ importers:
         version: 8.4.1
       '@graphql-codegen/cli':
         specifier: 5.0.2
-        version: 5.0.2(@parcel/watcher@2.4.1)(graphql@16.8.1)(typescript@5.4.5)
+        version: 5.0.2(graphql@16.8.1)(typescript@5.4.5)
       '@graphql-codegen/typescript':
         specifier: 4.0.6
         version: 4.0.6(graphql@16.8.1)
@@ -1825,7 +1825,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1871,7 +1871,7 @@ importers:
         version: 3.1.0
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1959,7 +1959,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -2017,7 +2017,7 @@ importers:
         version: 3.1.0
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -2090,7 +2090,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -2163,7 +2163,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -2269,7 +2269,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -2351,7 +2351,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@types/node@20.12.7)(typescript@5.4.5)
@@ -2360,11 +2360,6 @@ importers:
         version: link:../../packages/tsconfig
 
 packages:
-
-  /@aashutoshrathi/word-wrap@1.2.6:
-    resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
 
   /@ampproject/remapping@2.3.0:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -3967,6 +3962,29 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/core@7.24.5:
+    resolution: {integrity: sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.24.2
+      '@babel/generator': 7.24.5
+      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-module-transforms': 7.24.5(@babel/core@7.24.5)
+      '@babel/helpers': 7.24.5
+      '@babel/parser': 7.24.5
+      '@babel/template': 7.24.0
+      '@babel/traverse': 7.24.5
+      '@babel/types': 7.24.5
+      convert-source-map: 2.0.0
+      debug: 4.3.4(supports-color@5.5.0)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/generator@7.24.4:
     resolution: {integrity: sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==}
     engines: {node: '>=6.9.0'}
@@ -3975,6 +3993,16 @@ packages:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
+
+  /@babel/generator@7.24.5:
+    resolution: {integrity: sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.5
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 2.5.2
+    dev: true
 
   /@babel/helper-annotate-as-pure@7.22.5:
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
@@ -4046,6 +4074,13 @@ packages:
       '@babel/types': 7.24.0
     dev: true
 
+  /@babel/helper-module-imports@7.24.3:
+    resolution: {integrity: sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.5
+    dev: true
+
   /@babel/helper-module-transforms@7.23.3(@babel/core@7.24.4):
     resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
     engines: {node: '>=6.9.0'}
@@ -4060,6 +4095,20 @@ packages:
       '@babel/helper-validator-identifier': 7.22.20
     dev: true
 
+  /@babel/helper-module-transforms@7.24.5(@babel/core@7.24.5):
+    resolution: {integrity: sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-module-imports': 7.24.3
+      '@babel/helper-simple-access': 7.24.5
+      '@babel/helper-split-export-declaration': 7.24.5
+      '@babel/helper-validator-identifier': 7.24.5
+    dev: true
+
   /@babel/helper-optimise-call-expression@7.22.5:
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
     engines: {node: '>=6.9.0'}
@@ -4069,6 +4118,11 @@ packages:
 
   /@babel/helper-plugin-utils@7.24.0:
     resolution: {integrity: sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-plugin-utils@7.24.5:
+    resolution: {integrity: sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -4091,6 +4145,13 @@ packages:
       '@babel/types': 7.24.0
     dev: true
 
+  /@babel/helper-simple-access@7.24.5:
+    resolution: {integrity: sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.5
+    dev: true
+
   /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
     engines: {node: '>=6.9.0'}
@@ -4105,12 +4166,23 @@ packages:
       '@babel/types': 7.24.0
     dev: true
 
+  /@babel/helper-split-export-declaration@7.24.5:
+    resolution: {integrity: sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.5
+    dev: true
+
   /@babel/helper-string-parser@7.24.1:
     resolution: {integrity: sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==}
     engines: {node: '>=6.9.0'}
 
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-identifier@7.24.5:
+    resolution: {integrity: sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==}
     engines: {node: '>=6.9.0'}
 
   /@babel/helper-validator-option@7.23.5:
@@ -4125,6 +4197,17 @@ packages:
       '@babel/template': 7.24.0
       '@babel/traverse': 7.24.1
       '@babel/types': 7.24.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helpers@7.24.5:
+    resolution: {integrity: sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.24.0
+      '@babel/traverse': 7.24.5
+      '@babel/types': 7.24.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4144,6 +4227,14 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.24.0
+    dev: true
+
+  /@babel/parser@7.24.5:
+    resolution: {integrity: sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.24.5
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.24.4):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
@@ -4552,8 +4643,8 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.24.2
-      '@babel/parser': 7.24.4
-      '@babel/types': 7.24.0
+      '@babel/parser': 7.24.5
+      '@babel/types': 7.24.5
 
   /@babel/traverse@7.24.1:
     resolution: {integrity: sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==}
@@ -4573,12 +4664,38 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/traverse@7.24.5:
+    resolution: {integrity: sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.24.2
+      '@babel/generator': 7.24.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.24.5
+      '@babel/parser': 7.24.5
+      '@babel/types': 7.24.5
+      debug: 4.3.4(supports-color@5.5.0)
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/types@7.24.0:
     resolution: {integrity: sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.24.1
       '@babel/helper-validator-identifier': 7.22.20
+      to-fast-properties: 2.0.0
+
+  /@babel/types@7.24.5:
+    resolution: {integrity: sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.24.1
+      '@babel/helper-validator-identifier': 7.24.5
       to-fast-properties: 2.0.0
 
   /@bcoe/v8-coverage@0.2.3:
@@ -4892,8 +5009,8 @@ packages:
     resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
     dev: false
 
-  /@emotion/unitless@0.8.0:
-    resolution: {integrity: sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==}
+  /@emotion/unitless@0.8.1:
+    resolution: {integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==}
     dev: false
 
   /@esbuild/aix-ppc64@0.19.12:
@@ -5266,8 +5383,8 @@ packages:
     dev: false
     optional: true
 
-  /@google-cloud/storage@7.10.1:
-    resolution: {integrity: sha512-sZW14pfxEQZSIbBPs6doFYtcbK31Bs3E4jH5Ly3jJnBkYfkMPX8sXG3ZQXCJa88MKtUNPlgBdMN2OJUzmFe5/g==}
+  /@google-cloud/storage@7.10.2:
+    resolution: {integrity: sha512-NaCyhwu0cSqwj6waZO+8WiyzCXUBUfVE7T1fHAGRHEJ+CRy5on2ah/jfC0ZPYXL0q4JoPj98VtMW4bEgtFfKHw==}
     engines: {node: '>=14'}
     requiresBuild: true
     dependencies:
@@ -5320,9 +5437,9 @@ packages:
       '@parcel/watcher':
         optional: true
     dependencies:
-      '@babel/generator': 7.24.4
+      '@babel/generator': 7.24.5
       '@babel/template': 7.24.0
-      '@babel/types': 7.24.0
+      '@babel/types': 7.24.5
       '@graphql-codegen/client-preset': 4.2.5(graphql@16.8.1)
       '@graphql-codegen/core': 4.0.2(graphql@16.8.1)
       '@graphql-codegen/plugin-helpers': 5.0.3(graphql@16.8.1)
@@ -5333,9 +5450,9 @@ packages:
       '@graphql-tools/graphql-file-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/json-file-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/load': 8.0.2(graphql@16.8.1)
-      '@graphql-tools/prisma-loader': 8.0.3(@types/node@20.12.7)(graphql@16.8.1)
+      '@graphql-tools/prisma-loader': 8.0.4(@types/node@20.12.7)(graphql@16.8.1)
       '@graphql-tools/url-loader': 8.0.2(@types/node@20.12.7)(graphql@16.8.1)
-      '@graphql-tools/utils': 10.1.3(graphql@16.8.1)
+      '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       '@parcel/watcher': 2.4.1
       '@whatwg-node/fetch': 0.8.8
       chalk: 4.1.2
@@ -5355,7 +5472,7 @@ packages:
       string-env-interpolation: 1.0.1
       ts-log: 2.2.5
       tslib: 2.6.2
-      yaml: 2.4.1
+      yaml: 2.4.2
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@types/node'
@@ -5378,6 +5495,63 @@ packages:
       '@parcel/watcher':
         optional: true
     dependencies:
+      '@babel/generator': 7.24.5
+      '@babel/template': 7.24.0
+      '@babel/types': 7.24.5
+      '@graphql-codegen/client-preset': 4.2.5(graphql@16.8.1)
+      '@graphql-codegen/core': 4.0.2(graphql@16.8.1)
+      '@graphql-codegen/plugin-helpers': 5.0.3(graphql@16.8.1)
+      '@graphql-tools/apollo-engine-loader': 8.0.1(graphql@16.8.1)
+      '@graphql-tools/code-file-loader': 8.1.1(graphql@16.8.1)
+      '@graphql-tools/git-loader': 8.0.5(graphql@16.8.1)
+      '@graphql-tools/github-loader': 8.0.1(@types/node@20.12.7)(graphql@16.8.1)
+      '@graphql-tools/graphql-file-loader': 8.0.1(graphql@16.8.1)
+      '@graphql-tools/json-file-loader': 8.0.1(graphql@16.8.1)
+      '@graphql-tools/load': 8.0.2(graphql@16.8.1)
+      '@graphql-tools/prisma-loader': 8.0.4(@types/node@20.12.7)(graphql@16.8.1)
+      '@graphql-tools/url-loader': 8.0.2(@types/node@20.12.7)(graphql@16.8.1)
+      '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
+      '@whatwg-node/fetch': 0.8.8
+      chalk: 4.1.2
+      cosmiconfig: 8.3.6(typescript@5.4.5)
+      debounce: 1.2.1
+      detect-indent: 6.1.0
+      graphql: 16.8.1
+      graphql-config: 5.0.3(@types/node@20.12.7)(graphql@16.8.1)(typescript@5.4.5)
+      inquirer: 8.2.6
+      is-glob: 4.0.3
+      jiti: 1.21.0
+      json-to-pretty-yaml: 1.2.2
+      listr2: 4.0.5
+      log-symbols: 4.1.0
+      micromatch: 4.0.5
+      shell-quote: 1.8.1
+      string-env-interpolation: 1.0.1
+      ts-log: 2.2.5
+      tslib: 2.6.2
+      yaml: 2.4.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - cosmiconfig-toml-loader
+      - encoding
+      - enquirer
+      - supports-color
+      - typescript
+      - utf-8-validate
+    dev: true
+
+  /@graphql-codegen/cli@5.0.2(graphql@16.8.1)(typescript@5.4.5):
+    resolution: {integrity: sha512-MBIaFqDiLKuO4ojN6xxG9/xL9wmfD3ZjZ7RsPjwQnSHBCUXnEkdKvX+JVpx87Pq29Ycn8wTJUguXnTZ7Di0Mlw==}
+    hasBin: true
+    peerDependencies:
+      '@parcel/watcher': ^2.1.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    peerDependenciesMeta:
+      '@parcel/watcher':
+        optional: true
+    dependencies:
       '@babel/generator': 7.24.4
       '@babel/template': 7.24.0
       '@babel/types': 7.24.0
@@ -5391,7 +5565,7 @@ packages:
       '@graphql-tools/graphql-file-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/json-file-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/load': 8.0.2(graphql@16.8.1)
-      '@graphql-tools/prisma-loader': 8.0.3(@types/node@20.12.7)(graphql@16.8.1)
+      '@graphql-tools/prisma-loader': 8.0.3(graphql@16.8.1)
       '@graphql-tools/url-loader': 8.0.2(@types/node@20.12.7)(graphql@16.8.1)
       '@graphql-tools/utils': 10.1.3(graphql@16.8.1)
       '@whatwg-node/fetch': 0.8.8
@@ -5430,7 +5604,7 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.24.5
       '@babel/template': 7.24.0
       '@graphql-codegen/add': 5.0.2(graphql@16.8.1)
       '@graphql-codegen/gql-tag-operations': 4.0.6(graphql@16.8.1)
@@ -5440,7 +5614,7 @@ packages:
       '@graphql-codegen/typescript-operations': 4.2.0(graphql@16.8.1)
       '@graphql-codegen/visitor-plugin-common': 5.1.0(graphql@16.8.1)
       '@graphql-tools/documents': 1.0.0(graphql@16.8.1)
-      '@graphql-tools/utils': 10.1.3(graphql@16.8.1)
+      '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
@@ -5542,7 +5716,7 @@ packages:
       '@graphql-codegen/plugin-helpers': 5.0.3(graphql@16.8.1)
       '@graphql-codegen/typescript': 4.0.6(graphql@16.8.1)
       '@graphql-codegen/visitor-plugin-common': 5.1.0(graphql@16.8.1)
-      '@graphql-tools/utils': 10.1.3(graphql@16.8.1)
+      '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       auto-bind: 4.0.0
       graphql: 16.8.1
       tslib: 2.6.2
@@ -5575,7 +5749,7 @@ packages:
       '@graphql-codegen/plugin-helpers': 5.0.3(graphql@16.8.1)
       '@graphql-tools/optimize': 2.0.0(graphql@16.8.1)
       '@graphql-tools/relay-operation-optimizer': 7.0.1(graphql@16.8.1)
-      '@graphql-tools/utils': 10.1.3(graphql@16.8.1)
+      '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
       dependency-graph: 0.11.0
@@ -5853,6 +6027,17 @@ packages:
       tslib: 2.6.2
     dev: true
 
+  /@graphql-tools/merge@9.0.4(graphql@16.8.1):
+    resolution: {integrity: sha512-MivbDLUQ+4Q8G/Hp/9V72hbn810IJDEZQ57F01sHnlrrijyadibfVhaQfW/pNH+9T/l8ySZpaR/DpL5i+ruZ+g==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
+      graphql: 16.8.1
+      tslib: 2.6.2
+    dev: true
+
   /@graphql-tools/optimize@2.0.0(graphql@16.8.1):
     resolution: {integrity: sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==}
     engines: {node: '>=16.0.0'}
@@ -5863,7 +6048,7 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@graphql-tools/prisma-loader@8.0.3(@types/node@20.12.7)(graphql@16.8.1):
+  /@graphql-tools/prisma-loader@8.0.3(graphql@16.8.1):
     resolution: {integrity: sha512-oZhxnMr3Jw2WAW1h9FIhF27xWzIB7bXWM8olz4W12oII4NiZl7VRkFw9IT50zME2Bqi9LGh9pkmMWkjvbOpl+Q==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -5884,6 +6069,37 @@ packages:
       jose: 5.2.4
       js-yaml: 4.1.0
       json-stable-stringify: 1.1.1
+      lodash: 4.17.21
+      scuid: 1.1.0
+      tslib: 2.6.2
+      yaml-ast-parser: 0.0.43
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /@graphql-tools/prisma-loader@8.0.4(@types/node@20.12.7)(graphql@16.8.1):
+    resolution: {integrity: sha512-hqKPlw8bOu/GRqtYr0+dINAI13HinTVYBDqhwGAPIFmLr5s+qKskzgCiwbsckdrb5LWVFmVZc+UXn80OGiyBzg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/url-loader': 8.0.2(@types/node@20.12.7)(graphql@16.8.1)
+      '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
+      '@types/js-yaml': 4.0.9
+      '@whatwg-node/fetch': 0.9.17
+      chalk: 4.1.2
+      debug: 4.3.4(supports-color@5.5.0)
+      dotenv: 16.4.5
+      graphql: 16.8.1
+      graphql-request: 6.1.0(graphql@16.8.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.4
+      jose: 5.2.4
+      js-yaml: 4.1.0
       lodash: 4.17.21
       scuid: 1.1.0
       tslib: 2.6.2
@@ -5965,6 +6181,19 @@ packages:
 
   /@graphql-tools/utils@10.1.3(graphql@16.8.1):
     resolution: {integrity: sha512-loco2ctrrMQzdpSHbcOo6+Ecp21BV67cQ2pNGhuVKAexruu01RdLn3LgtK47B9BpLz3cUD6U0u1R0rur7xMOOg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.1)
+      cross-inspect: 1.0.0
+      dset: 3.1.3
+      graphql: 16.8.1
+      tslib: 2.6.2
+    dev: true
+
+  /@graphql-tools/utils@10.2.0(graphql@16.8.1):
+    resolution: {integrity: sha512-HYV7dO6pNA2nGKawygaBpk8y+vXOUjjzzO43W/Kb7EPRmXUEQKjHxPYRvQbiF72u1N3XxwGK5jnnFk9WVhUwYw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -9058,7 +9287,7 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
 
-  /@wesleytodd/openapi@0.3.0(core-js@3.37.0)(mobx@6.12.3)(openapi-types@12.1.3)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.8):
+  /@wesleytodd/openapi@0.3.0(core-js@3.37.0)(mobx@6.12.3)(openapi-types@12.1.3)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.9):
     resolution: {integrity: sha512-7vjiRFY4yW5aYTZzH4EINYpoClBZTahXWGbpaIl6SsL2XcikuvkgoHCA3t/Hu+3QibBT49W3BPXW3Bl8tr7Ddg==}
     dependencies:
       ajv: 8.12.0
@@ -9066,7 +9295,7 @@ packages:
       http-errors: 2.0.0
       merge-deep: 3.0.3
       path-to-regexp: 6.2.1
-      redoc: 2.1.3(core-js@3.37.0)(mobx@6.12.3)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.8)
+      redoc: 2.1.3(core-js@3.37.0)(mobx@6.12.3)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.9)
       router: 1.3.8
       serve-static: 1.15.0
       swagger-parser: 10.0.3(openapi-types@12.1.3)
@@ -11467,7 +11696,7 @@ packages:
     dependencies:
       semver: 7.6.0
       shelljs: 0.8.5
-      typescript: 5.5.0-dev.20240426
+      typescript: 5.5.0-dev.20240430
     dev: false
 
   /dreamopt@0.8.0:
@@ -12048,7 +12277,7 @@ packages:
       lodash.merge: 4.6.2
       minimatch: 3.1.2
       natural-compare: 1.4.0
-      optionator: 0.9.3
+      optionator: 0.9.4
       strip-ansi: 6.0.1
       text-table: 0.2.0
     transitivePeerDependencies:
@@ -12582,7 +12811,7 @@ packages:
       uuid: 9.0.1
     optionalDependencies:
       '@google-cloud/firestore': 7.6.0
-      '@google-cloud/storage': 7.10.1
+      '@google-cloud/storage': 7.10.2
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -13132,9 +13361,9 @@ packages:
       '@graphql-tools/graphql-file-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/json-file-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/load': 8.0.2(graphql@16.8.1)
-      '@graphql-tools/merge': 9.0.3(graphql@16.8.1)
+      '@graphql-tools/merge': 9.0.4(graphql@16.8.1)
       '@graphql-tools/url-loader': 8.0.2(@types/node@20.12.7)(graphql@16.8.1)
-      '@graphql-tools/utils': 10.1.3(graphql@16.8.1)
+      '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       cosmiconfig: 8.3.6(typescript@5.4.5)
       graphql: 16.8.1
       jiti: 1.21.0
@@ -16700,16 +16929,16 @@ packages:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
     dev: false
 
-  /optionator@0.9.3:
-    resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
+  /optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
     dependencies:
-      '@aashutoshrathi/word-wrap': 1.2.6
       deep-is: 0.1.4
       fast-levenshtein: 2.0.6
       levn: 0.4.1
       prelude-ls: 1.2.1
       type-check: 0.4.0
+      word-wrap: 1.2.5
     dev: true
 
   /ora@5.4.1:
@@ -17841,7 +18070,7 @@ packages:
     dependencies:
       redis-errors: 1.2.0
 
-  /redoc@2.1.3(core-js@3.37.0)(mobx@6.12.3)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.8):
+  /redoc@2.1.3(core-js@3.37.0)(mobx@6.12.3)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.9):
     resolution: {integrity: sha512-d7F9qLLxaiFW4GC03VkwlX9wuRIpx9aiIIf3o6mzMnqPfhxrn2IRKGndrkJeVdItgCfmg9jXZiFEowm60f1meQ==}
     engines: {node: '>=6.9', npm: '>=3.0.0'}
     peerDependencies:
@@ -17874,7 +18103,7 @@ packages:
       react-tabs: 4.3.0(react@18.3.1)
       slugify: 1.4.7
       stickyfill: 1.1.1
-      styled-components: 6.1.8(react-dom@18.3.1)(react@18.3.1)
+      styled-components: 6.1.9(react-dom@18.3.1)(react@18.3.1)
       swagger2openapi: 7.0.8
       url-template: 2.0.8
     transitivePeerDependencies:
@@ -18980,15 +19209,15 @@ packages:
     dev: false
     optional: true
 
-  /styled-components@6.1.8(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-PQ6Dn+QxlWyEGCKDS71NGsXoVLKfE1c3vApkvDYS5KAK+V8fNWGhbSUEo9Gg2iaID2tjLXegEW3bZDUGpofRWw==}
+  /styled-components@6.1.9(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-aBOqs0uMsYufFXSE4q6cA6Ty1fwZuMk4BJRHfiGSna59F1otnxiDelwhN4fEwmBtIymmF0ZqXHnpSigr2ps9Cg==}
     engines: {node: '>= 16'}
     peerDependencies:
       react: '>= 16.8.0'
       react-dom: '>= 16.8.0'
     dependencies:
       '@emotion/is-prop-valid': 1.2.1
-      '@emotion/unitless': 0.8.0
+      '@emotion/unitless': 0.8.1
       '@types/stylis': 4.2.0
       css-to-react-native: 3.2.0
       csstype: 3.1.2
@@ -19476,6 +19705,40 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
+  /ts-jest@29.1.2(@babel/core@7.24.5)(jest@29.7.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}
+    engines: {node: ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.24.5
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2)
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.6.0
+      typescript: 5.4.5
+      yargs-parser: 21.1.1
+    dev: true
+
   /ts-log@2.2.5:
     resolution: {integrity: sha512-PGcnJoTBnVGy6yYNFxWVNkdcAuAMstvutN9MgDJIV6L0oG8fB+ZNNy1T+wJzah8RPGor1mZuPQkVfXNDpy9eHA==}
     dev: true
@@ -19849,8 +20112,8 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript@5.5.0-dev.20240426:
-    resolution: {integrity: sha512-96cu+y3DrjSNhNSgB3t3nRiesCwBVjZpbjJ6DcQoCgt0crXXPrOMmJQH/E8TZ41U4JzaULD+cB1Z2owh5HANew==}
+  /typescript@5.5.0-dev.20240430:
+    resolution: {integrity: sha512-HDHiMzAPPZucY1VLkXpTF9qrxwqXv0h/SEDnZs59DPOPKlGlAn4c0o+1t45+kOvD2PhfzFpwHymQnmWBlNFAJA==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false
@@ -19985,12 +20248,12 @@ packages:
       murmurhash3js: 3.0.1
       semver: 7.6.0
 
-  /unleash-server@5.11.2(core-js@3.37.0)(mobx@6.12.3)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.8):
+  /unleash-server@5.11.2(core-js@3.37.0)(mobx@6.12.3)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.9):
     resolution: {integrity: sha512-NkSR4bhlzVuLiZ1gttu/n+lFR2jckIDxkeZDq2QhFGzBXe6hhuo8Tx7xPxKUCFwqtvi418z9d/cae6NsuZhuHA==}
     engines: {node: '>=18 <21'}
     dependencies:
       '@slack/web-api': 6.12.0
-      '@wesleytodd/openapi': 0.3.0(core-js@3.37.0)(mobx@6.12.3)(openapi-types@12.1.3)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.8)
+      '@wesleytodd/openapi': 0.3.0(core-js@3.37.0)(mobx@6.12.3)(openapi-types@12.1.3)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.9)
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
       async: 3.2.5
@@ -20381,6 +20644,11 @@ packages:
       winston-transport: 4.7.0
     dev: false
 
+  /word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
@@ -20512,6 +20780,12 @@ packages:
     resolution: {integrity: sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==}
     engines: {node: '>= 14'}
     hasBin: true
+
+  /yaml@2.4.2:
+    resolution: {integrity: sha512-B3VqDZ+JAg1nZpaEmWtTXUlBneoGx6CPM9b0TENK6aoSu5t73dItudwdgmi6tHlIZZId4dZ9skcAQ2UbcyAeVA==}
+    engines: {node: '>= 14'}
+    hasBin: true
+    dev: true
 
   /yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}

--- a/servers/shares-api/schema.graphql
+++ b/servers/shares-api/schema.graphql
@@ -85,4 +85,16 @@ type Mutation {
   with additional share context.
   """
   createShareLink(target: ValidUrl!, context: ShareContextInput): PocketShare
+  """
+  Attach share context to a Pocket Share. If a context already exists
+  on the Pocket Share, it will be overrwritten. Session ID via the `guid`
+  field on the JWT is used to determine ownership of a share.
+  That means users may only edit share links created in the same
+  session (intended to be a post-share add, not something returned to
+  later). It also lets us attribute ownership to anonymous/logged-out
+  users.
+  Attempting to update a nonexistent share or a share that is not owned
+  by the session user will return ShareNotFound.
+  """
+  addShareContext(slug: ID!, context: ShareContextInput!): ShareResult
 }

--- a/servers/shares-api/src/__generated__/types.ts
+++ b/servers/shares-api/src/__generated__/types.ts
@@ -27,10 +27,28 @@ export type Scalars = {
 export type Mutation = {
   __typename?: 'Mutation';
   /**
+   * Attach share context to a Pocket Share. If a context already exists
+   * on the Pocket Share, it will be overrwritten. Session ID via the `guid`
+   * field on the JWT is used to determine ownership of a share.
+   * That means users may only edit share links created in the same
+   * session (intended to be a post-share add, not something returned to
+   * later). It also lets us attribute ownership to anonymous/logged-out
+   * users.
+   * Attempting to update a nonexistent share or a share that is not owned
+   * by the session user will return ShareNotFound.
+   */
+  addShareContext?: Maybe<ShareResult>;
+  /**
    * Create a Pocket Share for a provided target URL, optionally
    * with additional share context.
    */
   createShareLink?: Maybe<PocketShare>;
+};
+
+
+export type MutationAddShareContextArgs = {
+  context?: InputMaybe<ShareContextInput>;
+  slug: Scalars['ID']['input'];
 };
 
 
@@ -194,8 +212,8 @@ export type ResolversTypes = ResolversObject<{
   ISOString: ResolverTypeWrapper<Scalars['ISOString']['output']>;
   Max300CharString: ResolverTypeWrapper<Scalars['Max300CharString']['output']>;
   Mutation: ResolverTypeWrapper<{}>;
-  PocketShare: ResolverTypeWrapper<PocketShare>;
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
+  PocketShare: ResolverTypeWrapper<PocketShare>;
   Query: ResolverTypeWrapper<{}>;
   ShareContext: ResolverTypeWrapper<ShareContext>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
@@ -213,8 +231,8 @@ export type ResolversParentTypes = ResolversObject<{
   ISOString: Scalars['ISOString']['output'];
   Max300CharString: Scalars['Max300CharString']['output'];
   Mutation: {};
-  PocketShare: PocketShare;
   ID: Scalars['ID']['output'];
+  PocketShare: PocketShare;
   Query: {};
   ShareContext: ShareContext;
   String: Scalars['String']['output'];
@@ -236,6 +254,7 @@ export interface Max300CharStringScalarConfig extends GraphQLScalarTypeConfig<Re
 }
 
 export type MutationResolvers<ContextType = IContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = ResolversObject<{
+  addShareContext?: Resolver<Maybe<ResolversTypes['ShareResult']>, ParentType, ContextType, RequireFields<MutationAddShareContextArgs, 'slug'>>;
   createShareLink?: Resolver<Maybe<ResolversTypes['PocketShare']>, ParentType, ContextType, RequireFields<MutationCreateShareLinkArgs, 'target'>>;
 }>;
 

--- a/servers/shares-api/src/apollo/resolvers.ts
+++ b/servers/shares-api/src/apollo/resolvers.ts
@@ -20,6 +20,12 @@ export const resolvers: Resolvers = {
         args.context,
       );
     },
+    addShareContext: (_, args, context) => {
+      return context.PocketShareModel.updateShareContext(
+        args.slug,
+        args.context,
+      );
+    },
   },
   Query: {
     shareSlug: (_, { slug }, context) => {

--- a/servers/shares-api/src/config/index.ts
+++ b/servers/shares-api/src/config/index.ts
@@ -27,6 +27,8 @@ export const config = {
     sharesTable: {
       name: process.env.SHARES_TABLE || 'SHARES-local-shares',
       ttl: 365 * 24 * 60 * 60 * 1000, // ~1 year in ms
+      userSalt: process.env.USERID_SALT || 'NACL',
+      guidSalt: process.env.GUID_SALT || 'MSG',
     },
   },
   tracing: {

--- a/servers/shares-api/src/datasources/shares.ts
+++ b/servers/shares-api/src/datasources/shares.ts
@@ -9,7 +9,6 @@ import {
   AuthenticationError,
   ForbiddenError,
 } from '@pocket-tools/apollo-utils';
-import { ShareContextInput, ShareResult } from '../__generated__/types';
 import * as Sentry from '@sentry/node';
 import { UserContext } from '../models/UserContext';
 

--- a/servers/shares-api/src/datasources/shares.ts
+++ b/servers/shares-api/src/datasources/shares.ts
@@ -2,13 +2,16 @@ import {
   DynamoDBDocumentClient,
   GetCommand,
   PutCommand,
+  UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { config } from '../config';
 import {
   AuthenticationError,
   ForbiddenError,
 } from '@pocket-tools/apollo-utils';
+import { ShareContextInput, ShareResult } from '../__generated__/types';
 import * as Sentry from '@sentry/node';
+import { UserContext } from '../models/UserContext';
 
 export type ShareEntity = {
   shareId: string;
@@ -18,12 +21,25 @@ export type ShareEntity = {
   createdAt: number; // epoch time in seconds
 };
 
+export type CreateShareEntity = ShareEntity & {
+  userId?: string;
+  guid?: string;
+};
+
 export interface ISharesDataSource {
   getShare(id: string): Promise<ShareEntity | null>;
   createShare(
-    input: ShareEntity,
+    input: CreateShareEntity,
   ):
     | Promise<ShareEntity>
+    | Promise<AuthenticationError>
+    | Promise<ForbiddenError>;
+  updateShareContext(
+    shareId: string,
+    context: Pick<ShareEntity, 'note' | 'highlights'>,
+    owner: { key: keyof UserContext; value: string },
+  ):
+    | Promise<ShareEntity | null>
     | Promise<AuthenticationError>
     | Promise<ForbiddenError>;
 }
@@ -68,7 +84,16 @@ export class SharesDataSourceUnauthenticated
   constructor(conn: DynamoDBDocumentClient) {
     super(conn);
   }
-  async createShare(input: ShareEntity): Promise<AuthenticationError> {
+  async updateShareContext(
+    shareId: string,
+    context: Pick<ShareEntity, 'note' | 'highlights'>,
+    owner: { key: keyof UserContext; value: string },
+  ): Promise<AuthenticationError> {
+    return new AuthenticationError(
+      'You must be logged in to update Share links',
+    );
+  }
+  async createShare(input: CreateShareEntity): Promise<AuthenticationError> {
     return new AuthenticationError(
       'You must be logged in to create Share links',
     );
@@ -82,7 +107,14 @@ export class SharesDataSourceNonNativeApp
   constructor(conn: DynamoDBDocumentClient) {
     super(conn);
   }
-  async createShare(input: ShareEntity): Promise<ForbiddenError> {
+  async updateShareContext(
+    shareId: string,
+    context: Pick<ShareEntity, 'note' | 'highlights'>,
+    owner: { key: keyof UserContext; value: string },
+  ): Promise<ForbiddenError> {
+    return new ForbiddenError('Only Native Pocket Apps may create Share links');
+  }
+  async createShare(input: CreateShareEntity): Promise<ForbiddenError> {
     return new ForbiddenError('Only Native Pocket Apps may create Share links');
   }
 }
@@ -103,7 +135,7 @@ export class SharesDataSourceAuthenticated
    * @returns the inserted entity
    * @throws error if request failed (did not return 200 status)
    */
-  async createShare(input: ShareEntity): Promise<ShareEntity> {
+  async createShare(input: CreateShareEntity): Promise<ShareEntity> {
     const ttl = Math.round(
       (Date.now() + config.dynamoDb.sharesTable.ttl) / 1000,
     );
@@ -117,5 +149,58 @@ export class SharesDataSourceAuthenticated
       throw new Error('Failed to create share record');
     }
     return input;
+  }
+  /**
+   * Update the context added to a share (the highlighted quotes or note).
+   * Overrwrites existing data if it exists.
+   * Requires that the owner matches the value stored in the database
+   * referenced by the passed owner key (e.g. guid).
+   * The calling function should ensure that at least one key in
+   * the `context` argument exists and contains data (not null/undefined).
+   * Otherwise this function will fail.
+   * @param shareId the key of the share to update
+   * @param context the context to attach to the share (quotes, note)
+   * @param owner owner object - the key to check (i.e. userId/guid) and
+   * the value to check equality against
+   * @returns the updated ShareEntity if successful, otherwise null
+   */
+  async updateShareContext(
+    shareId: string,
+    context: Pick<ShareEntity, 'note' | 'highlights'>,
+    owner: { key: keyof UserContext; value: string },
+  ): Promise<ShareEntity | null> {
+    const noteUpdate = context.note ? 'note = :note' : '';
+    const highlightUpdate = context.highlights
+      ? 'highlights = :highlights'
+      : '';
+    const updates = [noteUpdate, highlightUpdate].filter(Boolean).join(', ');
+    const UpdateExpression = `SET ${updates}`;
+    const update = new UpdateCommand({
+      Key: { shareId },
+      UpdateExpression,
+      ConditionExpression: `attribute_exists(shareId) and attribute_exists(${owner.key}) and ${owner.key} = :${owner.key}`,
+      ExpressionAttributeValues: {
+        [`:${owner.key}`]: owner.value,
+        ':note': context.note,
+        ':highlights': context.highlights,
+      },
+      ReturnValues: 'ALL_NEW',
+      TableName: SharesDataSourceAuthenticated.table.name,
+    });
+    try {
+      const response = await this.conn.send(update);
+      if (response?.Attributes != null) {
+        return response.Attributes as ShareEntity;
+      }
+    } catch (err) {
+      if (err.name === 'ConditionalCheckFailedException') {
+        return null;
+      } else {
+        Sentry.addBreadcrumb({ data: err.$metadata });
+        Sentry.captureException(err);
+        throw new Error('Failed to update share record');
+      }
+    }
+    return null;
   }
 }

--- a/servers/shares-api/src/models/ShareNotFoundModel.ts
+++ b/servers/shares-api/src/models/ShareNotFoundModel.ts
@@ -1,6 +1,6 @@
 import { ShareNotFound } from '../__generated__/types';
 
 export class ShareNotFoundModel implements ShareNotFound {
-  static message = `The link you followed has expired or does not exist.`;
+  static message = `The link has expired or does not exist.`;
   static __typename = 'ShareNotFound' as const;
 }

--- a/servers/shares-api/src/models/UserContext.ts
+++ b/servers/shares-api/src/models/UserContext.ts
@@ -1,0 +1,21 @@
+import { createHash } from 'node:crypto';
+
+export type UserContext = {
+  guid?: string;
+  userId?: string;
+};
+
+type UserSeasoning = { userSalt: string; guidSalt: string };
+
+export function UserContextFactory(
+  salts: UserSeasoning,
+  guid: string | undefined,
+  userId: string | undefined,
+): UserContext {
+  const sha256 = (input: string) =>
+    createHash('sha256').update(input, 'utf8').digest('hex');
+  return {
+    guid: guid ? sha256(salts.guidSalt + guid) : undefined,
+    userId: userId ? sha256(salts.userSalt + userId) : undefined,
+  };
+}

--- a/servers/shares-api/src/test/Max300CharString.integration.ts
+++ b/servers/shares-api/src/test/Max300CharString.integration.ts
@@ -3,7 +3,7 @@ import request from 'supertest';
 import { IContext } from '../apollo/context';
 import { startServer } from '../apollo/server';
 import { Application } from 'express';
-import { CREATE_SHARE, GET_SHARE } from './queries';
+import { CREATE_SHARE, GET_SHARE } from './operations';
 
 const uuidMock = jest.fn().mockImplementation(() => '0000-00-00');
 

--- a/servers/shares-api/src/test/addShareContext.integration.ts
+++ b/servers/shares-api/src/test/addShareContext.integration.ts
@@ -8,7 +8,7 @@ import { dynamoClient } from '../datasources/dynamoClient';
 import { SharesDataSourceAuthenticated } from '../datasources/shares';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 
-let uuidOverride = '0000-00-00';
+const uuidOverride = '0000-00-00';
 const uuidMock = jest.fn().mockImplementation(() => uuidOverride);
 jest.mock('uuid', () => ({ v4: () => uuidMock() }));
 

--- a/servers/shares-api/src/test/addShareContext.integration.ts
+++ b/servers/shares-api/src/test/addShareContext.integration.ts
@@ -1,0 +1,178 @@
+import { ApolloServer } from '@apollo/server';
+import request from 'supertest';
+import { IContext } from '../apollo/context';
+import { startServer } from '../apollo/server';
+import { Application } from 'express';
+import { CREATE_SHARE, ADD_SHARE_CONTEXT } from './operations';
+import { dynamoClient } from '../datasources/dynamoClient';
+import { SharesDataSourceAuthenticated } from '../datasources/shares';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+
+let uuidOverride = '0000-00-00';
+const uuidMock = jest.fn().mockImplementation(() => uuidOverride);
+jest.mock('uuid', () => ({ v4: () => uuidMock() }));
+
+describe('addShareContext mutation', () => {
+  let app: Application;
+  let server: ApolloServer<IContext>;
+  let graphQLUrl: string;
+  // Variables/data
+  const headers = { applicationisnative: 'true', userId: '1', guid: 'abc' };
+  const now = Math.round(Date.now() / 1000) * 1000;
+  jest.useFakeTimers({ now });
+
+  beforeAll(async () => {
+    // port 0 tells express to dynamically assign an available port
+    ({ app, server, url: graphQLUrl } = await startServer(0));
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+    await server.stop();
+  });
+  afterEach(async () => {});
+  it.each([
+    {
+      context: {
+        note: 'an innocent video',
+      },
+      expected: {
+        note: 'an innocent video',
+      },
+    },
+    {
+      context: {
+        highlights: { quotes: ['never gonna let you down'] },
+      },
+      expected: {
+        highlights: [{ quote: 'never gonna let you down' }],
+      },
+    },
+    {
+      context: {
+        note: 'an innocent video',
+        highlights: { quotes: ['never gonna let you down'] },
+      },
+      expected: {
+        note: 'an innocent video',
+        highlights: [{ quote: 'never gonna let you down' }],
+      },
+    },
+  ])('replaces existing context field(s)', async (fixture) => {
+    const originalContext = {
+      note: 'this is a cool video!',
+      highlights: [{ quote: 'never gonna give' }],
+    };
+    const createVars = {
+      target: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      context: {
+        note: 'this is a cool video!',
+        highlights: { quotes: ['never gonna give'] },
+      },
+    };
+    await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({ query: CREATE_SHARE, variables: createVars });
+    const variables = {
+      slug: uuidOverride,
+      context: fixture.context,
+    };
+    const res = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({ query: ADD_SHARE_CONTEXT, variables });
+    const expected = {
+      addShareContext: {
+        slug: uuidOverride,
+        context: {
+          ...originalContext,
+          ...fixture.expected,
+        },
+      },
+    };
+    expect(res.body.data).toEqual(expected);
+  });
+  it('returns ShareNotFound if owner (guid) does not match', async () => {
+    const createVars = {
+      target: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      context: {
+        note: 'this is a cool video!',
+        highlights: { quotes: ['never gonna give'] },
+      },
+    };
+    await request(app)
+      .post(graphQLUrl)
+      .set({ applicationisnative: 'true', userId: '1', guid: 'def' })
+      .send({ query: CREATE_SHARE, variables: createVars });
+    const variables = {
+      slug: uuidOverride,
+      context: { note: 'please watch' },
+    };
+    const res = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({ query: ADD_SHARE_CONTEXT, variables });
+    const expected = {
+      addShareContext: {
+        message: 'The link has expired or does not exist.',
+      },
+    };
+    expect(res.body.data).toEqual(expected);
+  });
+  it('returns ShareNotFound if the share does not have an explicit owner', async () => {
+    await new SharesDataSourceAuthenticated(dynamoClient()).createShare({
+      shareId: uuidOverride,
+      targetUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      note: 'this is a cool video!',
+      highlights: ['never gonna give'],
+      createdAt: now / 1000,
+    });
+    const variables = {
+      slug: uuidOverride,
+      context: { note: 'please watch' },
+    };
+    const res = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({ query: ADD_SHARE_CONTEXT, variables });
+    const expected = {
+      addShareContext: {
+        message: 'The link has expired or does not exist.',
+      },
+    };
+    expect(res.body.data).toEqual(expected);
+  });
+  it('returns ShareNotFound if the share does not exist', async () => {
+    const variables = {
+      slug: 'aaaaaa-aa-aaaaaaah',
+      context: { note: 'please watch' },
+    };
+    const res = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({ query: ADD_SHARE_CONTEXT, variables });
+    const expected = {
+      addShareContext: {
+        message: 'The link has expired or does not exist.',
+      },
+    };
+    expect(res.body.data).toEqual(expected);
+  });
+  it('Returns generic error if error is not ConditionalCheckFailedException', async () => {
+    jest
+      .spyOn(DynamoDBDocumentClient.prototype, 'send')
+      .mockImplementation(() => Promise.reject(new Error('some error')));
+    const variables = {
+      slug: 'aaaaaa-aa-aaaaaaah',
+      context: { note: 'please watch' },
+    };
+    const res = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({ query: ADD_SHARE_CONTEXT, variables });
+    expect(res.body.errors[0].message).toEqual('Failed to update share record');
+    expect(res.body.errors[0].extensions.code).toEqual('INTERNAL_SERVER_ERROR');
+  });
+});

--- a/servers/shares-api/src/test/createShareLink.integration.ts
+++ b/servers/shares-api/src/test/createShareLink.integration.ts
@@ -3,7 +3,7 @@ import request from 'supertest';
 import { IContext } from '../apollo/context';
 import { startServer } from '../apollo/server';
 import { Application } from 'express';
-import { CREATE_SHARE, GET_SHARE } from './queries';
+import { CREATE_SHARE, GET_SHARE } from './operations';
 
 const uuidMock = jest.fn().mockImplementation(() => '0000-00-00');
 

--- a/servers/shares-api/src/test/operations.ts
+++ b/servers/shares-api/src/test/operations.ts
@@ -30,3 +30,22 @@ export const GET_SHARE = print(gql`
     }
   }
 `);
+
+export const ADD_SHARE_CONTEXT = print(gql`
+  mutation addShareContext($slug: ID!, $context: ShareContextInput!) {
+    addShareContext(slug: $slug, context: $context) {
+      ... on PocketShare {
+        slug
+        context {
+          note
+          highlights {
+            quote
+          }
+        }
+      }
+      ... on ShareNotFound {
+        message
+      }
+    }
+  }
+`);

--- a/servers/shares-api/src/test/shareSlug.integration.ts
+++ b/servers/shares-api/src/test/shareSlug.integration.ts
@@ -3,7 +3,7 @@ import request from 'supertest';
 import { IContext } from '../apollo/context';
 import { startServer } from '../apollo/server';
 import { Application } from 'express';
-import { GET_SHARE } from './queries';
+import { GET_SHARE } from './operations';
 import { dynamoClient } from '../datasources/dynamoClient';
 import { SharesDataSourceAuthenticated } from '../datasources/shares';
 
@@ -71,7 +71,7 @@ describe('shareSlug', () => {
       .send({ query: GET_SHARE, variables });
     const expected = {
       shareSlug: {
-        message: 'The link you followed has expired or does not exist.',
+        message: 'The link has expired or does not exist.',
       },
     };
     expect(res.body.data).toEqual(expected);


### PR DESCRIPTION
To speed up the experience of creating links;
create the link on one view with a mutation, then optionally
use this mutation to attach context.

This is intended as a step done immediately after sharing the link, not coming back to it way later. This is why we can use the guid. It also lets us enable logged-out users to share links and have the same behavior, if we want to in the future.

** Changes **
* Created salts for userId (unused, but maybe in the future) and guid; uploaded to aws prod and dev accounts
* Save hashed + salted userId + guid (if available from JWT) when creating shares -- this future-proofs if we want to look up by the hashed userid in the future; note this is a one-way lookup, not an encryption/masking
* Add mutation to attach context to a link - checks hashed guid for ownership (same hashed guid used to create the record)
* Returns generic not found if the ownership check failed, or if the link does not exist

[POCKET-10035]

[POCKET-10035]: https://mozilla-hub.atlassian.net/browse/POCKET-10035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ