### PR TITLE
fix(search:corpus): add status to corpus indices

### DIFF
--- a/.docker/aws-resources/elasticsearch/esindex_corpus_de.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_de.json
@@ -14,6 +14,9 @@
         "type": "text",
         "analyzer": "german"
       },
+      "status": {
+        "type": "keyword"
+      },
       "url": {
         "type": "text"
       },

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_en.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_en.json
@@ -14,6 +14,9 @@
         "type": "text",
         "analyzer": "english"
       },
+      "status": {
+        "type": "keyword"
+      },
       "url": {
         "type": "text"
       },

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_es.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_es.json
@@ -14,6 +14,9 @@
         "type": "text",
         "analyzer": "spanish"
       },
+      "status": {
+        "type": "keyword"
+      },
       "url": {
         "type": "text"
       },

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_fr.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_fr.json
@@ -14,6 +14,9 @@
         "type": "text",
         "analyzer": "french"
       },
+      "status": {
+        "type": "keyword"
+      },
       "url": {
         "type": "text"
       },

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_it.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_it.json
@@ -14,6 +14,9 @@
         "type": "text",
         "analyzer": "italian"
       },
+      "status": {
+        "type": "keyword"
+      },
       "url": {
         "type": "text"
       },

--- a/lambdas/user-list-search-corpus-indexing/src/createDoc.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/createDoc.ts
@@ -20,6 +20,7 @@ export function createDoc(payload: EventPayload): CorpusItemIndex[] {
       curation_category: collection.curationCategory?.name,
       iab_child: collection.IABChildCategory?.name,
       iab_parent: collection.IABParentCategory?.name,
+      status: collection.status,
     };
     const parent: CorpusItemIndex = {
       meta: { _id: collection.externalId, _index },


### PR DESCRIPTION
The service now emits events for draft collections, so we want to ensure we can differentiate between
published and draft collections when we return results.

Future enhancements might delete or discard this data, but since it's possible to transition from Published to Draft and there just isn't much data, it's not
expensive to just keep it around for now as we decide on exactly how we want to model.


Note that this field being passed was already covered in tests, it just wasn't included on the elasticsearch request. So it is covered in integration tests without any changes.

I have already updated dev and prod indices to accept this field.