### PR TITLE
fix(v3proxy): bump request size limit and add logging

### DIFF
--- a/servers/v3-proxy-api/src/middleware/errorHandlers.ts
+++ b/servers/v3-proxy-api/src/middleware/errorHandlers.ts
@@ -99,6 +99,11 @@ export function logAndCaptureErrors(
   }
   // Okay, now we actually log things
   serverLogger.error(`${req.method}: ${req.baseUrl + req.path}: ${err}`);
+  const query = { ...req.query };
+  delete query['access_token'];
+  Sentry.addBreadcrumb({
+    data: { body: req.body, query },
+  });
   Sentry.captureException(err);
   next(err);
 }

--- a/servers/v3-proxy-api/src/server.ts
+++ b/servers/v3-proxy-api/src/server.ts
@@ -16,9 +16,10 @@ import v3SendRouter from './routes/v3Send';
 export async function startServer(port: number) {
   const app: Application = express();
   const httpServer: Server = createServer(app);
+  const sizeLimit = '600kb';
 
-  app.use(json());
-  app.use(urlencoded({ extended: true }));
+  app.use(json({ limit: sizeLimit }));
+  app.use(urlencoded({ limit: sizeLimit, extended: true }));
   app.set('query parser', 'simple');
   app.get('/.well-known/server-health', (req, res) => {
     res.status(200).send('ok');


### PR DESCRIPTION
Bump request size limit 6x

Add body and query params (except access token) to error tracking in sentry for debugging purposes

[POCKET-10338]

[POCKET-10338]: https://mozilla-hub.atlassian.net/browse/POCKET-10338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ