### PR TITLE
fix(v3proxy:send): fallback parsing for actions array

### DIFF
--- a/servers/v3-proxy-api/src/routes/v3Send.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Send.integration.ts
@@ -46,6 +46,19 @@ describe('v3/send', () => {
   afterEach(() => jest.clearAllMocks());
 
   describe('GET verb', () => {
+    it('handles GET requests with json-stringified query params already decoded by urlencoded middleware', async () => {
+      const actions =
+        '%5B%7B%22tags%22%3A%5B%22%21%40%23%24%25%26%22%5D%2C%22time%22%3A1714995462%2C%22url%22%3A%22https%3A%2F%2Fwww.independent.co.uk%2Flife-style%2Ffood-and-drink%2Ffeatures%2Fpizza-sauce-american-italian-food-b2534835.html%22%2C%22action%22%3A%22tags_replace%22%2C%22cxt_enter_cnt%22%3A0%2C%22cxt_online%22%3A2%2C%22cxt_orient%22%3A1%2C%22cxt_remove_cnt%22%3A0%2C%22cxt_suggested_available%22%3A0%2C%22cxt_suggested_cnt%22%3A0%2C%22cxt_tags_cnt%22%3A0%2C%22cxt_tap_cnt%22%3A1%2C%22cxt_theme%22%3A0%2C%22cxt_ui%22%3Anull%2C%22cxt_view%22%3A%22add_tags%22%2C%22sid%22%3A%221714834421%22%7D%5D';
+      const response = await request(app).get(
+        `/v3/send?consumer_key=test&guid=test&access_token=test&locale_lang=en-US&actions=${actions}`,
+      );
+      const expected = {
+        status: 1,
+        action_results: [true],
+        action_errors: [null],
+      };
+      expect(response.body).toEqual(expected);
+    });
     it('handles encoded actions array in GET request and returns expected response', async () => {
       const actions =
         '%5B%7B%22time%22%3A1712010135%2C%22action%22%3A%22opened_app%22%2C%22cxt_online%22%3A1%2C%22cxt_orient%22%3A1%2C%22cxt_theme%22%3A0%2C%22cxt_view%22%3A%22pocket%22%2C%22sid%22%3A%221712010135%22%7D%2C%7B%22event%22%3A%22open%22%2C%22section%22%3A%22options%22%2C%22time%22%3A1712010136%2C%22version%22%3A%221%22%2C%22view%22%3A%22options%22%2C%22action%22%3A%22pv%22%2C%22cxt_online%22%3A3%2C%22cxt_orient%22%3A1%2C%22cxt_theme%22%3A0%2C%22cxt_view%22%3A%22list%22%2C%22sid%22%3A%221712010135%22%7D%2C%7B%22time%22%3A1712016912%2C%22action%22%3A%22favorite%22%2C%22item_id%22%3A%22123345%22%2C%22cxt_view%22%3A%22pocket%22%2C%22sid%22%3A%221712010135%22%7D%5D';

--- a/servers/v3-proxy-api/src/routes/validations/SendSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/SendSchema.ts
@@ -73,7 +73,19 @@ export const V3SendSchemaGet: Schema = {
     isString: true,
     notEmpty: true,
     customSanitizer: {
-      options: (value) => JSON.parse(decodeURIComponent(value)),
+      options: (value) => {
+        // Is this already decoded JSON string?
+        try {
+          const actions = JSON.parse(value);
+          return actions;
+        } catch (err) {
+          // If not, it's probably a url-encoded JSON string
+          // which needs to be decoded first
+          if (err instanceof SyntaxError) {
+            return JSON.parse(decodeURIComponent(value));
+          }
+        }
+      },
     },
     custom: {
       options: (arr) =>


### PR DESCRIPTION
Previously we were assuming all query params were
still encoded strings; this is not true for some
GET request patterns. This PR first attempts to
parse actions array as JSON; if it fails, then
try decoding the string (assuming uri-encoded)
before reparsing as JSON.

In many cases it was fine to decode the already-
decoded string again, because the actions array
typically did not include special characters. But
since it's user input it's possible to say, make a tag with a percent sign. That was causing the whole thing to fail because it wasn't valid url encoding.

[POCKET-10048]

[POCKET-10048]: https://mozilla-hub.atlassian.net/browse/POCKET-10048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ