### PR TITLE
fix(annotations-api): making no handler implemented a log instead of an error

### DIFF
--- a/lambdas/annotations-api-events/src/index.spec.ts
+++ b/lambdas/annotations-api-events/src/index.spec.ts
@@ -34,24 +34,6 @@ describe('event handlers', () => {
       expect(deleteStub).toHaveBeenCalledTimes(1);
       expect(deleteStub.mock.calls[0]).toEqual([records.Records[0]]);
     });
-    it('returns batchItemFailure and logs to Sentry if handler does not exist', async () => {
-      const records = {
-        Records: [
-          {
-            body: JSON.stringify({
-              Message: JSON.stringify({ 'detail-type': 'NOT_A_TYPE' }),
-            }),
-            messageId: 'abc',
-          },
-        ],
-      };
-      const res = await processor(records as SQSEvent);
-      expect(res.batchItemFailures).toEqual([{ itemIdentifier: 'abc' }]);
-      expect(sentryStub).toHaveBeenCalledTimes(1);
-      expect(sentryStub.mock.calls[0][0].message).toEqual(
-        `Unable to retrieve handler for detail-type='NOT_A_TYPE'`,
-      );
-    });
   });
   describe('with handler errors', () => {
     beforeEach(() => {

--- a/lambdas/annotations-api-events/src/index.ts
+++ b/lambdas/annotations-api-events/src/index.ts
@@ -27,9 +27,8 @@ export async function processor(event: SQSEvent): Promise<SQSBatchResponse> {
     try {
       const message = JSON.parse(JSON.parse(record.body).Message);
       if (handlers[message['detail-type']] == null) {
-        throw new Error(
-          `Unable to retrieve handler for detail-type='${message['detail-type']}'`,
-        );
+        console.info(`No handler for detail-type='${message['detail-type']}'`);
+        return;
       }
       await handlers[message['detail-type']](record);
     } catch (error) {


### PR DESCRIPTION
## Goal

Fix a sentry bug that started popping up now that sentry is on the lambdas.

We should never throw on event handlers missing, unless the infrastructure will only ever send the appropriate handled events.

POCKET-10181