### PR TITLE
fix(corpus:search): fix typo in event name

### DIFF
--- a/lambdas/user-list-search-corpus-indexing/src/index.integration.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/index.integration.ts
@@ -46,8 +46,10 @@ describe('bulk indexer', () => {
       getDocById('corpus_en', 'fe67c4a0-ed4d-4489-a79a-9380dd8a2576'), // root-level collection
       getDocById('corpus_en', '78d3d5f3-4bad-4214-bb27-5c2ea908422c'), // the only collection story in first collection
       getDocById('corpus_en', '676defd9-a947-4955-8433-c395750d8551'), // the third collection story in second collection (spot-check)
+      getDocById('corpus_en', '3ab75776-42a1-4a54-a6d2-032fbec195eb'), // The approved item update
     ]);
     expect(roundtrip).toEqual([
+      expect.objectContaining({ found: true }),
       expect.objectContaining({ found: true }),
       expect.objectContaining({ found: true }),
       expect.objectContaining({ found: true }),
@@ -291,6 +293,25 @@ const exampleInvocationPayload = {
       messageId: 'a89c0ea2-7231-4347-889b-8d456812d4a0',
       receiptHandle:
         'AQEBH8A43AOSt9LC6PWYqTnu+3pVGx43nmsuVI0oALNieVa5SJ8CKu9dhQZKEpjQ4CxjWy19ic9r0AbpIGuj5JtB3nx5sf8jceCaF3Tjx3Cat22shHHsG251TTP8bSNx37Z2tHLBoWDiRYYgMoLBf7KlGi3DG4NOPN1pM/4fFiIpS+M1Jmnytz83IUd8+fgwEGZGAJ4pHQEjWHIA9sFinhaKoxow2tjWjp6bx6MxO/ZL6HMjUp/uHm6G0wrUMcpONwaP4mo6ZgNKnzkvzr+dyqmdUOwiv1grWWKBL9jtSua02ze/FoibmyMnYFZZJxNNyqrj25NdP0OPPcakwkcznjjd/08Tc4AbvsGHaQZ5foFPUUfITqW9K0fpS6KijEcXd5boXKq1GKWaxJ20j2Of+SmbMtB1+U6eBh8t8nfyz1YS8k4=',
+    },
+    {
+      messageId: '9f9792df-ab70-4884-8b72-cee0b8340afa',
+      receiptHandle:
+        'AQEBN1gA3AxoGK5y86v2mQGNkUJaBIl6K7KtdyEOnBmKgktdTL0fLppwhXWkgq/jrb5nr/uxvMCCFioPbfv5OaBgcSo/yRgj1PLet17pTKmEkczuIqF4MNH/SsiwmgyuG6lKMla53r8qzOoxmckb/Zie3gQ414Bok0AJc4+ts8MvKvwFmCUZgu9aeIzVzDuL1nOpJMda+Q0RxTEltZCmEJKr8cO8oZsy3po5wg9rFk6ITi0k19B76qlq3UTqXj6jB6BokL8z7Qq0JASfXGAxDGFRHg5riK1U5SG+pgfoFGJMfl/bwq+ZR9PrMTAE3+zmMcIZNVxAWeIljrAbgoUw7P5klYQScEsx9hjLn1TnYmHgYxEKQRSCoQv+K1OtaOBIG1xHQkSSakQ0HjkI/5nsrakIfZMsM0GuYrPKFF8QWCCSiyg=',
+      body: '{\n  "Type" : "Notification",\n  "MessageId" : "fe2cd9e6-4978-5680-84e0-8712b3052acf",\n  "TopicArn" : "arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-CorpusEventsTopic",\n  "Message" : "{\\"version\\":\\"0\\",\\"id\\":\\"ad060d80-ac54-cc42-5902-b3e4aef2a6dd\\",\\"detail-type\\":\\"update-approved-item\\",\\"source\\":\\"curation-migration-datasync\\",\\"account\\":\\"996905175585\\",\\"time\\":\\"2024-06-25T17:02:53Z\\",\\"region\\":\\"us-east-1\\",\\"resources\\":[],\\"detail\\":{\\"eventType\\":\\"update-approved-item\\",\\"approvedItemExternalId\\":\\"3ab75776-42a1-4a54-a6d2-032fbec195eb\\",\\"url\\":\\"https://snackstack.net/2024/05/25/uh-oh-a-story-of-spaghettios-and-forgotten-history/\\",\\"title\\":\\"Uh-Oh: A Story of SpaghettiOs and Forgotten History\\",\\"excerpt\\":\\"In which a pasta-filled rabbit hole leads to an unexpected place.\\",\\"language\\":\\"EN\\",\\"publisher\\":\\"Snack Stack\\",\\"imageUrl\\":\\"https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/b853f9bf-ea90-4280-b738-4feef27a4630.jpeg\\",\\"topic\\":\\"FOOD\\",\\"isSyndicated\\":false,\\"createdAt\\":\\"Tue, 25 Jun 2024 16:01:19 GMT\\",\\"createdBy\\":\\"ad|Mozilla-LDAP|mjeltsen\\",\\"updatedAt\\":\\"Tue, 25 Jun 2024 17:02:52 GMT\\",\\"authors\\":[{\\"externalId\\":\\"492ca986-b2b9-492c-a63d-0b0a713a5885\\",\\"name\\":\\"Doug Mack\\",\\"approvedItemId\\":175874,\\"sortOrder\\":0}],\\"isCollection\\":false,\\"domainName\\":\\"snackstack.net\\",\\"datePublished\\":\\"Sat, 25 May 2024 00:00:00 GMT\\",\\"isTimeSensitive\\":false,\\"source\\":\\"MANUAL\\"}}",\n  "Timestamp" : "2024-06-25T17:02:53.154Z",\n  "SignatureVersion" : "1",\n  "Signature" : "BTyAyJAO53xzanvuF5MAopx839LZJgVtUBym1fBn6nCjs7IhonSheqt1T3Afq4TWB3y8VV5hBcaTFqQqSlLCWjPzM8xbfBYL1gP6Ddasxnv2VR77qdhY8c8HmsYEuXO4WvJxqe8YOWVQHVgpegjuyTScaaCWxVztoDYC7O55KUG7hc/oJJw+RoxYNshtyTfEYVHQuV23zbWaNvp4GsbjEjOGcBb7BLTA10H2HPW9SxrU4IhMitgvuJm83Q57z0/6glheWL/aqYyjokaEgyAMTmypJNRflxv6OlVg1TTdcz31gozbIyg8P+q+LgNmUrxq+7NdgB0bp+fA9OFUSkPktQ==",\n  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-60eadc530605d63b8e62a523676ef735.pem",\n  "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-CorpusEventsTopic:95ac785f-1b3b-48e1-bf91-4f8583bd6ebd"\n}',
+      attributes: {
+        ApproximateReceiveCount: '1',
+        SentTimestamp: '1719600803083',
+        SenderId: 'AROAV7CHE6FNH4IKR3U2R:kschelonka@mozilla.com',
+        ApproximateFirstReceiveTimestamp: '1719600803092',
+      },
+      messageAttributes: {},
+      md5OfMessageAttributes: null,
+      md5OfBody: '09fb67b7b9f0899db20fbec34d77092e',
+      eventSource: 'aws:sqs',
+      eventSourceARN:
+        'arn:aws:sqs:us-east-1:410318598490:UserListSearch-Dev-CorpusEvents',
+      awsRegion: 'us-east-1',
     },
   ],
 };

--- a/lambdas/user-list-search-corpus-indexing/src/types.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/types.ts
@@ -32,7 +32,7 @@ export type CorpusItemIndex = {
 // and infrastructure/pocket-event-bridge/src/event-rules/collection-events/eventConfig.ts
 export const validDetailTypes = [
   'add-approved-item',
-  'updated-approved-item',
+  'update-approved-item',
   'collection-created',
   'collection-updated',
 ];

--- a/lambdas/user-list-search-corpus-parser-hydration/src/index.integration.ts
+++ b/lambdas/user-list-search-corpus-parser-hydration/src/index.integration.ts
@@ -80,6 +80,7 @@ describe('bulk indexer', () => {
     const seed = [
       { id: '78d3d5f3-4bad-4214-bb27-5c2ea908422c', index: 'corpus_en' },
       { id: '676defd9-a947-4955-8433-c395750d8551', index: 'corpus_en' },
+      { id: '3ab75776-42a1-4a54-a6d2-032fbec195eb', index: 'corpus_en' },
     ];
     await seedDocuments(seed);
     // Setup (scope makes it easier to do inside function)
@@ -89,6 +90,7 @@ describe('bulk indexer', () => {
       'https://www.espn.com/espn/feature/story/_/id/30423107/ncaa-women-bracketology-2023-women-college-basketball-projections',
       'https://www.cntraveler.com/story/can-americans-travel-to-cuba',
       'https://www.barcablaugranes.com/2023/3/8/23629747/barcelona-trio-are-playing-for-their-camp-nou-futures-now',
+      'https://snackstack.net/2024/05/25/uh-oh-a-story-of-spaghettios-and-forgotten-history/',
     ];
     const nockEndpoint = (url: string) => {
       const params = new URLSearchParams({
@@ -112,8 +114,13 @@ describe('bulk indexer', () => {
     const roundtrip = await Promise.all([
       getDocById('corpus_en', '78d3d5f3-4bad-4214-bb27-5c2ea908422c'), // the only collection story in first collection
       getDocById('corpus_en', '676defd9-a947-4955-8433-c395750d8551'), // the third collection story in second collection (spot-check)
+      getDocById('corpus_en', '3ab75776-42a1-4a54-a6d2-032fbec195eb'), // the approved item
     ]);
     expect(roundtrip).toEqual([
+      expect.objectContaining({
+        found: true,
+        _source: expect.objectContaining({ pocket_item_id: '12345' }),
+      }),
       expect.objectContaining({
         found: true,
         _source: expect.objectContaining({ pocket_item_id: '12345' }),
@@ -239,6 +246,25 @@ const exampleInvocationPayload = {
       messageId: 'a89c0ea2-7231-4347-889b-8d456812d4a0',
       receiptHandle:
         'AQEBH8A43AOSt9LC6PWYqTnu+3pVGx43nmsuVI0oALNieVa5SJ8CKu9dhQZKEpjQ4CxjWy19ic9r0AbpIGuj5JtB3nx5sf8jceCaF3Tjx3Cat22shHHsG251TTP8bSNx37Z2tHLBoWDiRYYgMoLBf7KlGi3DG4NOPN1pM/4fFiIpS+M1Jmnytz83IUd8+fgwEGZGAJ4pHQEjWHIA9sFinhaKoxow2tjWjp6bx6MxO/ZL6HMjUp/uHm6G0wrUMcpONwaP4mo6ZgNKnzkvzr+dyqmdUOwiv1grWWKBL9jtSua02ze/FoibmyMnYFZZJxNNyqrj25NdP0OPPcakwkcznjjd/08Tc4AbvsGHaQZ5foFPUUfITqW9K0fpS6KijEcXd5boXKq1GKWaxJ20j2Of+SmbMtB1+U6eBh8t8nfyz1YS8k4=',
+    },
+    {
+      messageId: '9f9792df-ab70-4884-8b72-cee0b8340afa',
+      receiptHandle:
+        'AQEBN1gA3AxoGK5y86v2mQGNkUJaBIl6K7KtdyEOnBmKgktdTL0fLppwhXWkgq/jrb5nr/uxvMCCFioPbfv5OaBgcSo/yRgj1PLet17pTKmEkczuIqF4MNH/SsiwmgyuG6lKMla53r8qzOoxmckb/Zie3gQ414Bok0AJc4+ts8MvKvwFmCUZgu9aeIzVzDuL1nOpJMda+Q0RxTEltZCmEJKr8cO8oZsy3po5wg9rFk6ITi0k19B76qlq3UTqXj6jB6BokL8z7Qq0JASfXGAxDGFRHg5riK1U5SG+pgfoFGJMfl/bwq+ZR9PrMTAE3+zmMcIZNVxAWeIljrAbgoUw7P5klYQScEsx9hjLn1TnYmHgYxEKQRSCoQv+K1OtaOBIG1xHQkSSakQ0HjkI/5nsrakIfZMsM0GuYrPKFF8QWCCSiyg=',
+      body: '{\n  "Type" : "Notification",\n  "MessageId" : "fe2cd9e6-4978-5680-84e0-8712b3052acf",\n  "TopicArn" : "arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-CorpusEventsTopic",\n  "Message" : "{\\"version\\":\\"0\\",\\"id\\":\\"ad060d80-ac54-cc42-5902-b3e4aef2a6dd\\",\\"detail-type\\":\\"update-approved-item\\",\\"source\\":\\"curation-migration-datasync\\",\\"account\\":\\"996905175585\\",\\"time\\":\\"2024-06-25T17:02:53Z\\",\\"region\\":\\"us-east-1\\",\\"resources\\":[],\\"detail\\":{\\"eventType\\":\\"update-approved-item\\",\\"approvedItemExternalId\\":\\"3ab75776-42a1-4a54-a6d2-032fbec195eb\\",\\"url\\":\\"https://snackstack.net/2024/05/25/uh-oh-a-story-of-spaghettios-and-forgotten-history/\\",\\"title\\":\\"Uh-Oh: A Story of SpaghettiOs and Forgotten History\\",\\"excerpt\\":\\"In which a pasta-filled rabbit hole leads to an unexpected place.\\",\\"language\\":\\"EN\\",\\"publisher\\":\\"Snack Stack\\",\\"imageUrl\\":\\"https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/b853f9bf-ea90-4280-b738-4feef27a4630.jpeg\\",\\"topic\\":\\"FOOD\\",\\"isSyndicated\\":false,\\"createdAt\\":\\"Tue, 25 Jun 2024 16:01:19 GMT\\",\\"createdBy\\":\\"ad|Mozilla-LDAP|mjeltsen\\",\\"updatedAt\\":\\"Tue, 25 Jun 2024 17:02:52 GMT\\",\\"authors\\":[{\\"externalId\\":\\"492ca986-b2b9-492c-a63d-0b0a713a5885\\",\\"name\\":\\"Doug Mack\\",\\"approvedItemId\\":175874,\\"sortOrder\\":0}],\\"isCollection\\":false,\\"domainName\\":\\"snackstack.net\\",\\"datePublished\\":\\"Sat, 25 May 2024 00:00:00 GMT\\",\\"isTimeSensitive\\":false,\\"source\\":\\"MANUAL\\"}}",\n  "Timestamp" : "2024-06-25T17:02:53.154Z",\n  "SignatureVersion" : "1",\n  "Signature" : "BTyAyJAO53xzanvuF5MAopx839LZJgVtUBym1fBn6nCjs7IhonSheqt1T3Afq4TWB3y8VV5hBcaTFqQqSlLCWjPzM8xbfBYL1gP6Ddasxnv2VR77qdhY8c8HmsYEuXO4WvJxqe8YOWVQHVgpegjuyTScaaCWxVztoDYC7O55KUG7hc/oJJw+RoxYNshtyTfEYVHQuV23zbWaNvp4GsbjEjOGcBb7BLTA10H2HPW9SxrU4IhMitgvuJm83Q57z0/6glheWL/aqYyjokaEgyAMTmypJNRflxv6OlVg1TTdcz31gozbIyg8P+q+LgNmUrxq+7NdgB0bp+fA9OFUSkPktQ==",\n  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-60eadc530605d63b8e62a523676ef735.pem",\n  "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-CorpusEventsTopic:95ac785f-1b3b-48e1-bf91-4f8583bd6ebd"\n}',
+      attributes: {
+        ApproximateReceiveCount: '1',
+        SentTimestamp: '1719600803083',
+        SenderId: 'AROAV7CHE6FNH4IKR3U2R:kschelonka@mozilla.com',
+        ApproximateFirstReceiveTimestamp: '1719600803092',
+      },
+      messageAttributes: {},
+      md5OfMessageAttributes: null,
+      md5OfBody: '09fb67b7b9f0899db20fbec34d77092e',
+      eventSource: 'aws:sqs',
+      eventSourceARN:
+        'arn:aws:sqs:us-east-1:410318598490:UserListSearch-Dev-CorpusEvents',
+      awsRegion: 'us-east-1',
     },
   ],
 };

--- a/lambdas/user-list-search-corpus-parser-hydration/src/types.ts
+++ b/lambdas/user-list-search-corpus-parser-hydration/src/types.ts
@@ -59,7 +59,7 @@ export type ParserResult = {
 // and infrastructure/pocket-event-bridge/src/event-rules/collection-events/eventConfig.ts
 export const validDetailTypes = [
   'add-approved-item',
-  'updated-approved-item',
+  'update-approved-item',
   'collection-created',
   'collection-updated',
 ];


### PR DESCRIPTION
Was causing events to be filtered out that
should not have been, resulting in empty body
in requests to elasticsearch.

[POCKET-10281]

[POCKET-10281]: https://mozilla-hub.atlassian.net/browse/POCKET-10281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ