### PR TITLE
feat(search:corpus): support source and grade fields

### DIFF
--- a/.docker/aws-resources/elasticsearch/esindex_corpus_de.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_de.json
@@ -67,6 +67,14 @@
       "parent_collection_id": {
         "type": "keyword",
         "index": false
+      },
+      "curation_source": {
+        "type": "keyword",
+        "index": true
+      },
+      "quality_rank": {
+        "type": "byte",
+        "index": true
       }
     }
   }

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_en.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_en.json
@@ -67,6 +67,14 @@
       "parent_collection_id": {
         "type": "keyword",
         "index": false
+      },
+      "curation_source": {
+        "type": "keyword",
+        "index": true
+      },
+      "quality_rank": {
+        "type": "byte",
+        "index": true
       }
     }
   }

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_es.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_es.json
@@ -67,6 +67,14 @@
       "parent_collection_id": {
         "type": "keyword",
         "index": false
+      },
+      "curation_source": {
+        "type": "keyword",
+        "index": true
+      },
+      "quality_rank": {
+        "type": "byte",
+        "index": true
       }
     }
   }

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_fr.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_fr.json
@@ -67,6 +67,14 @@
       "parent_collection_id": {
         "type": "keyword",
         "index": false
+      },
+      "curation_source": {
+        "type": "keyword",
+        "index": true
+      },
+      "quality_rank": {
+        "type": "byte",
+        "index": true
       }
     }
   }

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_it.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_it.json
@@ -67,6 +67,14 @@
       "parent_id": {
         "type": "keyword",
         "index": false
+      },
+      "curation_source": {
+        "type": "keyword",
+        "index": true
+      },
+      "quality_rank": {
+        "type": "byte",
+        "index": true
       }
     }
   }

--- a/lambdas/user-list-search-corpus-indexing/src/config.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/config.ts
@@ -13,4 +13,10 @@ export const config = {
     fr: 'corpus_fr',
     de: 'corpus_de',
   },
+  // Mapping of letter grade to numeric
+  gradeRankMap: {
+    a: 1,
+    b: 2,
+    c: 3,
+  },
 };

--- a/lambdas/user-list-search-corpus-indexing/src/createDoc.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/createDoc.ts
@@ -79,6 +79,10 @@ export function createDoc(payload: EventPayload): CorpusItemIndex[] {
             ? Math.round(new Date(event.datePublished).getTime() / 1000)
             : undefined,
           is_collection_story: false,
+          curation_source: event.source,
+          quality_rank: event.grade
+            ? config.gradeRankMap[event.grade?.toLowerCase()]
+            : undefined,
         },
       },
     ];

--- a/lambdas/user-list-search-corpus-indexing/src/createDoc.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/createDoc.ts
@@ -81,7 +81,7 @@ export function createDoc(payload: EventPayload): CorpusItemIndex[] {
           is_collection_story: false,
           curation_source: event.source,
           quality_rank: event.grade
-            ? config.gradeRankMap[event.grade?.toLowerCase()]
+            ? config.gradeRankMap[event.grade.toLowerCase()]
             : undefined,
         },
       },

--- a/lambdas/user-list-search-corpus-indexing/src/types.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/types.ts
@@ -60,6 +60,8 @@ export type ApprovedItemPayload = {
   isCollection?: boolean;
   domainName?: string;
   isTimeSensitive?: boolean;
+  source?: string | null;
+  grade?: string | null;
 };
 
 // servers/shared-snowplow-consumer/src/eventConsumer/collectionEvents/types.ts


### PR DESCRIPTION
New fields included on events, which indicate
the source of the curation (e.g. ML prospect
or manual curation add), and the grade of
the content (A/B/C) as a numeric ranking.

Relates to https://github.com/Pocket/content-monorepo/pull/178

TODO:

- [x] Update search index mappings (dev)
- [x] Update search index mappings (prod)
- [x] ~Confirm grade is sent for approved items (not just scheduled), and remove if not the case~ Grade can be sent for approved items but isn't currently. just leave it for the future