### PR TITLE
chore: update readerSlug documentation

### DIFF
--- a/servers/parser-graphql-wrapper/schema.graphql
+++ b/servers/parser-graphql-wrapper/schema.graphql
@@ -416,8 +416,8 @@ type Query {
   Resolve Reader View links which might point to SavedItems that do not
   exist, aren't in the Pocket User's list, or are requested by a logged-out
   user (or user without a Pocket Account).
-  Fetches data to create an interstitial page/modal so the visitor can click
-  through to the shared site.
+  Fetches data which clients can use to generate an appropriate fallback view
+  that allows users to preview the content and access the original source site.
   """
   readerSlug(slug: ID!): ReaderViewResult!
 }
@@ -450,11 +450,18 @@ extend type Collection @key(fields: "slug") {
   slug: String! @external
 }
 
+"""
+Result for resolving a getpocket.com/read/<slug> link.
+"""
 type ReaderViewResult @key(fields: "slug") {
   slug: ID!
   fallbackPage: ReaderFallback
 }
 
+"""
+Metadata of an Item in Pocket for preview purposes,
+or an ItemNotFound result if the record does not exist.
+"""
 union ReaderFallback = ReaderInterstitial | ItemNotFound
 
 enum PocketMetadataSource {
@@ -511,6 +518,16 @@ type OEmbed implements PocketMetadata {
   type: OEmbedType
 }
 
+"""
+Card preview data for Items resolved from reader view
+(getpocket.com/read/) links.
+
+Should be used to create a view if Reader Mode cannot
+be rendered (e.g. the link is visited by an anonymous
+Pocket user, or a Pocket User that does not have the 
+underlying Item in their Saves). Due to legal obligations
+we can only display Reader Mode for SavedItems.
+"""
 type ReaderInterstitial {
   itemCard: PocketMetadata
 }


### PR DESCRIPTION
Adding some additional documentation for nested fields, and tweaking the wording of the base type documentation (remove 'shared' to disambiguate with sharing).

There was an assumption that the typical case for accessing a getpocket.com/read/ link which resolves to an item not in your saves is because someone that _did_ have it copy-pasted the read link to you, but that's not the only case. Update to reflect.