### PR TITLE
fix(scheme): adding in a url scheme if one does not exist

### DIFF
--- a/servers/list-api/src/resolvers/utils.spec.ts
+++ b/servers/list-api/src/resolvers/utils.spec.ts
@@ -1,9 +1,22 @@
 import { SavedItemTagsInput, Tag } from '../types';
 import {
   atLeastOneOf,
+  ensureHttpPrefix,
   getSavedItemMapFromTags,
   getSavedItemTagsMap,
 } from './utils';
+
+describe('ensureHttpPrefix', () => {
+  it.each([
+    { input: 'getpocket.com', expected: 'http://getpocket.com' },
+    { input: 'http://getpocket.com', expected: 'http://getpocket.com' },
+    { input: 'https://getpocket.com', expected: 'https://getpocket.com' },
+    { input: 'ftp://getpocket.com', expected: 'ftp://getpocket.com' },
+    { input: 'mailto:getpocket.com', expected: 'mailto:getpocket.com' },
+  ])('should always return a prefixed url', ({ input, expected }) => {
+    expect(ensureHttpPrefix(input)).toEqual(expected);
+  });
+});
 
 describe('getSavedItemMapFromTags', () => {
   it('should return a savedItem map from a list of tags', () => {

--- a/servers/list-api/src/resolvers/utils.ts
+++ b/servers/list-api/src/resolvers/utils.ts
@@ -6,6 +6,18 @@ import {
 } from '../types';
 
 /**
+ * Returns a URl that will always have some kind of HTTP prefix if one does not exist.
+ * @param url URL that we want to update to have a prefix
+ */
+export function ensureHttpPrefix(url: string): string {
+  const urlPattern = /^(https?|ftp|mailto|file|data|ws|wss|tel):\/?\/?/i; // Regex to match common URL schemes
+  if (!urlPattern.test(url)) {
+    return 'http://' + url;
+  }
+  return url;
+}
+
+/**
  * Returns a savedItemMap from the list of tags.
  * @param tags list of tags from which savedItem keys are generated.
  */

--- a/servers/list-api/src/test/graphql/mutations/savedItemById/savedItemsMutationService-upsert.integration.ts
+++ b/servers/list-api/src/test/graphql/mutations/savedItemById/savedItemsMutationService-upsert.integration.ts
@@ -208,6 +208,56 @@ describe('UpsertSavedItem Mutation', () => {
       expect(data.favoritedAt).toBeNull();
     });
 
+    it('should add a valid item that does not have a http:// and return savedItem with http:// added', async () => {
+      const variables = {
+        url: 'getpocket.com',
+      };
+
+      const ADD_AN_ITEM = `
+        mutation addAnItem($url: String!) {
+          upsertSavedItem(input: { url: $url }) {
+            id
+            url
+            title
+            _createdAt
+            _updatedAt
+            favoritedAt
+            archivedAt
+            isFavorite
+            isArchived
+            _deletedAt
+            _version
+            item {
+              ... on Item {
+                givenUrl
+              }
+            }
+            tags {
+              name
+            }
+          }
+        }
+      `;
+
+      const mutationResult = await request(app).post(url).set(headers).send({
+        query: ADD_AN_ITEM,
+        variables,
+      });
+      expect(mutationResult).not.toBeNull();
+      const data = mutationResult.body.data?.upsertSavedItem;
+      expect(data.id).toEqual('8');
+      expect(data.title).toEqual(`http://${variables.url}`);
+      expect(data.url).toEqual(`http://${variables.url}`);
+      expect(data.isFavorite).toBeFalse();
+      expect(data.isArchived).toBeFalse();
+      expect(data._deletedAt).toBeNull();
+      expect(data._version).toBeNull();
+      expect(data.item.givenUrl).toEqual(`http://${variables.url}`);
+      expect(data.tags[0].name).toEqual('zebra');
+      expect(data.archivedAt).toBeNull();
+      expect(data.favoritedAt).toBeNull();
+    });
+
     it('should return user provided title on the returned savedItem', async () => {
       const variables = {
         url: 'http://getpocket.com',


### PR DESCRIPTION
## Goal

Urls like google.com are not adding to a users list because they have no url scheme.

This will attempt to add http: as a scheme to urls like this that come through.


[POCKET-10341](https://mozilla-hub.atlassian.net/browse/POCKET-10341)

[POCKET-10341]: https://mozilla-hub.atlassian.net/browse/POCKET-10341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ