### PR TITLE
fix(annotations): convert null patch to empty string

### DIFF
--- a/servers/annotations-api/src/dataservices/highlights.ts
+++ b/servers/annotations-api/src/dataservices/highlights.ts
@@ -401,7 +401,7 @@ export class HighlightsDataService {
     return {
       id: entity.annotation_id,
       quote: entity.quote,
-      patch: entity.patch,
+      patch: entity.patch ?? '',
       version: entity.version,
       _createdAt: entity.created_at.getTime() / 1000,
       _updatedAt: entity.updated_at.getTime() / 1000,

--- a/servers/annotations-api/src/test/query/highlights-fixtures.ts
+++ b/servers/annotations-api/src/test/query/highlights-fixtures.ts
@@ -78,10 +78,23 @@ export const seedData = (now) => ({
       updated_at: now,
       created_at: now,
     },
+    {
+      annotation_id: '4d27b61e-bc6b-4de7-92f3-5214d6eb2741',
+      user_id: 5,
+      item_id: 2,
+      quote:
+        'Basically, when hardware performance has been pushed to its final limit, and programmers have had several centuries to code, you reach a point where there is far more signicant code than can be rationalized',
+      version: 0,
+      patch: undefined,
+      status: 1,
+      updated_at: now,
+      created_at: now,
+    },
   ],
   list: [
     { item_id: 1, user_id: 1, time_updated: now, api_id_updated: 0 },
     { item_id: 2, user_id: 1, time_updated: now, api_id_updated: 0 },
     { item_id: 3, user_id: 1, time_updated: now, api_id_updated: 0 }, // no highlights
+    { item_id: 2, user_id: 5, time_updated: now, api_id_updated: 0 },
   ],
 });

--- a/servers/annotations-api/src/test/query/highlights.integration.ts
+++ b/servers/annotations-api/src/test/query/highlights.integration.ts
@@ -83,4 +83,24 @@ describe('Highlights on a SavedItem', () => {
     expect(res).toBeTruthy();
     expect(annotations).toHaveLength(0);
   });
+  it('converts null patch to empty string and does not throw error', async () => {
+    const variables = { itemId: 2 };
+    const res = await request(app)
+      .post(graphQLUrl)
+      .set({ userid: '5', premium: 'true' })
+      .send({ query: print(GET_HIGHLIGHTS), variables });
+    const annotations = res.body.data?._entities[0].annotations?.highlights;
+    const expected = {
+      id: '4d27b61e-bc6b-4de7-92f3-5214d6eb2741',
+      quote:
+        'Basically, when hardware performance has been pushed to its final limit, and programmers have had several centuries to code, you reach a point where there is far more signicant code than can be rationalized',
+      patch: '',
+      version: 0,
+      _updatedAt: Math.round(now.getTime() / 1000),
+      _createdAt: Math.round(now.getTime() / 1000),
+    };
+    expect(res.body.errors).toBeUndefined();
+    expect(annotations).toHaveLength(1);
+    expect(annotations[0]).toEqual(expected);
+  });
 });


### PR DESCRIPTION
Currently there are some 'v1' annotations which have null patches in the database. These annotations were available to a smaller cohort of beta android users in 2017 and were superseded by the current 'v2' annotations in late 2017. Rarely these annotations are being requested (mostly by our internal test accounts) and result in a server error when GraphQL rejects the null value due to 'patch' not being nullable in the schema.

This converts these rare patches to empty strings rather than introducing a breaking change. Confirmed with iOS and web clients that the 'v1' patches are handled differently/ that empty patches will simply be discarded. So there should be no change in visual behavior other than reducing errors.

[POCKET-1033]