### PR TITLE
fix(corpus:index): fix collection urls and standardize casing

### DIFF
--- a/lambdas/user-list-search-corpus-indexing/src/createDoc.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/createDoc.ts
@@ -1,5 +1,6 @@
 import { EventPayload, CorpusItemIndex } from './types';
 import { config } from './config';
+import { buildCollectionUrl } from './utils';
 
 /**
  * Build elasticsearch documents from the event payload.
@@ -20,13 +21,13 @@ export function createDoc(payload: EventPayload): CorpusItemIndex[] {
       curation_category: collection.curationCategory?.name,
       iab_child: collection.IABChildCategory?.name,
       iab_parent: collection.IABParentCategory?.name,
-      status: collection.status,
+      status: collection.status.toLowerCase(),
     };
     const parent: CorpusItemIndex = {
       meta: { _id: collection.externalId, _index },
       fields: {
         title: collection.title,
-        url: collection.slug,
+        url: buildCollectionUrl(collection.slug, collection.language),
         excerpt: collection.excerpt,
         is_syndicated: false,
         publisher: 'Pocket',

--- a/lambdas/user-list-search-corpus-indexing/src/utils.spec.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/utils.spec.ts
@@ -1,0 +1,35 @@
+import { buildCollectionUrl } from './utils';
+
+describe('buildCollectionUrl', () => {
+  it.each([
+    {
+      slug: 'pocket-pride-reads',
+      lang: 'EN',
+      expected: 'https://getpocket.com/collections/pocket-pride-reads',
+    },
+    {
+      slug: 'pocket-pride-geschichten',
+      lang: 'DE',
+      expected: 'https://getpocket.com/de/collections/pocket-pride-geschichten',
+    },
+  ])(
+    'works for english and non-english collections',
+    ({ slug, lang, expected }) => {
+      expect(buildCollectionUrl(slug, lang)).toEqual(expected);
+    },
+  );
+  it.each([
+    {
+      slug: 'https://getpocket.com/de/collections/pocket-pride-geschichten',
+      lang: 'DE',
+      expected: 'https://getpocket.com/de/collections/pocket-pride-geschichten',
+    },
+    {
+      slug: 'https://getpocket.com/collections/pocket-pride-reads',
+      lang: 'EN',
+      expected: 'https://getpocket.com/collections/pocket-pride-reads',
+    },
+  ])('works for full urls', ({ slug, lang, expected }) => {
+    expect(buildCollectionUrl(slug, lang)).toEqual(expected);
+  });
+});

--- a/lambdas/user-list-search-corpus-indexing/src/utils.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/utils.ts
@@ -1,0 +1,25 @@
+/**
+ * This method is copied in user-list-search-corpus-parser-hydration
+ * (sharing lambda code is really annoying and not worth it for just this)
+ * Create a URL from the collection slug and language.
+ * Sometimes URLs are already passed to the event in the
+ * slug field, or at least were historically; just allow
+ * these to go through without parsing.
+ * @param slug the collection's slug (possibly a full URL)
+ * @param langCode the language of the collection (case-insensitive)
+ * @returns the URL where the collection is hosted on pocket.com,
+ * if it exists
+ */
+export function buildCollectionUrl(slug: string, langCode: string): string {
+  // english-language does not have 'en'
+  const lang = langCode.toLowerCase();
+  const collectionLang = lang === 'en' ? '' : lang;
+  try {
+    new URL(slug);
+  } catch {
+    return ['https://getpocket.com', collectionLang, 'collections', slug]
+      .filter((_) => _.length)
+      .join('/');
+  }
+  return slug;
+}

--- a/lambdas/user-list-search-corpus-parser-hydration/src/index.integration.ts
+++ b/lambdas/user-list-search-corpus-parser-hydration/src/index.integration.ts
@@ -103,6 +103,7 @@ describe('bulk indexer', () => {
         createIfNone: '1',
         enableItemUrlFallback: '1',
         output: 'regular',
+        serviceId: config.privilegedServiceId,
         url,
       });
       const result = BaseParserResult(url);
@@ -192,6 +193,7 @@ describe('bulk indexer', () => {
         createIfNone: '1',
         enableItemUrlFallback: '1',
         output: 'regular',
+        serviceId: config.privilegedServiceId,
         url,
       });
       const result = BaseParserResult(url);

--- a/lambdas/user-list-search-corpus-parser-hydration/src/index.integration.ts
+++ b/lambdas/user-list-search-corpus-parser-hydration/src/index.integration.ts
@@ -81,6 +81,7 @@ describe('bulk indexer', () => {
       { id: '78d3d5f3-4bad-4214-bb27-5c2ea908422c', index: 'corpus_en' },
       { id: '676defd9-a947-4955-8433-c395750d8551', index: 'corpus_en' },
       { id: '3ab75776-42a1-4a54-a6d2-032fbec195eb', index: 'corpus_en' },
+      { id: '599b49e5-c91f-47d8-a6d3-1ce2cb520acc', index: 'corpus_en' },
     ];
     await seedDocuments(seed);
     // Setup (scope makes it easier to do inside function)
@@ -91,6 +92,8 @@ describe('bulk indexer', () => {
       'https://www.cntraveler.com/story/can-americans-travel-to-cuba',
       'https://www.barcablaugranes.com/2023/3/8/23629747/barcelona-trio-are-playing-for-their-camp-nou-futures-now',
       'https://snackstack.net/2024/05/25/uh-oh-a-story-of-spaghettios-and-forgotten-history/',
+      'https://getpocket.com/collections/herrajs-collection-test-labels',
+      'https://getpocket.com/collections/testing-snowplow-events-for-collection-creation',
     ];
     const nockEndpoint = (url: string) => {
       const params = new URLSearchParams({
@@ -141,6 +144,9 @@ describe('bulk indexer', () => {
   it('filters out failed parser responses and consolidates message ids', async () => {
     const seed = [
       { id: '78d3d5f3-4bad-4214-bb27-5c2ea908422c', index: 'corpus_en' },
+      { id: '3ab75776-42a1-4a54-a6d2-032fbec195eb', index: 'corpus_en' },
+      { id: '310b6ea8-9206-3e85-2b18-f3c936737182', index: 'corpus_en' },
+      { id: '599b49e5-c91f-47d8-a6d3-1ce2cb520acc', index: 'corpus_en' },
     ];
     await seedDocuments(seed);
     // Setup (scope makes it easier to do inside function)
@@ -164,6 +170,18 @@ describe('bulk indexer', () => {
       {
         url: 'https://www.barcablaugranes.com/2023/3/8/23629747/barcelona-trio-are-playing-for-their-camp-nou-futures-now',
         status: 500,
+      },
+      {
+        url: 'https://getpocket.com/collections/herrajs-collection-test-labels',
+        status: 200,
+      },
+      {
+        url: 'https://getpocket.com/collections/testing-snowplow-events-for-collection-creation',
+        status: 200,
+      },
+      {
+        url: 'https://snackstack.net/2024/05/25/uh-oh-a-story-of-spaghettios-and-forgotten-history/',
+        status: 200,
       },
     ];
     const nockEndpoint = (url: string, status: number) => {

--- a/lambdas/user-list-search-corpus-parser-hydration/src/utils.spec.ts
+++ b/lambdas/user-list-search-corpus-parser-hydration/src/utils.spec.ts
@@ -1,0 +1,35 @@
+import { buildCollectionUrl } from './utils';
+
+describe('buildCollectionUrl', () => {
+  it.each([
+    {
+      slug: 'pocket-pride-reads',
+      lang: 'EN',
+      expected: 'https://getpocket.com/collections/pocket-pride-reads',
+    },
+    {
+      slug: 'pocket-pride-geschichten',
+      lang: 'DE',
+      expected: 'https://getpocket.com/de/collections/pocket-pride-geschichten',
+    },
+  ])(
+    'works for english and non-english collections',
+    ({ slug, lang, expected }) => {
+      expect(buildCollectionUrl(slug, lang)).toEqual(expected);
+    },
+  );
+  it.each([
+    {
+      slug: 'https://getpocket.com/de/collections/pocket-pride-geschichten',
+      lang: 'DE',
+      expected: 'https://getpocket.com/de/collections/pocket-pride-geschichten',
+    },
+    {
+      slug: 'https://getpocket.com/collections/pocket-pride-reads',
+      lang: 'EN',
+      expected: 'https://getpocket.com/collections/pocket-pride-reads',
+    },
+  ])('works for full urls', ({ slug, lang, expected }) => {
+    expect(buildCollectionUrl(slug, lang)).toEqual(expected);
+  });
+});

--- a/lambdas/user-list-search-corpus-parser-hydration/src/utils.ts
+++ b/lambdas/user-list-search-corpus-parser-hydration/src/utils.ts
@@ -1,0 +1,25 @@
+/**
+ * This method is copied in user-list-search-corpus-indexing
+ * (sharing lambda code is really annoying and not worth it for just this)
+ * Create a URL from the collection slug and language.
+ * Sometimes URLs are already passed to the event in the
+ * slug field, or at least were historically; just allow
+ * these to go through without parsing.
+ * @param slug the collection's slug (possibly a full URL)
+ * @param langCode the language of the collection (case-insensitive)
+ * @returns the URL where the collection is hosted on pocket.com,
+ * if it exists
+ */
+export function buildCollectionUrl(slug: string, langCode: string): string {
+  // english-language does not have 'en'
+  const lang = langCode.toLowerCase();
+  const collectionLang = lang === 'en' ? '' : lang;
+  try {
+    new URL(slug);
+  } catch {
+    return ['https://getpocket.com', collectionLang, 'collections', slug]
+      .filter((_) => _.length)
+      .join('/');
+  }
+  return slug;
+}


### PR DESCRIPTION
Makes requests to the parser for collections to generate
the records and identifiers used to federate them as Pocket Items.

Add some additional seeding to the test to reflect this.

Standardize casing for status (historically it's uppercase but
is now lowercase -- when we reprocess the dataset, standardize
on lowercase).

Create urls for collections rather than just putting the slugs
there; sometimes the slugs in historical data are full URLs, and
sometimes they are just slugs. Parse conditionally so when we
reprocess data they are all standardized.

[POCKET-10301]

[POCKET-10301]: https://mozilla-hub.atlassian.net/browse/POCKET-10301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ