### PR TITLE
fix(scale): bump up the scaling of our main services to increase stability

### DIFF
--- a/infrastructure/list-api/src/main.ts
+++ b/infrastructure/list-api/src/main.ts
@@ -426,8 +426,8 @@ class ListAPI extends TerraformStack {
           'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy',
       },
       autoscalingConfig: {
-        targetMinCapacity: config.environment === 'Prod' ? 2 : 1,
-        targetMaxCapacity: config.environment === 'Prod' ? 10 : 10,
+        targetMinCapacity: config.environment === 'Prod' ? 6 : 1,
+        targetMaxCapacity: config.environment === 'Prod' ? 20 : 10,
       },
       alarms: {
         http5xxErrorPercentage: {

--- a/infrastructure/parser-graphql-wrapper/src/main.ts
+++ b/infrastructure/parser-graphql-wrapper/src/main.ts
@@ -382,8 +382,8 @@ class ParserGraphQLWrapper extends TerraformStack {
       },
 
       autoscalingConfig: {
-        targetMinCapacity: config.environment === 'Prod' ? 4 : 1,
-        targetMaxCapacity: config.environment === 'Prod' ? 10 : 10,
+        targetMinCapacity: config.environment === 'Prod' ? 8 : 1,
+        targetMaxCapacity: config.environment === 'Prod' ? 20 : 10,
       },
       alarms: {
         //Triggers critical alert if 25% of request throws 5xx for

--- a/infrastructure/v3-proxy-api/src/main.ts
+++ b/infrastructure/v3-proxy-api/src/main.ts
@@ -248,8 +248,8 @@ class Stack extends TerraformStack {
           'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy',
       },
       autoscalingConfig: {
-        targetMinCapacity: config.isDev ? 1 : 2,
-        targetMaxCapacity: 10,
+        targetMinCapacity: config.isDev ? 1 : 4,
+        targetMaxCapacity: 20,
       },
       alarms: {
         //TODO: When you start using the service add the pagerduty arns as an action `pagerDuty.snsNonCriticalAlarmTopic.arn`


### PR DESCRIPTION
#Goal

Looking at the AWS graphs we are doing some up and down scaling and getting lots of 502 gateway timeouts. This attempts to rectify this with some more horsepower.

I chose values based on doubling what the services averagely sit at.