### PR TITLE
chore(search/article): add secret ID to access article view

### DIFF
--- a/infrastructure/user-list-search/ecs.tf
+++ b/infrastructure/user-list-search/ecs.tf
@@ -25,6 +25,10 @@ locals {
     {
       name      = "UNLEASH_KEY"
       valueFrom = "${local.secret_path}UNLEASH_KEY"
+    },
+    {
+      name      = "PARSER_PRIVILEGED_SERVICE_ID"
+      valueFrom = "${local.ssm_path}PARSER_PRIVILEGED_SERVICE_ID"
     }
   ]
 }

--- a/infrastructure/user-list-search/main.tf
+++ b/infrastructure/user-list-search/main.tf
@@ -18,6 +18,10 @@ data "aws_ssm_parameter" "sentry_dsn" {
   name = "/${local.name}/${local.env}/SENTRY_DSN"
 }
 
+data "aws_ssm_parameter" "parser_privileged_service_id" {
+  name = "/${local.name}/${local.env}/PARSER_PRIVILEGED_SERVICE_ID"
+}
+
 data "aws_ssm_parameter" "parser_endpoint" {
   name = "/${local.name}/${local.env}/PARSER_ENDPOINT"
 }

--- a/servers/user-list-search/src/config/index.ts
+++ b/servers/user-list-search/src/config/index.ts
@@ -25,6 +25,10 @@ export const config = {
       process.env.CONTENT_AURORA_DB ||
       '{"password":"","dbname":"content","engine":"mysql","port":"3306","host":"localhost","username":"pkt_listserch_r"}',
   },
+  parser: {
+    privilegedServiceId:
+      process.env.PARSER_PRIVILEGED_SERVICE_ID || 'my-needs-matter',
+  },
   aws: {
     region: process.env.AWS_REGION || 'us-east-1',
     elasticsearch: {


### PR DESCRIPTION
Articles may be hidden from end-user clients due
to publisher request to default to original view.

We do not currently use the Parser service, but
once we do this will enable us to claim as a
privileged service to pull article content for
full text search indexing.

[POCKET-10247]

[POCKET-10247]: https://mozilla-hub.atlassian.net/browse/POCKET-10247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ