### PR TITLE
fix(since): truncate decimal based since values

### DIFF
--- a/servers/v3-proxy-api/src/routes/v3Get.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Get.integration.ts
@@ -1032,7 +1032,14 @@ describe('v3Get', () => {
       expect(apiSpy.mock.lastCall[3].filter).toBeUndefined();
       expect(response.headers['x-source']).toBe(expectedHeaders['X-Source']);
     });
-    it.each([1719263946000, 1719263946, '1719263946000', '1719263946'])(
+    it.each([
+      1719263946000,
+      1719263946,
+      '1719263946000',
+      '1719263946',
+      '1719263946.129312',
+      1719263946.129312,
+    ])(
       'should convert since milliseconds to seconds, but leave seconds alone',
       async (time) => {
         const apiSpy = jest

--- a/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
@@ -108,11 +108,6 @@ export const V3GetSchema: Schema = {
   },
   since: {
     optional: true,
-    isInt: {
-      options: {
-        min: 0,
-      },
-    },
     toInt: true,
     customSanitizer: {
       options: (value) => timeSeconds(value),


### PR DESCRIPTION
## Goal

Fix some old iOS client 400s causing noise by truncated their decimal based since values

https://mozilla-hub.atlassian.net/browse/POCKET-10347?atlOrigin=eyJpIjoiNTRlYzdiNTQzNjk3NDdlMGIwZDA4OGI4NTFmZTM2NDciLCJwIjoiamlyYS1zbGFjay1pbnQifQ