### PR TITLE
chore(search): add max concurrency limits on lambdas

### DIFF
--- a/infrastructure/user-list-search/backfill_item_update_consumer.tf
+++ b/infrastructure/user-list-search/backfill_item_update_consumer.tf
@@ -64,6 +64,9 @@ resource "aws_lambda_event_source_mapping" "item_update_backfill_sqs" {
   event_source_arn = aws_sqs_queue.user_items_update_backfill.arn
   function_name    = aws_lambda_alias.item_update_backfill_sqs_processor.arn #We set the function to our alias
   enabled          = true
+  scaling_config {
+    maximum_concurrency = 20
+  }
 }
 
 resource "aws_iam_role" "item_update_backfill_lambda_role" {

--- a/infrastructure/user-list-search/backfill_user_list_import_consumer.tf
+++ b/infrastructure/user-list-search/backfill_user_list_import_consumer.tf
@@ -64,6 +64,9 @@ resource "aws_lambda_event_source_mapping" "user_list_import_backfill_sqs" {
   event_source_arn = aws_sqs_queue.user_list_import_backfill.arn
   function_name    = aws_lambda_alias.user_list_import_backfill_sqs_processor.arn #We set the function to our alias
   enabled          = true
+  scaling_config {
+    maximum_concurrency = 10
+  }
 }
 
 resource "aws_iam_role" "user_list_import_backfill_lambda_role" {

--- a/infrastructure/user-list-search/corpus_events_consumer.tf
+++ b/infrastructure/user-list-search/corpus_events_consumer.tf
@@ -63,6 +63,9 @@ resource "aws_lambda_event_source_mapping" "corpus_events_sqs" {
   maximum_batching_window_in_seconds = 300
   function_name                      = aws_lambda_alias.corpus_events_sqs_processor.arn #We set the function to our alias
   enabled                            = true
+  scaling_config {
+    maximum_concurrency = 5
+  }
 }
 
 resource "aws_iam_role" "corpus_events_lambda_role" {

--- a/infrastructure/user-list-search/corpus_events_hydration_consumer.tf
+++ b/infrastructure/user-list-search/corpus_events_hydration_consumer.tf
@@ -63,6 +63,9 @@ resource "aws_lambda_event_source_mapping" "corpus_events_hydration_sqs" {
   maximum_batching_window_in_seconds = 300
   function_name                      = aws_lambda_alias.corpus_events_hydration_sqs_processor.arn #We set the function to our alias
   enabled                            = true
+  scaling_config {
+    maximum_concurrency = 5
+  }
 }
 
 resource "aws_iam_role" "corpus_events_hydration_lambda_role" {

--- a/infrastructure/user-list-search/event_handler_consumer.tf
+++ b/infrastructure/user-list-search/event_handler_consumer.tf
@@ -63,6 +63,9 @@ resource "aws_lambda_event_source_mapping" "user_list_events_sqs" {
   batch_size       = 1
   function_name    = aws_lambda_alias.user_list_events_sqs_processor.arn #We set the function to our alias
   enabled          = true
+  scaling_config {
+    maximum_concurrency = 20
+  }
 }
 
 resource "aws_iam_role" "user_list_events_lambda_role" {

--- a/infrastructure/user-list-search/item_delete_consumer.tf
+++ b/infrastructure/user-list-search/item_delete_consumer.tf
@@ -64,6 +64,9 @@ resource "aws_lambda_event_source_mapping" "item_delete_sqs" {
   event_source_arn = aws_sqs_queue.user_items_delete.arn
   function_name    = aws_lambda_alias.item_delete_sqs_processor.arn #We set the function to our alias
   enabled          = true
+  scaling_config {
+    maximum_concurrency = 20
+  }
 }
 
 resource "aws_iam_role" "item_delete_lambda_role" {

--- a/infrastructure/user-list-search/item_update_consumer.tf
+++ b/infrastructure/user-list-search/item_update_consumer.tf
@@ -62,6 +62,9 @@ resource "aws_lambda_event_source_mapping" "item_update_sqs" {
   event_source_arn = aws_sqs_queue.user_items_update.arn
   function_name    = aws_lambda_alias.item_update_sqs_processor.arn #We set the function to our alias
   enabled          = true
+  scaling_config {
+    maximum_concurrency = 20
+  }
 }
 
 resource "aws_iam_role" "item_update_lambda_role" {

--- a/infrastructure/user-list-search/locals.tf
+++ b/infrastructure/user-list-search/locals.tf
@@ -40,8 +40,8 @@ locals {
     SQS_USER_ITEMS_UPDATE_URL = aws_sqs_queue.user_items_update.id
     SQS_USER_ITEMS_DELETE_URL = aws_sqs_queue.user_items_delete.id
     # The endpoint doesn't include protocol
-    ELASTICSEARCH_HOST        = "https://${local.elastic.endpoint}"
-    PARSER_ENDPOINT           = data.aws_ssm_parameter.parser_endpoint.value
+    ELASTICSEARCH_HOST = "https://${local.elastic.endpoint}"
+    PARSER_ENDPOINT    = data.aws_ssm_parameter.parser_endpoint.value
   }
   sqsEndpoint = "https://sqs.us-east-1.amazonaws.com"
   snsTopicName = {

--- a/infrastructure/user-list-search/user_list_import_consumer.tf
+++ b/infrastructure/user-list-search/user_list_import_consumer.tf
@@ -62,6 +62,9 @@ resource "aws_lambda_event_source_mapping" "user_list_import_sqs" {
   event_source_arn = aws_sqs_queue.user_list_import.arn
   function_name    = aws_lambda_alias.user_list_import_sqs_processor.arn #We set the function to our alias
   enabled          = true
+  scaling_config {
+    maximum_concurrency = 10
+  }
 }
 
 resource "aws_iam_role" "user_list_import_lambda_role" {


### PR DESCRIPTION
We don't want runaway lambdas, especially if
they're all making requests to one service.

[POCKET-10252]

[POCKET-10252]: https://mozilla-hub.atlassian.net/browse/POCKET-10252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ