### PR TITLE
chore(list): int->bigint temp table migration

### DIFF
--- a/.docker/mysql-8-resources/schema/01a-mono-db-readitla_ril-tmp-schema.sql
+++ b/.docker/mysql-8-resources/schema/01a-mono-db-readitla_ril-tmp-schema.sql
@@ -2705,7 +2705,7 @@ create index user_id
 create table `readitla_ril-tmp`.item_tags
 (
     user_id        int unsigned                           not null,
-    item_id        int unsigned                           not null,
+    item_id        bigint unsigned                        not null,
     tag            varchar(25) charset utf8mb4 default '' not null,
     entered_by     varchar(42) charset latin1             not null,
     status         tinyint unsigned            default 1  not null,
@@ -2807,8 +2807,8 @@ create index share_id
 create table list
 (
     user_id        int unsigned               not null,
-    item_id        int unsigned               not null,
-    resolved_id    int unsigned               not null,
+    item_id        bigint unsigned            not null,
+    resolved_id    bigint unsigned            not null,
     given_url      text                       not null,
     title          varchar(75)                not null,
     time_added     datetime                   not null,
@@ -2871,7 +2871,7 @@ create index userItemPending
 create table list_meta
 (
     user_id    int unsigned                        not null,
-    item_id    int unsigned                        not null,
+    item_id    bigint unsigned                     not null,
     meta_id    smallint unsigned                   not null,
     value      text collate utf8_unicode_ci        not null,
     api_id     mediumint unsigned                  not null,
@@ -5178,7 +5178,7 @@ create table user_annotations
     annotation_id varchar(50)                                not null
         primary key,
     user_id       int unsigned                               not null,
-    item_id       int unsigned                               not null,
+    item_id       bigint unsigned                            not null,
     quote         mediumtext                                 null,
     patch         mediumtext                                 null,
     version       int(10)          default 1                 not null,

--- a/servers/list-api/src/dataService/listPaginationService.ts
+++ b/servers/list-api/src/dataService/listPaginationService.ts
@@ -138,8 +138,8 @@ export class ListPaginationService {
         `CREATE TEMPORARY TABLE \`${ListPaginationService.LIST_TEMP_TABLE}\` ` +
           '(' +
           '`seq` int NOT NULL AUTO_INCREMENT PRIMARY KEY, ' +
-          '`item_id` int(10) unsigned NOT NULL, ' +
-          '`resolved_id` int(10) unsigned NOT NULL, ' +
+          '`item_id` bigint unsigned NOT NULL, ' +
+          '`resolved_id` bigint unsigned NOT NULL, ' +
           /*
            * Setting VARCHAR length for given_url to 5,000. This is a hack to get it
            * reasonably high to prevent url from getting truncated since the
@@ -169,7 +169,7 @@ export class ListPaginationService {
       .raw(
         `CREATE TEMPORARY TABLE \`${ListPaginationService.HIGHLIGHTS_TEMP_TABLE}\` ` +
           '(' +
-          '`item_id` int(10) unsigned NOT NULL PRIMARY KEY' +
+          '`item_id` bigint unsigned NOT NULL PRIMARY KEY' +
           ') ENGINE = MEMORY',
       )
       .connection(connection);
@@ -185,7 +185,7 @@ export class ListPaginationService {
       .raw(
         `CREATE TEMPORARY TABLE \`${ListPaginationService.TAGS_TEMP_TABLE}\` ` +
           '(' +
-          '`item_id` int(10) unsigned NOT NULL PRIMARY KEY' +
+          '`item_id` bigint unsigned NOT NULL PRIMARY KEY' +
           ') ENGINE = MEMORY',
       )
       .connection(connection);


### PR DESCRIPTION
Update schema of local tables related to list
to use bigint, and the temp table used to paginate.

[POCKET-9326]

[POCKET-9326]: https://mozilla-hub.atlassian.net/browse/POCKET-9326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ