### PR TITLE
fix(v3proxy): accept numeric item_ids

### DIFF
--- a/servers/v3-proxy-api/src/routes/validations/SendActionValidators.ts
+++ b/servers/v3-proxy-api/src/routes/validations/SendActionValidators.ts
@@ -179,7 +179,7 @@ function HasItemIdOrUrl<TBase extends ActionSanitizable>(Base: TBase) {
         // parseInt has some unexpected behavior for strings that
         // contain numerals + numbers, e.g. parseInt('123abc') returns 123.
         // In this case, these numeric strings only contain numerals
-        const hasNonNumeral = this.input.item_id.match(/\D/)?.length;
+        const hasNonNumeral = this.input.item_id.toString().match(/\D/)?.length;
         const itemId = parseInt(this.input.item_id);
         if (hasNonNumeral || isNaN(itemId) || itemId < 0) {
           const error: ArrayFieldError = {

--- a/servers/v3-proxy-api/src/routes/validations/sendActionValidators.spec.ts
+++ b/servers/v3-proxy-api/src/routes/validations/sendActionValidators.spec.ts
@@ -20,6 +20,11 @@ describe('send validator', () => {
         input: { item_id: '12345', action: 'favorite' as const },
         expected: { itemId: 12345, action: 'favorite', time: now },
       },
+      // integer item_id
+      {
+        input: { item_id: 12345, action: 'favorite' as const },
+        expected: { itemId: 12345, action: 'favorite', time: now },
+      },
       {
         input: { item_id: '12345', action: 'unfavorite' as const },
         expected: { itemId: 12345, action: 'unfavorite', time: now },


### PR DESCRIPTION
Previously it was assumed only strings were
sent, but we can see that numeric IDs are sent
occasionally (which was causing an error when
calling string methods).

[POCKET-10281]

[POCKET-10281]: https://mozilla-hub.atlassian.net/browse/POCKET-10281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ