### PR TITLE
feat(v3proxy:errors): skip Forbidden errors orginating from recentSearch

### DIFF
--- a/servers/v3-proxy-api/src/generated/graphql/types.ts
+++ b/servers/v3-proxy-api/src/generated/graphql/types.ts
@@ -716,7 +716,7 @@ export type Item = {
    */
   originDomainId?: Maybe<Scalars['String']['output']>;
   /** The client preview/display logic for this url */
-  preview?: Maybe<ItemSummary>;
+  preview?: Maybe<PocketMetadata>;
   /** A server generated unique reader slug for this item based on itemId */
   readerSlug: Scalars['String']['output'];
   /** Recommend similar articles to show in the bottom of an article. */
@@ -810,7 +810,7 @@ export type ItemNotFound = {
 /** Union type for items that may or may not be processed */
 export type ItemResult = Item | PendingItem;
 
-export type ItemSummary = {
+export type ItemSummary = PocketMetadata & {
   __typename?: 'ItemSummary';
   authors?: Maybe<Array<Author>>;
   datePublished?: Maybe<Scalars['ISOString']['output']>;
@@ -945,6 +945,18 @@ export type MarticleText = {
 /** Default Mutation Type */
 export type Mutation = {
   __typename?: 'Mutation';
+  /**
+   * Attach share context to a Pocket Share. If a context already exists
+   * on the Pocket Share, it will be overrwritten. Session ID via the `guid`
+   * field on the JWT is used to determine ownership of a share.
+   * That means users may only edit share links created in the same
+   * session (intended to be a post-share add, not something returned to
+   * later). It also lets us attribute ownership to anonymous/logged-out
+   * users.
+   * Attempting to update a nonexistent share or a share that is not owned
+   * by the session user will return ShareNotFound.
+   */
+  addShareContext?: Maybe<ShareResult>;
   /** Add a batch of items to an existing shareable list. */
   addToShareableList: ShareableList;
   /**
@@ -1190,6 +1202,13 @@ export type Mutation = {
    * and creates it if it doesn't.
    */
   upsertSavedItem: SavedItem;
+};
+
+
+/** Default Mutation Type */
+export type MutationAddShareContextArgs = {
+  context: ShareContextInput;
+  slug: Scalars['ID']['input'];
 };
 
 
@@ -1700,6 +1719,19 @@ export enum PendingItemStatus {
   Unresolved = 'UNRESOLVED'
 }
 
+export type PocketMetadata = {
+  authors?: Maybe<Array<Author>>;
+  datePublished?: Maybe<Scalars['ISOString']['output']>;
+  domain?: Maybe<DomainMetadata>;
+  excerpt?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  image?: Maybe<Image>;
+  item?: Maybe<Item>;
+  source: ItemSummarySource;
+  title?: Maybe<Scalars['String']['output']>;
+  url: Scalars['Url']['output'];
+};
+
 /**
  * New Pocket Save Type, replacing SavedItem.
  *
@@ -1755,7 +1787,7 @@ export type PocketShare = {
   __typename?: 'PocketShare';
   context?: Maybe<ShareContext>;
   createdAt?: Maybe<Scalars['ISOString']['output']>;
-  preview?: Maybe<ItemSummary>;
+  preview?: Maybe<PocketMetadata>;
   shareUrl: Scalars['ValidUrl']['output'];
   slug: Scalars['ID']['output'];
   targetUrl: Scalars['ValidUrl']['output'];
@@ -2119,7 +2151,7 @@ export type ReaderFallback = ItemNotFound | ReaderInterstitial;
 
 export type ReaderInterstitial = {
   __typename?: 'ReaderInterstitial';
-  itemCard?: Maybe<ItemSummary>;
+  itemCard?: Maybe<PocketMetadata>;
 };
 
 export type ReaderViewResult = {

--- a/servers/v3-proxy-api/src/graph/graphQLClient.ts
+++ b/servers/v3-proxy-api/src/graph/graphQLClient.ts
@@ -1,5 +1,17 @@
-import { GraphQLClient } from 'graphql-request';
-
+import {
+  ClientError,
+  Variables,
+  RequestDocument,
+  GraphQLClient,
+  resolveRequestDocument,
+} from 'graphql-request';
+import {
+  GraphQLRequestContext,
+  GraphQLResponse,
+  ResponseMiddleware,
+  VariablesAndRequestHeadersArgs,
+} from 'graphql-request/build/esm/types';
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import {
   SavedItemsSimpleQuery,
   SavedItemsSimpleQueryVariables,
@@ -18,55 +30,154 @@ import {
   AddTagsToSavedItemDocument,
   SearchSavedItemsSimpleQueryVariables,
   SearchSavedItemsSimpleQuery,
-  SearchSavedItemsSimpleDocument,
   SearchSavedItemsCompleteQueryVariables,
   SearchSavedItemsCompleteQuery,
   SearchSavedItemsCompleteDocument,
+  SearchSavedItemsSimpleDocument,
 } from '../generated/graphql';
 import config from '../config';
 import * as Sentry from '@sentry/node';
-/**
- * gives a graphQLClient for pocket-graph url
- *
- * This client initializes a `graphql-request` client
- * @param headers any headers received by proxy is just pass through to web graphQL proxy.
- * @param accessToken accessToken of the user
- * @param consumerKey consumerKey associated with the user
- */
+
 export function getClient(
   accessToken: string,
   consumerKey: string,
   headers: any,
 ) {
-  //these headers are not compatible with GraphQLClient's fetch.
-  //they throw an error instead, so ignoring them
-  // headers might include cookie, some observability traceIds, apollo studio headers
-  // so, we are implicitly passing them and removing only those that causes issues
-  delete headers['content-length'];
-  delete headers['content-type'];
-  delete headers['user-agent'];
-  delete headers['host'];
-  delete headers['accept-encoding'];
-  delete headers['connection'];
+  return new GraphQLClientFactory(
+    accessToken,
+    consumerKey,
+    headers,
+  ).createClient();
+}
 
-  let url: string;
+/**
+ * Essentially a GraphQLClient Factory, which allows
+ * for us to handle partial error/data responses with
+ * middleware.
+ * Instantiating this class sets up the basic configuration
+ * for a GraphQL Client class (e.g. the endpoint url and the
+ * headers we always include on the request).
+ * Calling the `request` method creates an internal instance of
+ * GraphQLClient, which is used to serve the request. The
+ * internal GraphQLClient is injected with custom middleware
+ * that
+ * The alternative of using `rawRequest` would require significant
+ * refactoring due to the changes in response type, call signature, etc.
+ * This allows us to essentially keep the same behavior of throwing
+ * errors when we receive them, UNLESS it's an error we know we want
+ * to skip (for example, requesting search history for a non-premium user).
+ * If we want to skip other kinds of errors they just need to be included
+ * in the middleware filter.
+ */
+export class GraphQLClientFactory {
+  url: string;
+  constructor(
+    accessToken: string,
+    consumerKey: string,
+    private headers: any,
+  ) {
+    //these headers are not compatible with GraphQLClient's fetch.
+    //they throw an error instead, so ignoring them
+    // headers might include cookie, some observability traceIds, apollo studio headers
+    // so, we are implicitly passing them and removing only those that causes issues
+    delete headers['content-length'];
+    delete headers['content-type'];
+    delete headers['user-agent'];
+    delete headers['host'];
+    delete headers['accept-encoding'];
+    delete headers['connection'];
 
-  // add in that this is the proxy to the graphql call
-  headers['apollographql-client-name'] = config.app.serviceName;
+    // add in that this is the proxy to the graphql call
+    headers['apollographql-client-name'] = config.app.serviceName;
 
-  //to allow both access token/consumer key based auth or cookie based auth
-  if (accessToken && consumerKey) {
-    url = `${config.graphQLProxy}?consumer_key=${consumerKey}&access_token=${accessToken}`;
-  } else {
-    url = `${config.graphQLProxy}?consumer_key=${consumerKey}`;
+    //to allow both access token/consumer key based auth or cookie based auth
+    if (accessToken && consumerKey) {
+      this.url = `${config.graphQLProxy}?consumer_key=${consumerKey}&access_token=${accessToken}`;
+    } else {
+      this.url = `${config.graphQLProxy}?consumer_key=${consumerKey}`;
+    }
   }
-  Sentry.addBreadcrumb({ message: `creating GraphQL client` });
-  return new GraphQLClient(url, {
-    headers: headers,
-    //fetch implementation used by node version,
-    //can give custom fetch package
-    fetch,
-  });
+  public createClient(responseMiddleware?: ResponseMiddleware) {
+    return new GraphQLClient(this.url, {
+      headers: this.headers,
+      fetch,
+      responseMiddleware,
+      errorPolicy: 'all',
+    });
+  }
+  /**
+   * Essentially a wrapper over `GraphQLClient.request`, but not all
+   * overloads are implemented since we don't use them all.
+   * Creates a new instance of GraphQLClient with custom middleware
+   * to handle the request. The reason we need to wrap this function
+   * is because the ResponseMiddleware type does not have access to
+   * the request scope, which is necessary to properly build a ClientError
+   * if the request should result in one.
+   * This method uses a closure to inject the request context into the
+   * middleware function so we can return well-formed errors when needed.
+   */
+  async request<T, V extends Variables = Variables>(
+    document: RequestDocument | TypedDocumentNode<T, V>,
+    ...variablesAndRequestHeaders: VariablesAndRequestHeadersArgs<V>
+  ): Promise<T> {
+    //
+    const { query } = resolveRequestDocument(document);
+    const [variables] = variablesAndRequestHeaders;
+    const middleware = GraphQLClientFactory.createMiddlewareFn({
+      query,
+      variables,
+    });
+    const client = this.createClient(middleware);
+    return client.request(document, ...variablesAndRequestHeaders);
+  }
+  /**
+   * Create middleware function with access to the request context, so we
+   * can return well-formed errors when needed.
+   * Used to get around having to refactor to use rawRequest, but still
+   * handle data + error responses.
+   * This middleware explicitly skips the ForbiddenError returned when
+   * recentSearches are requested for non-premium users. We still want
+   * the response data in this case. Can add more error handling in
+   * the future as needed.
+   */
+  static createMiddlewareFn(
+    context: GraphQLRequestContext,
+  ): ResponseMiddleware {
+    const middleware: ResponseMiddleware = (response) => {
+      if (!(response instanceof Error) && response.errors) {
+        // Filter out the recent searches forbidden error
+        // In the proxy this data is requested regardless of
+        // premium status, so it's just skipped
+        // If we want to add more matchers for skipping other
+        // errors we can refactor this to become more modular
+        const errors = response.errors.filter(
+          (error) =>
+            !(
+              error.path.indexOf('recentSearches') &&
+              error.extensions.code === 'FORBIDDEN'
+            ),
+        );
+        // If there are still other kinds of errors, throw;
+        // The rejected promise will be caught on the `catch`
+        // callback of the middleware step, then the else-if statement
+        // below will re-throw it for final handling
+        if (errors.length) {
+          const gqlResponse: GraphQLResponse = {
+            data: response.data,
+            errors: errors,
+            extensions: response.extensions,
+            status: response.status,
+          };
+          throw new ClientError(gqlResponse, context);
+        }
+        // There are unskipped errors; re-throw so that the request
+        // evaluates to an error
+      } else if (response instanceof Error) {
+        throw response;
+      }
+    };
+    return middleware;
+  }
 }
 
 /**
@@ -84,7 +195,7 @@ export async function callSavedItemsByOffsetSimple(
   variables: SavedItemsSimpleQueryVariables,
 ): Promise<SavedItemsSimpleQuery> {
   Sentry.addBreadcrumb({ message: 'invoking callSavedItemsByOffsetSimple' });
-  const client = getClient(accessToken, consumerKey, headers);
+  const client = new GraphQLClientFactory(accessToken, consumerKey, headers);
   return client.request<SavedItemsSimpleQuery, SavedItemsSimpleQueryVariables>(
     SavedItemsSimpleDocument,
     variables,
@@ -101,7 +212,7 @@ export async function callSavedItemsByOffsetComplete(
   variables: SavedItemsCompleteQueryVariables,
 ): Promise<SavedItemsCompleteQuery> {
   Sentry.addBreadcrumb({ message: 'invoking callSavedItemsByOffsetComplete' });
-  const client = getClient(accessToken, consumerKey, headers);
+  const client = new GraphQLClientFactory(accessToken, consumerKey, headers);
   return client.request<
     SavedItemsCompleteQuery,
     SavedItemsCompleteQueryVariables
@@ -126,7 +237,7 @@ export async function callSearchByOffsetSimple(
   variables: SearchSavedItemsSimpleQueryVariables,
 ): Promise<SearchSavedItemsSimpleQuery> {
   Sentry.addBreadcrumb({ message: 'invoking callSearchByOffsetSimple' });
-  const client = getClient(accessToken, consumerKey, headers);
+  const client = new GraphQLClientFactory(accessToken, consumerKey, headers);
   return client.request<
     SearchSavedItemsSimpleQuery,
     SearchSavedItemsSimpleQueryVariables
@@ -144,7 +255,7 @@ export async function callSearchByOffsetComplete(
   variables: SearchSavedItemsCompleteQueryVariables,
 ): Promise<SearchSavedItemsCompleteQuery> {
   Sentry.addBreadcrumb({ message: 'invoking callSearchByOffsetComplete' });
-  const client = getClient(accessToken, consumerKey, headers);
+  const client = new GraphQLClientFactory(accessToken, consumerKey, headers);
   return client.request<
     SearchSavedItemsCompleteQuery,
     SearchSavedItemsCompleteQueryVariables
@@ -180,6 +291,8 @@ export async function addSavedItem(
   tags?: string[],
 ): Promise<AddSavedItemCompleteMutation | AddTagsToSavedItemMutation> {
   Sentry.addBreadcrumb({ message: 'invoking addSavedItem' });
+  // This one can use the base client since we don't have any errors we
+  // know that we need to skip for the 'add' mutation
   if (tags) {
     const addResult = await client.request<
       AddSavedItemBeforeTagMutation,

--- a/servers/v3-proxy-api/src/graph/graphQLClient.ts
+++ b/servers/v3-proxy-api/src/graph/graphQLClient.ts
@@ -60,7 +60,9 @@ export function getClient(
  * Calling the `request` method creates an internal instance of
  * GraphQLClient, which is used to serve the request. The
  * internal GraphQLClient is injected with custom middleware
- * that
+ * that allows us to handle error data specially; in this case, we
+ * want to skip some known errors but still return data, and return
+ * error if there is an unhandled issue.
  * The alternative of using `rawRequest` would require significant
  * refactoring due to the changes in response type, call signature, etc.
  * This allows us to essentially keep the same behavior of throwing


### PR DESCRIPTION
Handle partial error/data response, since we still want the rest of the data even if recentSearch returns null + Forbidden error (i.e. if the requester is not logged into a premium account). Supports Android pattern for retrieving recent search history.

[POCKET-10034]

This was tested manually by making real calls to the graph using a premium and non-premium account. I'm trying to figure out if it's possible to test this another way, but I can't mock the `GraphQLClient.request` method anymore because it will not invoke the middleware... Alternative is standing up a local graph server that mirrors prod or making canary requests to the real graph...

[POCKET-10034]: https://mozilla-hub.atlassian.net/browse/POCKET-10034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ