### PR TITLE
fix(account-data-deleter): removing alarm thats noisy

### DIFF
--- a/infrastructure/account-data-deleter/src/dataDeleterApp.ts
+++ b/infrastructure/account-data-deleter/src/dataDeleterApp.ts
@@ -59,7 +59,7 @@ export class DataDeleterApp extends Construct {
     return new PocketALBApplication(this, 'application', {
       alarms: {
         http5xxErrorPercentage: {
-          actions: config.isProd ? [snsTopic.arn] : [],
+          actions: config.isProd ? [] : [],
           evaluationPeriods: 4,
           period: 300, //5 mins each
           threshold: 25,


### PR DESCRIPTION
## Goal

Remove noisy alarm that consistently does not have enough data.

![Screenshot 2024-07-10 at 4 03 06 PM](https://github.com/Pocket/pocket-monorepo/assets/1010384/57198f00-f581-4380-952a-52c779975735)
