### PR TITLE
fix(v3proxy): convert epoch timestamps in request to seconds

### DIFF
--- a/servers/v3-proxy-api/src/routes/v3Get.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Get.integration.ts
@@ -1007,6 +1007,22 @@ describe('v3Get', () => {
       expect(apiSpy.mock.lastCall[3].filter.updatedSince).toEqual(123123);
       expect(response.headers['x-source']).toBe(expectedHeaders['X-Source']);
     });
+    it.each([1719263946000, 1719263946, '1719263946000', '1719263946'])(
+      'should convert since milliseconds to seconds, but leave seconds alone',
+      async (time) => {
+        const apiSpy = jest
+          .spyOn(GraphQLCalls, 'callSavedItemsByOffsetComplete')
+          .mockImplementation(() => Promise.resolve(mockGraphGetComplete));
+        const response = await request(app).get('/v3/get').query({
+          consumer_key: 'test',
+          access_token: 'test',
+          since: time,
+          detailType: 'complete',
+        });
+        expect(apiSpy.mock.lastCall[3].filter.updatedSince).toEqual(1719263946);
+        expect(response.headers['x-source']).toBe(expectedHeaders['X-Source']);
+      },
+    );
     it.each([
       { consumer_key: 'test', access_token: 'test', detailType: 'complete' },
       {

--- a/servers/v3-proxy-api/src/routes/validations/FetchSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/FetchSchema.ts
@@ -1,4 +1,5 @@
 import { Schema } from 'express-validator';
+import { timeSeconds } from './shared';
 
 /**
  * Note: this type is manually documented, since the
@@ -89,7 +90,10 @@ export const V3FetchSchema: Schema = {
       },
     },
     customSanitizer: {
-      options: (value) => (typeof value === 'string' ? parseInt(value) : value),
+      options: (value) =>
+        typeof value === 'string'
+          ? timeSeconds(parseInt(value))
+          : timeSeconds(value),
     },
   },
   shares: {
@@ -144,6 +148,9 @@ export const V3FetchSchema: Schema = {
       },
     },
     toInt: true,
+    customSanitizer: {
+      options: (value) => timeSeconds(value),
+    },
   },
   hasAnnotations: {
     optional: true,

--- a/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
@@ -1,5 +1,5 @@
 import { Schema } from 'express-validator';
-
+import { timeSeconds } from './shared';
 /**
  * Note: this type is manually documented, since the
  * Schema validator doesn't infer types.
@@ -114,6 +114,9 @@ export const V3GetSchema: Schema = {
       },
     },
     toInt: true,
+    customSanitizer: {
+      options: (value) => timeSeconds(value),
+    },
   },
   updatedBefore: {
     optional: true,

--- a/servers/v3-proxy-api/src/routes/validations/shared.spec.ts
+++ b/servers/v3-proxy-api/src/routes/validations/shared.spec.ts
@@ -1,0 +1,12 @@
+import { timeSeconds } from './shared';
+
+describe('shared validators/sanitizers', () => {
+  describe('timeSeconds', () => {
+    it('converts milliseconds to seconds', () => {
+      expect(timeSeconds(1719263946000)).toEqual(1719263946);
+    });
+    it('leaves seconds alone', () => {
+      expect(timeSeconds(171926394)).toEqual(171926394);
+    });
+  });
+});

--- a/servers/v3-proxy-api/src/routes/validations/shared.ts
+++ b/servers/v3-proxy-api/src/routes/validations/shared.ts
@@ -1,0 +1,13 @@
+/**
+ * Infer whether a given timestamp is in milliseconds or
+ * seconds, and convert it to seconds if milliseconds.
+ * @param time an epoch timestamp (seconds/milliseconds)
+ */
+export function timeSeconds(time: number) {
+  // Assume time is milliseconds if it's 13 digits or more
+  // This will work until time in seconds has 13 digits (33658-09-37T01:46:40 UTC)
+  // Which... I think is ok.
+  // Our timestamps can't be older than 2001 so there's no issue
+  // with supporting 12-digit milliseconds (999999999999 = 2001-09-09T01:46:39 UTC)
+  return time.toString().length >= 13 ? Math.round(time / 1000) : time;
+}


### PR DESCRIPTION
Infers seconds vs. milliseconds with constraints (do not need
to support timestamps prior to 2001 or thousands of years from
now)

[POCKET-10239]

[POCKET-10239]: https://mozilla-hub.atlassian.net/browse/POCKET-10239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ