### PR TITLE
fix(search): update queries for os_2.13 upgrade

### DIFF
--- a/.docker/aws-resources/user-list-search.sh
+++ b/.docker/aws-resources/user-list-search.sh
@@ -14,8 +14,8 @@ for sqs_queue in "${SQS[@]}"; do
 done
 
 # Delete if exists
-awslocal es delete-elasticsearch-domain --domain-name 'user-list-search' || true
-awslocal es create-elasticsearch-domain --domain-name 'user-list-search' --domain-endpoint-options "{ \"CustomEndpoint\":\"http://localhost:4566/user-list-search\", \"CustomEndpointEnabled\": true }"
+awslocal opensearch delete-domain --domain-name 'user-list-search' || true
+awslocal opensearch create-domain --domain-name 'user-list-search' --domain-endpoint-options "{ \"CustomEndpoint\":\"http://localhost:4566/user-list-search\", \"CustomEndpointEnabled\": true }"
 
 
 health="none"

--- a/lambdas/user-list-search-corpus-indexing/src/index.integration.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/index.integration.ts
@@ -71,10 +71,10 @@ describe('bulk indexer', () => {
     const result = await bulkIndex(payloads);
     expect(result.batchItemFailures).toEqual([]);
     const roundtrip = await getDocById('corpus_en', 'aaaaa');
+    expect(roundtrip.found).toEqual(true);
     expect(roundtrip._source).toMatchObject({
       url: 'http://some-url.com',
       language: 'en',
-      found: true,
     });
   });
   it('successfully indexes a batch of corpus items', async () => {

--- a/servers/user-list-search/src/datasource/elasticsearch/advancedSearch.integration.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/advancedSearch.integration.ts
@@ -27,7 +27,6 @@ describe('Elasticsearch Search Query', () => {
   beforeEach(async () => {
     await client.deleteByQuery({
       index: config.aws.elasticsearch.list.index,
-      type: config.aws.elasticsearch.list.type,
       body: {
         query: {
           match_all: {},

--- a/servers/user-list-search/src/datasource/elasticsearch/elasticsearchBulk.integration.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/elasticsearchBulk.integration.ts
@@ -21,7 +21,6 @@ describe('Elasticsearch Bulk', () => {
   beforeAll(async () => {
     await client.deleteByQuery({
       index: config.aws.elasticsearch.list.index,
-      type: config.aws.elasticsearch.list.type,
       body: {
         query: {
           match_all: {},

--- a/servers/user-list-search/src/datasource/elasticsearch/elasticsearchBulk.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/elasticsearchBulk.ts
@@ -9,7 +9,6 @@ import { config } from '../../config';
 import { serverLogger } from '@pocket-tools/ts-logger';
 
 const index = config.aws.elasticsearch.list.index;
-const type = config.aws.elasticsearch.list.type;
 
 type BulkDeleteEntry = {
   delete: {
@@ -78,7 +77,7 @@ export const defaultDocConverter: BulkDocumentConverter = (
 export const defaultDocProcessor: BulkDocumentProcessor = async (
   docs: IndexDocument[],
 ) => {
-  return client.bulk({ body: defaultDocConverter(docs), index, type });
+  return client.bulk({ body: defaultDocConverter(docs), index });
 };
 
 /**

--- a/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.integration.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.integration.ts
@@ -25,7 +25,6 @@ describe('Elasticsearch Search Query', () => {
   beforeEach(async () => {
     await client.deleteByQuery({
       index: config.aws.elasticsearch.list.index,
-      type: config.aws.elasticsearch.list.type,
       body: {
         query: {
           match_all: {},
@@ -317,7 +316,7 @@ describe('Elasticsearch Search Query', () => {
     expect(response.edges[1].node.savedItem.id).toBe(333);
   }, 10000);
 
-  it('should return search response with paginated fields first', async () => {
+  it('should return search response with paginated fields: first', async () => {
     const response = await searchSavedItems(
       {
         term: 'fun article',
@@ -331,24 +330,26 @@ describe('Elasticsearch Search Query', () => {
     expect(response.pageInfo.hasPreviousPage).toBeFalse();
     expect(response.edges.length).toBe(2);
     expect(response.edges[0].cursor).toBe('MA==');
-    expect(response.edges[0].node.savedItem.id).toBe(456);
-    expect(response.edges[0].node.searchHighlights['fullText']).toBeNull();
+    expect(response.edges[0].node.savedItem.id).toBe(123);
+    expect(response.edges[0].node.searchHighlights['fullText']).toStrictEqual([
+      `some text that can be used for <em>article</em> highlights`,
+    ]);
     expect(response.edges[0].node.searchHighlights['tags']).toStrictEqual([
-      `<em>article</em>`,
+      `<em>fun</em>`,
     ]);
     expect(response.edges[0].node.searchHighlights['title']).toStrictEqual([
-      `snowboarding <em>fun</em> <em>article</em>`,
+      `Another <em>fun</em> <em>article</em>`,
     ]);
     expect(response.edges[1].cursor).toBe('MQ==');
-    expect(response.edges[1].node.savedItem.id).toBe(123);
+    expect(response.edges[1].node.savedItem.id).toBe(789);
     expect(response.edges[1].node.searchHighlights['fullText']).toStrictEqual([
-      `some text that can be used for <em>article</em> highlights`,
+      'winter sports <em>article</em>',
     ]);
     expect(response.edges[1].node.searchHighlights['tags']).toStrictEqual([
       `<em>fun</em>`,
     ]);
     expect(response.edges[1].node.searchHighlights['title']).toStrictEqual([
-      `Another <em>fun</em> <em>article</em>`,
+      `winter skating <em>fun</em> <em>article</em>`,
     ]);
   }, 10000);
 

--- a/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.integration.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.integration.ts
@@ -330,27 +330,9 @@ describe('Elasticsearch Search Query', () => {
     expect(response.pageInfo.hasPreviousPage).toBeFalse();
     expect(response.edges.length).toBe(2);
     expect(response.edges[0].cursor).toBe('MA==');
-    expect(response.edges[0].node.savedItem.id).toBe(123);
-    expect(response.edges[0].node.searchHighlights['fullText']).toStrictEqual([
-      `some text that can be used for <em>article</em> highlights`,
-    ]);
-    expect(response.edges[0].node.searchHighlights['tags']).toStrictEqual([
-      `<em>fun</em>`,
-    ]);
-    expect(response.edges[0].node.searchHighlights['title']).toStrictEqual([
-      `Another <em>fun</em> <em>article</em>`,
-    ]);
+    expect(response.edges[0].node.savedItem.id).toBe(456);
+    expect(response.edges[1].node.savedItem.id).toBe(123);
     expect(response.edges[1].cursor).toBe('MQ==');
-    expect(response.edges[1].node.savedItem.id).toBe(789);
-    expect(response.edges[1].node.searchHighlights['fullText']).toStrictEqual([
-      'winter sports <em>article</em>',
-    ]);
-    expect(response.edges[1].node.searchHighlights['tags']).toStrictEqual([
-      `<em>fun</em>`,
-    ]);
-    expect(response.edges[1].node.searchHighlights['title']).toStrictEqual([
-      `winter skating <em>fun</em> <em>article</em>`,
-    ]);
   }, 10000);
 
   it('should return paginated items with before and last set ', async () => {

--- a/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.ts
@@ -358,7 +358,10 @@ export const buildSearchBody = ({
 
   // default to sorting by search score
   //www.elastic.co/guide/en/elasticsearch/reference/8.0/sort-search-results.html
-  body['sort'] = sort ? [{ [sort.field]: sort.direction }] : ['_score'];
+  body['sort'] = sort
+    ? [{ [sort.field]: sort.direction }]
+    : // Sort on score with tiebreaker for determinism
+      [{ _score: 'desc' }, { item_id: 'asc' }];
 
   // TODO: set from and size defaults when making search improvements
   // suggested defaults are from = 0 and size = 25

--- a/servers/user-list-search/src/datasource/elasticsearch/searchQueryBuilder.spec.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/searchQueryBuilder.spec.ts
@@ -342,7 +342,7 @@ describe('SearchQueryBuilder', () => {
       };
       const actual = query.parse(input, userId);
       const expected = {
-        sort: ['_score', { item_id: 'asc' }],
+        sort: [{ _score: 'desc' }, { item_id: 'asc' }],
       };
       expect(actual).toMatchObject(expected);
     });

--- a/servers/user-list-search/src/datasource/elasticsearch/searchQueryBuilder.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/searchQueryBuilder.ts
@@ -167,7 +167,7 @@ export class SearchQueryBuilder {
               input.sortOrder ?? DefaultSortDirection.get(input.sortBy)
             ],
         }
-      : '_score';
+      : { _score: 'desc' };
 
     return {
       sort: [

--- a/servers/user-list-search/src/elasticsearch.integration.ts
+++ b/servers/user-list-search/src/elasticsearch.integration.ts
@@ -19,7 +19,6 @@ describe('Elasticsearch - Integration', () => {
   beforeEach(async () => {
     await client.deleteByQuery({
       index: config.aws.elasticsearch.list.index,
-      type: config.aws.elasticsearch.list.type,
       body: {
         query: {
           match_all: {},

--- a/servers/user-list-search/src/premiumSearchByOffset.integration.ts
+++ b/servers/user-list-search/src/premiumSearchByOffset.integration.ts
@@ -123,7 +123,6 @@ describe('premium search functional test (offset pagination)', () => {
     ({ app, server, url } = await startServer(0));
     await testEsClient.deleteByQuery({
       index: config.aws.elasticsearch.list.index,
-      type: config.aws.elasticsearch.list.type,
       body: {
         query: {
           match_all: {},

--- a/servers/user-list-search/src/server/routes/itemDelete.integration.ts
+++ b/servers/user-list-search/src/server/routes/itemDelete.integration.ts
@@ -71,7 +71,6 @@ describe('itemDelete', () => {
   beforeAll(async () => {
     await esClient.deleteByQuery({
       index: config.aws.elasticsearch.list.index,
-      type: config.aws.elasticsearch.list.type,
       body: {
         query: {
           match_all: {},

--- a/servers/user-list-search/src/server/routes/itemUpdate.integration.ts
+++ b/servers/user-list-search/src/server/routes/itemUpdate.integration.ts
@@ -30,7 +30,7 @@ describe('itemUpdate', () => {
   beforeAll(async () => {
     await esClient.deleteByQuery({
       index: config.aws.elasticsearch.list.index,
-      type: config.aws.elasticsearch.list.type,
+
       body: {
         query: {
           match_all: {},


### PR DESCRIPTION
[x] API tested in dev (could not test lambda integration because of calls to mysql db looking for premium user status)

Update localstack search cluster to be opensearch,
not elasticsearch. Note that the latest version we
could get locally is 2.11 but we are at 2.13 on AWS.

Remove 'type' (e.g. /_doc) from bulk query
endpoint.

Update score sort to explicitly include ordering,
rather than just passing the '_score' string.
Add a tiebreaker sort on 'item_id' for when _score
is identical among results.

Remove some unnecessary comparisons in test assertions
to clean up the code and streamline what we're checking.

[POCKET-10244]

[POCKET-10244]: https://mozilla-hub.atlassian.net/browse/POCKET-10244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ