### PR TITLE
chore(corpus:search): denormalize ID for sorting

### DIFF
--- a/.docker/aws-resources/elasticsearch/esindex_corpus_de.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_de.json
@@ -10,6 +10,10 @@
       "enabled": true
     },
     "properties": {
+      "corpusId": {
+        "type": "keyword",
+        "index": false
+      },
       "title": {
         "type": "text",
         "analyzer": "german"

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_en.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_en.json
@@ -10,6 +10,10 @@
       "enabled": true
     },
     "properties": {
+      "corpusId": {
+        "type": "keyword",
+        "index": false
+      },
       "title": {
         "type": "text",
         "analyzer": "english"

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_es.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_es.json
@@ -10,6 +10,10 @@
       "enabled": true
     },
     "properties": {
+      "corpusId": {
+        "type": "keyword",
+        "index": false
+      },
       "title": {
         "type": "text",
         "analyzer": "spanish"

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_fr.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_fr.json
@@ -10,6 +10,10 @@
       "enabled": true
     },
     "properties": {
+      "corpusId": {
+        "type": "keyword",
+        "index": false
+      },
       "title": {
         "type": "text",
         "analyzer": "french"

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_it.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_it.json
@@ -10,6 +10,10 @@
       "enabled": true
     },
     "properties": {
+      "corpusId": {
+        "type": "keyword",
+        "index": false
+      },
       "title": {
         "type": "text",
         "analyzer": "italian"

--- a/lambdas/user-list-search-corpus-indexing/src/createDoc.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/createDoc.ts
@@ -26,6 +26,7 @@ export function createDoc(payload: EventPayload): CorpusItemIndex[] {
     const parent: CorpusItemIndex = {
       meta: { _id: collection.externalId, _index },
       fields: {
+        corpusId: collection.externalId,
         title: collection.title,
         url: buildCollectionUrl(collection.slug, collection.language),
         excerpt: collection.excerpt,
@@ -44,6 +45,7 @@ export function createDoc(payload: EventPayload): CorpusItemIndex[] {
         _index,
       },
       fields: {
+        corpusId: story.collection_story_id,
         parent_collection_id: collection.externalId,
         url: story.url,
         title: story.title,
@@ -65,6 +67,7 @@ export function createDoc(payload: EventPayload): CorpusItemIndex[] {
           _index: config.indexLangMap[event.language.toLowerCase()],
         },
         fields: {
+          corpusId: event.approvedItemExternalId,
           title: event.title,
           url: event.url,
           excerpt: event.excerpt,

--- a/lambdas/user-list-search-corpus-indexing/src/index.integration.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/index.integration.ts
@@ -77,6 +77,7 @@ describe('bulk indexer', () => {
     expect(roundtrip._source).toMatchObject({
       url: 'http://some-url.com',
       language: 'en',
+      corpusId: 'aaaaa',
     });
   });
   it('successfully indexes a batch of corpus items', async () => {

--- a/lambdas/user-list-search-corpus-indexing/src/types.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/types.ts
@@ -8,6 +8,7 @@ export type EventPayload = {
 export type CorpusItemIndex = {
   meta: { _id: string; _index: string };
   fields: Partial<{
+    corpusId: string;
     title: string;
     url: string;
     excerpt: string;


### PR DESCRIPTION
Want to use the ApprovedItem ID for deterministic
sort response. To do it efficiently we should not
use the _id field but should denormalize the data
and copy it into a doc_values field.

**TODO**
- [x] Update dev mappings
- [x] Update prod mappings