### PR TITLE
feat(search:auth): enable logged-out corpus search

### DIFF
--- a/servers/user-list-search/src/corpus/keywordSearch.integration.ts
+++ b/servers/user-list-search/src/corpus/keywordSearch.integration.ts
@@ -20,7 +20,37 @@ describe('Corpus search - keyword', () => {
     await deleteDocuments();
     await server.stop();
   });
-  it.todo('should work for logged-out users using a pocket application');
+  it('should work for logged-out users using a pocket application', async () => {
+    const variables = {
+      search: { query: 'refrigerator' },
+      filter: { language: 'EN' },
+    };
+    const res = await request(app)
+      .post(url)
+      .set({ userid: 'anonymous', applicationisnative: 'true' })
+      .send({
+        query: print(SEARCH_CORPUS),
+        variables,
+      });
+    expect(res.body.errors).toBeUndefined();
+    expect(res.body.data.searchCorpus).toBeTruthy();
+  });
+  it('should not work for logged-out users on a non-native app', async () => {
+    const variables = {
+      search: { query: 'refrigerator' },
+      filter: { language: 'EN' },
+    };
+    const res = await request(app)
+      .post(url)
+      .set({ userid: 'anonymous', applicationisnative: 'false' })
+      .send({
+        query: print(SEARCH_CORPUS),
+        variables,
+      });
+    expect(res.body.errors).toBeArrayOfSize(1);
+    expect(res.body.errors[0].extensions.code).toEqual('FORBIDDEN');
+    expect(res.body.data.searchCorpus).toBeNull();
+  });
   it('should return all expected fields and work with minimum required inputs', async () => {
     const variables = {
       search: { query: 'refrigerator' },

--- a/servers/user-list-search/src/corpus/keywordSearch.integration.ts
+++ b/servers/user-list-search/src/corpus/keywordSearch.integration.ts
@@ -11,6 +11,7 @@ describe('Corpus search - keyword', () => {
   let app: Application;
   let server: ApolloServer<ContextManager>;
   let url: string;
+  const defaultHeaders = { userid: '1', applicationisnative: 'true' };
   beforeAll(async () => {
     await deleteDocuments();
     await seedCorpus();
@@ -58,7 +59,7 @@ describe('Corpus search - keyword', () => {
     };
     const res = await request(app)
       .post(url)
-      .set({ userid: '1' })
+      .set(defaultHeaders)
       .send({
         query: print(SEARCH_CORPUS),
         variables,
@@ -98,7 +99,7 @@ describe('Corpus search - keyword', () => {
       };
       const res = await request(app)
         .post(url)
-        .set({ userid: '1' })
+        .set(defaultHeaders)
         .send({
           query: print(SEARCH_CORPUS),
           variables,
@@ -146,7 +147,7 @@ describe('Corpus search - keyword', () => {
       };
       const res = await request(app)
         .post(url)
-        .set({ userid: '1' })
+        .set(defaultHeaders)
         .send({
           query: print(SEARCH_CORPUS),
           variables,
@@ -167,7 +168,7 @@ describe('Corpus search - keyword', () => {
       };
       const res = await request(app)
         .post(url)
-        .set({ userid: '1' })
+        .set(defaultHeaders)
         .send({
           query: print(SEARCH_CORPUS),
           variables,
@@ -188,7 +189,7 @@ describe('Corpus search - keyword', () => {
       };
       const res = await request(app)
         .post(url)
-        .set({ userid: '1' })
+        .set(defaultHeaders)
         .send({
           query: print(SEARCH_CORPUS),
           variables,
@@ -209,7 +210,7 @@ describe('Corpus search - keyword', () => {
       };
       const res = await request(app)
         .post(url)
-        .set({ userid: '1' })
+        .set(defaultHeaders)
         .send({
           query: print(SEARCH_CORPUS),
           variables,
@@ -233,7 +234,7 @@ describe('Corpus search - keyword', () => {
         };
         const res = await request(app)
           .post(url)
-          .set({ userid: '1' })
+          .set(defaultHeaders)
           .send({
             query: print(SEARCH_CORPUS),
             variables,
@@ -261,7 +262,7 @@ describe('Corpus search - keyword', () => {
         };
         const res = await request(app)
           .post(url)
-          .set({ userid: '1' })
+          .set(defaultHeaders)
           .send({
             query: print(SEARCH_CORPUS),
             variables,
@@ -288,7 +289,7 @@ describe('Corpus search - keyword', () => {
         };
         const res = await request(app)
           .post(url)
-          .set({ userid: '1' })
+          .set(defaultHeaders)
           .send({
             query: print(SEARCH_CORPUS),
             variables,
@@ -317,7 +318,7 @@ describe('Corpus search - keyword', () => {
         };
         const res = await request(app)
           .post(url)
-          .set({ userid: '1' })
+          .set(defaultHeaders)
           .send({
             query: print(SEARCH_CORPUS),
             variables,
@@ -344,7 +345,7 @@ describe('Corpus search - keyword', () => {
         };
         const res = await request(app)
           .post(url)
-          .set({ userid: '1' })
+          .set(defaultHeaders)
           .send({
             query: print(SEARCH_CORPUS),
             variables,
@@ -371,7 +372,7 @@ describe('Corpus search - keyword', () => {
         };
         const res = await request(app)
           .post(url)
-          .set({ userid: '1' })
+          .set(defaultHeaders)
           .send({
             query: print(SEARCH_CORPUS),
             variables,
@@ -393,7 +394,7 @@ describe('Corpus search - keyword', () => {
       };
       const res = await request(app)
         .post(url)
-        .set({ userid: '1' })
+        .set(defaultHeaders)
         .send({
           query: print(SEARCH_CORPUS),
           variables,
@@ -413,7 +414,7 @@ describe('Corpus search - keyword', () => {
       };
       const res = await request(app)
         .post(url)
-        .set({ userid: '1' })
+        .set(defaultHeaders)
         .send({
           query: print(SEARCH_CORPUS),
           variables,
@@ -434,7 +435,7 @@ describe('Corpus search - keyword', () => {
       };
       const res = await request(app)
         .post(url)
-        .set({ userid: '1' })
+        .set(defaultHeaders)
         .send({
           query: print(SEARCH_CORPUS),
           variables,
@@ -454,7 +455,7 @@ describe('Corpus search - keyword', () => {
       };
       const res = await request(app)
         .post(url)
-        .set({ userid: '1' })
+        .set(defaultHeaders)
         .send({
           query: print(SEARCH_CORPUS),
           variables,
@@ -473,7 +474,7 @@ describe('Corpus search - keyword', () => {
       };
       const res = await request(app)
         .post(url)
-        .set({ userid: '1' })
+        .set(defaultHeaders)
         .send({
           query: print(SEARCH_CORPUS),
           variables,
@@ -494,7 +495,7 @@ describe('Corpus search - keyword', () => {
       };
       const res = await request(app)
         .post(url)
-        .set({ userid: '1' })
+        .set(defaultHeaders)
         .send({
           query: print(SEARCH_CORPUS),
           variables,
@@ -521,7 +522,7 @@ describe('Corpus search - keyword', () => {
       };
       const res = await request(app)
         .post(url)
-        .set({ userid: '1' })
+        .set(defaultHeaders)
         .send({
           query: print(SEARCH_CORPUS),
           variables,
@@ -544,7 +545,7 @@ describe('Corpus search - keyword', () => {
       };
       const res = await request(app)
         .post(url)
-        .set({ userid: '1' })
+        .set(defaultHeaders)
         .send({
           query: print(SEARCH_CORPUS),
           variables,
@@ -574,7 +575,7 @@ describe('Corpus search - keyword', () => {
       };
       const firstRes = await request(app)
         .post(url)
-        .set({ userid: '1' })
+        .set(defaultHeaders)
         .send({
           query: print(SEARCH_CORPUS),
           variables,
@@ -582,7 +583,7 @@ describe('Corpus search - keyword', () => {
       const cursor = firstRes.body.data.searchCorpus.pageInfo.endCursor;
       const res = await request(app)
         .post(url)
-        .set({ userid: '1' })
+        .set(defaultHeaders)
         .send({
           query: print(SEARCH_CORPUS),
           variables: { ...variables, pagination: { first: 3, after: cursor } },


### PR DESCRIPTION
For native Pocket applications only.

Adds assertion that a user is logged in to
every other mutation and User field resolver.

This is an alternative to the router-based auth
directives we were trying to use, because of a
bug which causes the entire query to be rejected
if the unauthorized component references a variable.

https://github.com/apollographql/router/issues/5648

Since we probably will migrate to router-enforced auth once this bug is fixed, this less elegant method requires the least refactoring (vs. using the more complicated auth models in other subgraphs)

[POCKET-10286]

[POCKET-10286]: https://mozilla-hub.atlassian.net/browse/POCKET-10286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ