### PR TITLE
fix(shares:events): fix share event detail schema

### DIFF
--- a/servers/shares-api/src/events/EventBus.ts
+++ b/servers/shares-api/src/events/EventBus.ts
@@ -39,7 +39,7 @@ export class EventBus {
       Entries: [
         {
           EventBusName: config.aws.eventBus.name,
-          Detail: JSON.stringify(payload),
+          Detail: JSON.stringify({ pocketShare: payload }),
           Source: config.aws.eventBus.source,
           DetailType: eventType,
         },


### PR DESCRIPTION
Was missing the key that snowplow was looking
for, and instead just had the object as the
payload.