### PR TITLE
fix(oembed): expire oembed data after 2 days

### DIFF
--- a/servers/parser-graphql-wrapper/src/models/pocketMetadataModels/OEmbedModel.ts
+++ b/servers/parser-graphql-wrapper/src/models/pocketMetadataModels/OEmbedModel.ts
@@ -13,7 +13,7 @@ import { extract } from '@extractus/oembed-extractor';
 export class OEmbedModel implements IPocketMetadataDataSource {
   // Use oEmbed for TikTok, and others in the future
   matcher = /^(.*\b(tiktok\.com|ted\.com)\b).*$/;
-  ttl = 7 * 60 * 60 * 24; // 7 days of ttl cache
+  ttl = 2 * 60 * 60 * 24; // 2 days of ttl cache since TikTok expires their oembed urls after 2 days of generation
   source = PocketMetadataSource.Oembed;
   version = 1;
 


### PR DESCRIPTION
## Goal

I noticed that the image urls returned from the TikTok oembed endpoint only last for 2 days. 

If this is a theme, we will need to build TTL into the model, or cache the tiktok image urls 🤔 