### PR TITLE
fix(v3proxy): fix typo in default error and add test coverage

### DIFF
--- a/servers/v3-proxy-api/src/routes/ActionsRouter.ts
+++ b/servers/v3-proxy-api/src/routes/ActionsRouter.ts
@@ -130,8 +130,7 @@ export class ActionsRouter {
       } catch (err) {
         const defaultMessage = 'Something Went Wrong';
         if (err instanceof ClientError) {
-          const defaultError = customErrorHeaders('INTENAL_SERVER_ERROR');
-
+          const defaultError = customErrorHeaders('INTERNAL_SERVER_ERROR');
           // Log bad inputs because that indicates a bug in the proxy code
           // Anything else should be captured by the router/subgraphs
           if (err.response.status === 400) {


### PR DESCRIPTION
Fixes a typo which was causing the default error data to be undefined.

Added test coverage for accessing the default error data.

[POCKET-10240]

[POCKET-10240]: https://mozilla-hub.atlassian.net/browse/POCKET-10240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ