### PR TITLE
feat(corpus:content): enable privileged content extraction for hydrator

### DIFF
--- a/infrastructure/user-list-search/locals.tf
+++ b/infrastructure/user-list-search/locals.tf
@@ -40,8 +40,9 @@ locals {
     SQS_USER_ITEMS_UPDATE_URL = aws_sqs_queue.user_items_update.id
     SQS_USER_ITEMS_DELETE_URL = aws_sqs_queue.user_items_delete.id
     # The endpoint doesn't include protocol
-    ELASTICSEARCH_HOST = "https://${local.elastic.endpoint}"
-    PARSER_ENDPOINT    = data.aws_ssm_parameter.parser_endpoint.value
+    ELASTICSEARCH_HOST           = "https://${local.elastic.endpoint}"
+    PARSER_ENDPOINT              = data.aws_ssm_parameter.parser_endpoint.value
+    PARSER_PRIVILEGED_SERVICE_ID = data.aws_ssm_parameter.parser_privileged_service_id.value
   }
   sqsEndpoint = "https://sqs.us-east-1.amazonaws.com"
   snsTopicName = {

--- a/lambdas/user-list-search-corpus-parser-hydration/src/config.ts
+++ b/lambdas/user-list-search-corpus-parser-hydration/src/config.ts
@@ -11,6 +11,7 @@ export const config = {
   esEndpoint:
     process.env.ELASTICSEARCH_HOST || 'http://localhost:4566/user-list-search',
   parserEndpoint: process.env.PARSER_ENDPOINT || 'https://parser.com/text',
+  privilegedServiceId: process.env.PARSER_PRIVILEGED_SERVICE_ID || 'abc-123',
   indexLangMap: {
     en: 'corpus_en',
     it: 'corpus_it',

--- a/lambdas/user-list-search-corpus-parser-hydration/src/parserRequest.ts
+++ b/lambdas/user-list-search-corpus-parser-hydration/src/parserRequest.ts
@@ -23,6 +23,7 @@ export async function parserRequest(
     createIfNone: '1',
     enableItemUrlFallback: '1',
     output: 'regular',
+    serviceId: config.privilegedServiceId,
   };
   const queryParams = new URLSearchParams({
     ...options,


### PR DESCRIPTION
This is not served to the end-user and purely aids in
discovery of content (which would have the positive
end-result of driving more traffic to the publisher).

[POCKET-10285]

[POCKET-10285]: https://mozilla-hub.atlassian.net/browse/POCKET-10285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ