### PR TITLE
fix(sentry): ensuring integrations are added to sentry

### DIFF
--- a/packages/sentry/src/initSentry.ts
+++ b/packages/sentry/src/initSentry.ts
@@ -3,8 +3,10 @@ import * as Sentry from '@sentry/node';
 
 export const initSentry = (options?: NodeOptions) => {
   Sentry.init({
-    ...options,
     includeLocalVariables: true,
     maxValueLength: 2000,
+    // https://github.com/getsentry/sentry-javascript/blob/develop/packages/node/src/sdk/index.ts#L82-L84
+    tracesSampleRate: 0,
+    ...options,
   });
 };


### PR DESCRIPTION
## Goal

It seems that a sentry update disabled the integrations we want by default if you don't pass in a trace sample rate option, even if its 0.

https://github.com/getsentry/sentry-javascript/blob/develop/packages/node/src/sdk/index.ts#L82-L84

