### PR TITLE
feat(search:corpus): add indices for language-specific corpora

### DIFF
--- a/.docker/aws-resources/elasticsearch/esindex_corpus_de.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_de.json
@@ -1,0 +1,69 @@
+{
+  "settings": {
+    "index": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1
+    }
+  },
+  "mappings": {
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "title": {
+        "type": "text",
+        "analyzer": "german"
+      },
+      "url": {
+        "type": "text"
+      },
+      "excerpt": {
+        "type": "text",
+        "analyzer": "german"
+      },
+      "is_syndicated": {
+        "type": "boolean"
+      },
+      "language": {
+        "type": "keyword"
+      },
+      "publisher": {
+        "type": "text",
+        "analyzer": "simple"
+      },
+      "topic": {
+        "type": "keyword"
+      },
+      "authors": {
+        "type": "text",
+        "analyzer": "simple"
+      },
+      "created_at": {
+        "type": "date",
+        "format": "strict_date_optional_time||epoch_second"
+      },
+      "published_at": {
+        "type": "date",
+        "format": "strict_date_optional_time||epoch_second"
+      },
+      "is_collection": {
+        "type": "boolean"
+      },
+      "collection_labels": {
+        "type": "keyword"
+      },
+      "curation_category": {
+        "type": "keyword"
+      },
+      "iab_parent": {
+        "type": "keyword"
+      },
+      "iab_child": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_en.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_en.json
@@ -1,0 +1,69 @@
+{
+  "settings": {
+    "index": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1
+    }
+  },
+  "mappings": {
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "title": {
+        "type": "text",
+        "analyzer": "english"
+      },
+      "url": {
+        "type": "text"
+      },
+      "excerpt": {
+        "type": "text",
+        "analyzer": "english"
+      },
+      "is_syndicated": {
+        "type": "boolean"
+      },
+      "language": {
+        "type": "keyword"
+      },
+      "publisher": {
+        "type": "text",
+        "analyzer": "simple"
+      },
+      "topic": {
+        "type": "keyword"
+      },
+      "authors": {
+        "type": "text",
+        "analyzer": "simple"
+      },
+      "created_at": {
+        "type": "date",
+        "format": "strict_date_optional_time||epoch_second"
+      },
+      "published_at": {
+        "type": "date",
+        "format": "strict_date_optional_time||epoch_second"
+      },
+      "is_collection": {
+        "type": "boolean"
+      },
+      "collection_labels": {
+        "type": "keyword"
+      },
+      "curation_category": {
+        "type": "keyword"
+      },
+      "iab_parent": {
+        "type": "keyword"
+      },
+      "iab_child": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_es.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_es.json
@@ -1,0 +1,69 @@
+{
+  "settings": {
+    "index": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1
+    }
+  },
+  "mappings": {
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "title": {
+        "type": "text",
+        "analyzer": "spanish"
+      },
+      "url": {
+        "type": "text"
+      },
+      "excerpt": {
+        "type": "text",
+        "analyzer": "spanish"
+      },
+      "is_syndicated": {
+        "type": "boolean"
+      },
+      "language": {
+        "type": "keyword"
+      },
+      "publisher": {
+        "type": "text",
+        "analyzer": "simple"
+      },
+      "topic": {
+        "type": "keyword"
+      },
+      "authors": {
+        "type": "text",
+        "analyzer": "simple"
+      },
+      "created_at": {
+        "type": "date",
+        "format": "strict_date_optional_time||epoch_second"
+      },
+      "published_at": {
+        "type": "date",
+        "format": "strict_date_optional_time||epoch_second"
+      },
+      "is_collection": {
+        "type": "boolean"
+      },
+      "collection_labels": {
+        "type": "keyword"
+      },
+      "curation_category": {
+        "type": "keyword"
+      },
+      "iab_parent": {
+        "type": "keyword"
+      },
+      "iab_child": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_fr.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_fr.json
@@ -1,0 +1,69 @@
+{
+  "settings": {
+    "index": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1
+    }
+  },
+  "mappings": {
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "title": {
+        "type": "text",
+        "analyzer": "french"
+      },
+      "url": {
+        "type": "text"
+      },
+      "excerpt": {
+        "type": "text",
+        "analyzer": "french"
+      },
+      "is_syndicated": {
+        "type": "boolean"
+      },
+      "language": {
+        "type": "keyword"
+      },
+      "publisher": {
+        "type": "text",
+        "analyzer": "simple"
+      },
+      "topic": {
+        "type": "keyword"
+      },
+      "authors": {
+        "type": "text",
+        "analyzer": "simple"
+      },
+      "created_at": {
+        "type": "date",
+        "format": "strict_date_optional_time||epoch_second"
+      },
+      "published_at": {
+        "type": "date",
+        "format": "strict_date_optional_time||epoch_second"
+      },
+      "is_collection": {
+        "type": "boolean"
+      },
+      "collection_labels": {
+        "type": "keyword"
+      },
+      "curation_category": {
+        "type": "keyword"
+      },
+      "iab_parent": {
+        "type": "keyword"
+      },
+      "iab_child": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_it.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_it.json
@@ -1,0 +1,69 @@
+{
+  "settings": {
+    "index": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1
+    }
+  },
+  "mappings": {
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "title": {
+        "type": "text",
+        "analyzer": "italian"
+      },
+      "url": {
+        "type": "text"
+      },
+      "excerpt": {
+        "type": "text",
+        "analyzer": "italian"
+      },
+      "is_syndicated": {
+        "type": "boolean"
+      },
+      "language": {
+        "type": "keyword"
+      },
+      "publisher": {
+        "type": "text",
+        "analyzer": "simple"
+      },
+      "topic": {
+        "type": "keyword"
+      },
+      "authors": {
+        "type": "text",
+        "analyzer": "simple"
+      },
+      "created_at": {
+        "type": "date",
+        "format": "strict_date_optional_time||epoch_second"
+      },
+      "published_at": {
+        "type": "date",
+        "format": "strict_date_optional_time||epoch_second"
+      },
+      "is_collection": {
+        "type": "boolean"
+      },
+      "collection_labels": {
+        "type": "keyword"
+      },
+      "curation_category": {
+        "type": "keyword"
+      },
+      "iab_parent": {
+        "type": "keyword"
+      },
+      "iab_child": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.docker/aws-resources/elasticsearch/esindex_list.json
+++ b/.docker/aws-resources/elasticsearch/esindex_list.json
@@ -1,7 +1,7 @@
 {
   "settings": {
     "index": {
-      "number_of_shards": 331,
+      "number_of_shards": 10,
       "number_of_replicas": 2
     }
   },

--- a/.docker/aws-resources/user-list-search.sh
+++ b/.docker/aws-resources/user-list-search.sh
@@ -40,17 +40,34 @@ do
   sleep 3
 done
 
+corpus_langs=(
+  en
+  de
+  es
+  fr
+  it
+)
 # if we have a healthy cluster, create the index
 if [ $health == "green" ]
 then
-  curl -vX PUT "http://localhost:4566/user-list-search/list" --header "Content-Type: application/json" -d @"$(dirname ${BASH_SOURCE[0]})/elasticsearch/esindex.json"
-
-  echo "elasticsearch index created!"
-  sleep 
+  curl -vX PUT "http://localhost:4566/user-list-search/list" --header "Content-Type: application/json" -d @"$(dirname ${BASH_SOURCE[0]})/elasticsearch/esindex_list.json"
+  echo "elasticsearch list index created!"
+  sleep 1
 
   curl -vX PUT "http://localhost:4566/user-list-search/list/_settings" -H "Content-Type: application/json" -d @"$(dirname ${BASH_SOURCE[0]})/elasticsearch/slow-query-log-thresholds.json"
+  echo "elasticsearch slow log thresholds set for list index!"
+  sleep 1
 
-  echo "elasticsearch slow log thresholds set!"
+  for lang in "${corpus_langs[@]}"; do
+    curl -vX PUT "http://localhost:4566/user-list-search/corpus_${lang}" --header "Content-Type: application/json" -d @"$(dirname ${BASH_SOURCE[0]})/elasticsearch/esindex_corpus_${lang}.json"
+    echo "elasticsearch corpus (${lang}) index created!"
+    sleep 1
+
+    curl -vX PUT "http://localhost:4566/user-list-search/corpus_${lang}/_settings" --header "Content-Type: application/json" -d @"$(dirname ${BASH_SOURCE[0]})/elasticsearch/slow-query-log-thresholds.json"
+    echo "elasticsearch slow log thresholds set for corpus (${lang}) index!"
+    sleep 1
+  done
+
 else
   echo "no healthy cluster found after 60 seconds. index not created. :("
 fi

--- a/infrastructure/user-list-search/apollo_ecs.tf
+++ b/infrastructure/user-list-search/apollo_ecs.tf
@@ -52,6 +52,26 @@ module "apollo" {
       value = local.elastic_index
     },
     {
+      name  = "CORPUS_INDEX_EN"
+      value = local.corpus_index_en
+    },
+    {
+      name  = "CORPUS_INDEX_ES"
+      value = local.corpus_index_es
+    },
+    {
+      name  = "CORPUS_INDEX_IT"
+      value = local.corpus_index_it
+    },
+    {
+      name  = "CORPUS_INDEX_FR"
+      value = local.corpus_index_fr
+    },
+    {
+      name  = "CORPUS_INDEX_DE"
+      value = local.corpus_index_de
+    },
+    {
       name  = "ELASTICSEARCH_DOMAIN"
       value = local.elastic.domain_name
     },

--- a/infrastructure/user-list-search/locals.tf
+++ b/infrastructure/user-list-search/locals.tf
@@ -14,6 +14,11 @@ locals {
   container_name       = "node"
   container_credential = "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:Shared/DockerHub"
   elastic_index        = "list"
+  corpus_index_en      = "corpus_en"
+  corpus_index_fr      = "corpus_fr"
+  corpus_index_es      = "corpus_es"
+  corpus_index_it      = "corpus_it"
+  corpus_index_de      = "corpus_de"
   elastic = {
     endpoint    = local.workspace.es_cluster_enable ? aws_elasticsearch_domain.user_search[0].endpoint : null
     domain_name = local.workspace.es_cluster_enable ? aws_elasticsearch_domain.user_search[0].domain_name : null

--- a/servers/user-list-search/src/config/index.ts
+++ b/servers/user-list-search/src/config/index.ts
@@ -32,13 +32,25 @@ export const config = {
         process.env.ELASTICSEARCH_HOST ||
         'http://localhost:4566/user-list-search',
       apiVersion: '7.1',
-      index: process.env.ELASTICSEARCH_INDEX || 'list',
-      type: process.env.ELASTICSEARCH_TYPE || '_doc',
-      defaultQueryScore: process.env.ELASTICSEARCH_DEFAULT_QUERY_SCORE || 1,
-      maxRetries: 3,
-      deleteConfig: {
-        slices: 100,
+      list: {
+        index: process.env.ELASTICSEARCH_INDEX || 'list',
+        type: process.env.ELASTICSEARCH_TYPE || '_doc',
+        defaultQueryScore: process.env.ELASTICSEARCH_DEFAULT_QUERY_SCORE || 1,
+        deleteConfig: {
+          slices: 100,
+        },
       },
+      corpus: {
+        index: {
+          // language-specific corpus indices
+          en: process.env.CORPUS_INDEX_EN || 'corpus_en',
+          es: process.env.CORPUS_INDEX_ES || 'corpus_es',
+          de: process.env.CORPUS_INDEX_DE || 'corpus_de',
+          fr: process.env.CORPUS_INDEX_FR || 'corpus_fr',
+          it: process.env.CORPUS_INDEX_IT || 'corpus_it',
+        },
+      },
+      maxRetries: 3,
     },
     sqs: {
       waitTimeSeconds: 20,

--- a/servers/user-list-search/src/datasource/elasticsearch/advancedSearch.integration.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/advancedSearch.integration.ts
@@ -26,8 +26,8 @@ const defaultDocProps = {
 describe('Elasticsearch Search Query', () => {
   beforeEach(async () => {
     await client.deleteByQuery({
-      index: config.aws.elasticsearch.index,
-      type: config.aws.elasticsearch.type,
+      index: config.aws.elasticsearch.list.index,
+      type: config.aws.elasticsearch.list.type,
       body: {
         query: {
           match_all: {},
@@ -36,7 +36,9 @@ describe('Elasticsearch Search Query', () => {
     });
 
     // Wait for delete to finish
-    await client.indices.refresh({ index: config.aws.elasticsearch.index });
+    await client.indices.refresh({
+      index: config.aws.elasticsearch.list.index,
+    });
 
     await bulkDocument([
       {

--- a/servers/user-list-search/src/datasource/elasticsearch/elasticsearchBulk.integration.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/elasticsearchBulk.integration.ts
@@ -20,8 +20,8 @@ const defaultDocProps = {
 describe('Elasticsearch Bulk', () => {
   beforeAll(async () => {
     await client.deleteByQuery({
-      index: config.aws.elasticsearch.index,
-      type: config.aws.elasticsearch.type,
+      index: config.aws.elasticsearch.list.index,
+      type: config.aws.elasticsearch.list.type,
       body: {
         query: {
           match_all: {},
@@ -30,7 +30,9 @@ describe('Elasticsearch Bulk', () => {
     });
 
     // Wait for delete to finish
-    await client.indices.refresh({ index: config.aws.elasticsearch.index });
+    await client.indices.refresh({
+      index: config.aws.elasticsearch.list.index,
+    });
 
     await bulkDocument([
       {
@@ -45,7 +47,9 @@ describe('Elasticsearch Bulk', () => {
       },
     ]);
     // Wait for index to finish
-    await client.indices.refresh({ index: config.aws.elasticsearch.index });
+    await client.indices.refresh({
+      index: config.aws.elasticsearch.list.index,
+    });
   });
 
   it('can bulk index a document', async () => {

--- a/servers/user-list-search/src/datasource/elasticsearch/elasticsearchBulk.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/elasticsearchBulk.ts
@@ -8,8 +8,8 @@ import { client } from './index';
 import { config } from '../../config';
 import { serverLogger } from '@pocket-tools/ts-logger';
 
-const index = config.aws.elasticsearch.index;
-const type = config.aws.elasticsearch.type;
+const index = config.aws.elasticsearch.list.index;
+const type = config.aws.elasticsearch.list.type;
 
 type BulkDeleteEntry = {
   delete: {

--- a/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.integration.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.integration.ts
@@ -24,8 +24,8 @@ const defaultDocProps = {
 describe('Elasticsearch Search Query', () => {
   beforeEach(async () => {
     await client.deleteByQuery({
-      index: config.aws.elasticsearch.index,
-      type: config.aws.elasticsearch.type,
+      index: config.aws.elasticsearch.list.index,
+      type: config.aws.elasticsearch.list.type,
       body: {
         query: {
           match_all: {},
@@ -34,7 +34,9 @@ describe('Elasticsearch Search Query', () => {
     });
 
     // Wait for delete to finish
-    await client.indices.refresh({ index: config.aws.elasticsearch.index });
+    await client.indices.refresh({
+      index: config.aws.elasticsearch.list.index,
+    });
 
     await bulkDocument([
       {
@@ -133,7 +135,9 @@ describe('Elasticsearch Search Query', () => {
     ]);
 
     // Wait for index to finish
-    await client.indices.refresh({ index: config.aws.elasticsearch.index });
+    await client.indices.refresh({
+      index: config.aws.elasticsearch.list.index,
+    });
   });
 
   // For now this gives us confidence that basic search is not

--- a/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.ts
@@ -19,7 +19,7 @@ import {
   UserSearchSavedItemsByOffsetArgs,
 } from '../../__generated__/types';
 
-const { index, type, defaultQueryScore } = config.aws.elasticsearch;
+const { index, type, defaultQueryScore } = config.aws.elasticsearch.list;
 
 export const ElasticSearchFilterStatus = {
   ARCHIVED: 'ARCHIVED',

--- a/servers/user-list-search/src/elasticsearch.integration.ts
+++ b/servers/user-list-search/src/elasticsearch.integration.ts
@@ -18,8 +18,8 @@ const defaultDocProps = {
 describe('Elasticsearch - Integration', () => {
   beforeEach(async () => {
     await client.deleteByQuery({
-      index: config.aws.elasticsearch.index,
-      type: config.aws.elasticsearch.type,
+      index: config.aws.elasticsearch.list.index,
+      type: config.aws.elasticsearch.list.type,
       body: {
         query: {
           match_all: {},
@@ -28,7 +28,9 @@ describe('Elasticsearch - Integration', () => {
     });
 
     // Wait for delete to finish
-    await client.indices.refresh({ index: config.aws.elasticsearch.index });
+    await client.indices.refresh({
+      index: config.aws.elasticsearch.list.index,
+    });
 
     await bulkDocument([
       {
@@ -94,13 +96,15 @@ describe('Elasticsearch - Integration', () => {
     ]);
 
     // Wait for index to finish
-    await client.indices.refresh({ index: config.aws.elasticsearch.index });
+    await client.indices.refresh({
+      index: config.aws.elasticsearch.list.index,
+    });
   });
 
   it('deletes all documents for a given user_id', async () => {
     const search = (userId: string) =>
       client.search({
-        index: config.aws.elasticsearch.index,
+        index: config.aws.elasticsearch.list.index,
         routing: userId,
         body: {
           query: {
@@ -117,7 +121,9 @@ describe('Elasticsearch - Integration', () => {
     await deleteSearchIndexByUserId('1');
 
     // Wait for delete to finish
-    await client.indices.refresh({ index: config.aws.elasticsearch.index });
+    await client.indices.refresh({
+      index: config.aws.elasticsearch.list.index,
+    });
 
     const resUser1 = await search('1');
     const resUser2 = await search('2');

--- a/servers/user-list-search/src/elasticsearch.ts
+++ b/servers/user-list-search/src/elasticsearch.ts
@@ -170,7 +170,8 @@ export async function deleteSearchIndexByUserId(
   userId: string,
   waitForCompletion = false,
 ): Promise<DeleteDocumentByQueryResponse | void> {
-  const { index, maxRetries, deleteConfig } = config.aws.elasticsearch;
+  const { list, maxRetries } = config.aws.elasticsearch;
+  const { index, deleteConfig } = list;
   return client.deleteByQuery({
     index,
     maxRetries,

--- a/servers/user-list-search/src/premiumSearch.integration.ts
+++ b/servers/user-list-search/src/premiumSearch.integration.ts
@@ -127,8 +127,8 @@ describe('premium search functional test', () => {
   beforeAll(async () => {
     ({ app, server, url } = await startServer(0));
     await testEsClient.deleteByQuery({
-      index: config.aws.elasticsearch.index,
-      type: config.aws.elasticsearch.type,
+      index: config.aws.elasticsearch.list.index,
+      type: config.aws.elasticsearch.list.type,
       body: {
         query: {
           match_all: {},
@@ -138,7 +138,7 @@ describe('premium search functional test', () => {
 
     // Wait for delete to finish
     await testEsClient.indices.refresh({
-      index: config.aws.elasticsearch.index,
+      index: config.aws.elasticsearch.list.index,
     });
 
     await db('readitla_ril-tmp.list').truncate();
@@ -234,7 +234,7 @@ describe('premium search functional test', () => {
 
     // Takes a hot sec for the data to be available, otherwise test flakes
     await testEsClient.indices.refresh({
-      index: config.aws.elasticsearch.index,
+      index: config.aws.elasticsearch.list.index,
     });
   });
 

--- a/servers/user-list-search/src/premiumSearchByOffset.integration.ts
+++ b/servers/user-list-search/src/premiumSearchByOffset.integration.ts
@@ -122,8 +122,8 @@ describe('premium search functional test (offset pagination)', () => {
   beforeAll(async () => {
     ({ app, server, url } = await startServer(0));
     await testEsClient.deleteByQuery({
-      index: config.aws.elasticsearch.index,
-      type: config.aws.elasticsearch.type,
+      index: config.aws.elasticsearch.list.index,
+      type: config.aws.elasticsearch.list.type,
       body: {
         query: {
           match_all: {},
@@ -133,7 +133,7 @@ describe('premium search functional test (offset pagination)', () => {
 
     // Wait for delete to finish
     await testEsClient.indices.refresh({
-      index: config.aws.elasticsearch.index,
+      index: config.aws.elasticsearch.list.index,
     });
 
     await db('readitla_ril-tmp.list').truncate();
@@ -227,7 +227,7 @@ describe('premium search functional test (offset pagination)', () => {
     await Promise.all(items);
     // Takes a hot sec for the data to be available, otherwise test flakes
     await testEsClient.indices.refresh({
-      index: config.aws.elasticsearch.index,
+      index: config.aws.elasticsearch.list.index,
     });
   });
 

--- a/servers/user-list-search/src/server/routes/itemDelete.integration.ts
+++ b/servers/user-list-search/src/server/routes/itemDelete.integration.ts
@@ -70,8 +70,8 @@ describe('itemDelete', () => {
 
   beforeAll(async () => {
     await esClient.deleteByQuery({
-      index: config.aws.elasticsearch.index,
-      type: config.aws.elasticsearch.type,
+      index: config.aws.elasticsearch.list.index,
+      type: config.aws.elasticsearch.list.type,
       body: {
         query: {
           match_all: {},
@@ -79,7 +79,9 @@ describe('itemDelete', () => {
       },
     });
     // Wait for delete to finish
-    await esClient.indices.refresh({ index: config.aws.elasticsearch.index });
+    await esClient.indices.refresh({
+      index: config.aws.elasticsearch.list.index,
+    });
 
     ({ app, server } = await startServer(0));
   });
@@ -93,7 +95,9 @@ describe('itemDelete', () => {
     }
 
     // Wait for background indexing to finish
-    await esClient.indices.refresh({ index: config.aws.elasticsearch.index });
+    await esClient.indices.refresh({
+      index: config.aws.elasticsearch.list.index,
+    });
 
     //Ensure each document we just passed along was deleted for user 1
     for (let i = 1; i <= 5; i++) {

--- a/servers/user-list-search/src/server/routes/itemUpdate.integration.ts
+++ b/servers/user-list-search/src/server/routes/itemUpdate.integration.ts
@@ -29,8 +29,8 @@ describe('itemUpdate', () => {
 
   beforeAll(async () => {
     await esClient.deleteByQuery({
-      index: config.aws.elasticsearch.index,
-      type: config.aws.elasticsearch.type,
+      index: config.aws.elasticsearch.list.index,
+      type: config.aws.elasticsearch.list.type,
       body: {
         query: {
           match_all: {},
@@ -38,7 +38,9 @@ describe('itemUpdate', () => {
       },
     });
     // Wait for delete to finish
-    await esClient.indices.refresh({ index: config.aws.elasticsearch.index });
+    await esClient.indices.refresh({
+      index: config.aws.elasticsearch.list.index,
+    });
 
     ({ app, server } = await startServer(0));
   });
@@ -71,7 +73,9 @@ describe('itemUpdate', () => {
     }
 
     // Wait for background indexing to finish
-    await esClient.indices.refresh({ index: config.aws.elasticsearch.index });
+    await esClient.indices.refresh({
+      index: config.aws.elasticsearch.list.index,
+    });
 
     //Ensure each document we just passed along was indexed for user 1
     for (let i = 1; i <= 5; i++) {
@@ -118,7 +122,9 @@ describe('itemUpdate', () => {
     }
 
     // Wait for background indexing to finish
-    await esClient.indices.refresh({ index: config.aws.elasticsearch.index });
+    await esClient.indices.refresh({
+      index: config.aws.elasticsearch.list.index,
+    });
 
     //Ensure each document we just passed along was indexed for user 1
     for (let i = 1; i <= 5; i++) {


### PR DESCRIPTION
Set up local infrastructure and environment variables for corpus search indices. These indices are language-specific. 

**Note that this doesn't actually create the indices on the prod/dev clusters**, but it does locally. I'm not sure how we want to capture this. In the `bin` folder? It's kind of like a schema migration.

Related changes:
* reduce the shards in the local list index

Related PR:
* enrich event bridge events with additional data: https://github.com/Pocket/content-monorepo/pull/165

[POCKET-10121]

[POCKET-10121]: https://mozilla-hub.atlassian.net/browse/POCKET-10121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ