### PR TITLE
feat(v3proxy:tags): clear tags if replacement is empty

### DIFF
--- a/servers/v3-proxy-api/src/routes/v3Send.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Send.integration.ts
@@ -432,6 +432,37 @@ describe('v3/send', () => {
               });
             },
           );
+          it.each(['', []])(
+            'makes a tags_clear request if tags_replace array is empty',
+            async (tags) => {
+              const input = {
+                action: 'tags_replace',
+                url: 'http://test.com',
+                time: '1711558016',
+                tags,
+              };
+              const res = await request(app)
+                .post('/v3/send')
+                .send({
+                  consumer_key: 'test',
+                  access_token: 'test',
+                  actions: [input],
+                });
+              expect(clientSpy).toHaveBeenCalledTimes(1);
+              expect(
+                clientSpy.mock.calls[0][0].definitions[0].name.value,
+              ).toEqual('ClearTags');
+              expect(clientSpy.mock.calls[0][1]).toEqual({
+                savedItem: { url: 'http://test.com' },
+                timestamp: '2024-03-27T16:46:56.000Z',
+              });
+              expect(res.body).toEqual({
+                status: 1,
+                action_results: [true],
+                action_errors: [null],
+              });
+            },
+          );
         });
         describe('tags_remove', () => {
           it.each([

--- a/servers/v3-proxy-api/src/routes/validations/SendActionValidators.ts
+++ b/servers/v3-proxy-api/src/routes/validations/SendActionValidators.ts
@@ -730,11 +730,28 @@ export function ActionSanitizer(input: MaybeAction): SendAction {
       }).validate();
     case 'tags_add':
     case 'tags_remove':
-    case 'tags_replace':
       return new ItemTagActionSanitizer({
         ...input,
         action: input.action,
       }).validate();
+    case 'tags_replace':
+      // Android sends an empty replacement array rather than
+      // using the tags_clear action...
+      if (
+        input.tags != null &&
+        (Array.isArray(input.tags) || typeof input.tags === 'string') &&
+        input.tags.length === 0
+      )
+        return new ItemActionSanitizer({
+          ...input,
+          action: 'tags_clear',
+        });
+      else {
+        return new ItemTagActionSanitizer({
+          ...input,
+          action: input.action,
+        }).validate();
+      }
     case 'tag_delete':
       return new TagDeleteActionSanitizer({
         ...input,


### PR DESCRIPTION
Changes the replace_tags action to clear_tags action if replacement value is empty

[POCKET-10098]

[POCKET-10098]: https://mozilla-hub.atlassian.net/browse/POCKET-10098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ