### PR TITLE
fix(v3proxy:get): add contentType=all to get schema

### DIFF
--- a/servers/v3-proxy-api/src/graph/get/toGraphQL.ts
+++ b/servers/v3-proxy-api/src/graph/get/toGraphQL.ts
@@ -111,6 +111,8 @@ export function SavedItemsFilterFactory(params: V3GetParams) {
         video: { contentType: SavedItemsContentType.HasVideoInclusive },
         article: { contentType: SavedItemsContentType.IsReadable },
         image: { contentType: SavedItemsContentType.IsImage },
+        // "all" is implicit -- the absence of a filter value
+        all: undefined,
       };
       return contentMap[val];
     },

--- a/servers/v3-proxy-api/src/routes/v3Get.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Get.integration.ts
@@ -975,6 +975,19 @@ describe('v3Get', () => {
         sort: 'shortest',
         since: '12345',
       },
+      {
+        consumer_key: 'test',
+        access_token: 'test',
+        detailType: 'complete',
+        contentType: 'all',
+        count: '10',
+        offset: '10',
+        state: 'read',
+        favorite: '0',
+        tag: 'tag',
+        sort: 'shortest',
+        since: '12345',
+      },
     ])('should work with valid query parameters (GET)', async (params) => {
       jest
         .spyOn(GraphQLCalls, 'callSavedItemsByOffsetComplete')
@@ -1005,6 +1018,18 @@ describe('v3Get', () => {
         detailType: 'complete',
       });
       expect(apiSpy.mock.lastCall[3].filter.updatedSince).toEqual(123123);
+      expect(response.headers['x-source']).toBe(expectedHeaders['X-Source']);
+    });
+    it('should not add contentType filter if value="all"', async () => {
+      const apiSpy = jest
+        .spyOn(GraphQLCalls, 'callSavedItemsByOffsetComplete')
+        .mockImplementation(() => Promise.resolve(mockGraphGetComplete));
+      const response = await request(app).get('/v3/get').query({
+        consumer_key: 'test',
+        access_token: 'test',
+        detailType: 'complete',
+      });
+      expect(apiSpy.mock.lastCall[3].filter).toBeUndefined();
       expect(response.headers['x-source']).toBe(expectedHeaders['X-Source']);
     });
     it.each([1719263946000, 1719263946, '1719263946000', '1719263946'])(

--- a/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
@@ -7,7 +7,7 @@ import { timeSeconds } from './shared';
 export type V3GetParams = {
   access_token?: string;
   consumer_key: string;
-  contentType?: 'article' | 'image' | 'video';
+  contentType?: 'article' | 'image' | 'video' | 'all';
   count: number;
   detailType: 'simple' | 'complete';
   favorite?: boolean;
@@ -133,7 +133,7 @@ export const V3GetSchema: Schema = {
     optional: true,
     toLowerCase: true,
     isIn: {
-      options: [['article', 'image', 'video']],
+      options: [['article', 'image', 'video', 'all']],
     },
   },
   favorite: {


### PR DESCRIPTION
Enables passing contentType=all to v3/get

[POCKET-10339]

[POCKET-10339]: https://mozilla-hub.atlassian.net/browse/POCKET-10339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ