### PR TITLE
fix(v3proxy): handle undefined error data

### DIFF
--- a/servers/v3-proxy-api/src/graph/get/toRest.ts
+++ b/servers/v3-proxy-api/src/graph/get/toRest.ts
@@ -534,7 +534,7 @@ export function savedItemsCompleteTotalToRest(
   options?: { withAnnotations?: boolean },
 ): GetResponseCompleteTotal {
   return {
-    total: response.user.savedItemsByOffset.totalCount.toString(),
+    total: response.user?.savedItemsByOffset.totalCount.toString(),
     ...savedItemsCompleteToRest(response, options),
   };
 }

--- a/servers/v3-proxy-api/src/middleware/errorHandlers.ts
+++ b/servers/v3-proxy-api/src/middleware/errorHandlers.ts
@@ -23,6 +23,11 @@ const errorHeaders = {
   },
 };
 
+export type WebErrorMap = {
+  'X-Error-Code': number;
+  'X-Error': string;
+};
+
 /**
  * (Partial) implementation of v3 API's custom error headers.
  * See public_html/localization/dict-errors-*.json in Web repo.
@@ -39,7 +44,7 @@ export function customErrorHeaders(errorCode: unknown, language = 'en') {
   return {
     'X-Error-Code': errorHeaders[errorCode]['X-Error-Code'],
     'X-Error': errorHeaders[errorCode][language],
-  };
+  } as WebErrorMap;
 }
 /**
  * Handle errors thrown by GraphQL Client (returned by pocket-graph)
@@ -57,11 +62,11 @@ export function clientErrorHandler(
     res.status(err.response.status);
     // There might be more than 1 error, but we will just return the first
     const primaryError = err.response.errors?.[0];
-    const headers = customErrorHeaders(primaryError.extensions.code);
+    const headers = customErrorHeaders(primaryError?.extensions.code);
     // Set headers if they're not undefined
     headers && res.set(headers);
     // Set error data
-    const message = primaryError.message ?? defaultMessage;
+    const message = primaryError?.message ?? defaultMessage;
     res.send({ error: message });
   } else if (err instanceof InputValidationError) {
     res

--- a/servers/v3-proxy-api/src/routes/v3Get.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Get.integration.ts
@@ -1017,7 +1017,7 @@ describe('v3Get', () => {
         since: '123123',
         detailType: 'complete',
       });
-      expect(apiSpy.mock.lastCall[3].filter.updatedSince).toEqual(123123);
+      expect(apiSpy.mock.lastCall?.[3].filter?.updatedSince).toEqual(123123);
       expect(response.headers['x-source']).toBe(expectedHeaders['X-Source']);
     });
     it('should not add contentType filter if value="all"', async () => {
@@ -1029,7 +1029,7 @@ describe('v3Get', () => {
         access_token: 'test',
         detailType: 'complete',
       });
-      expect(apiSpy.mock.lastCall[3].filter).toBeUndefined();
+      expect(apiSpy.mock.lastCall?.[3].filter).toBeUndefined();
       expect(response.headers['x-source']).toBe(expectedHeaders['X-Source']);
     });
     it.each([
@@ -1051,7 +1051,9 @@ describe('v3Get', () => {
           since: time,
           detailType: 'complete',
         });
-        expect(apiSpy.mock.lastCall[3].filter.updatedSince).toEqual(1719263946);
+        expect(apiSpy.mock.lastCall?.[3].filter?.updatedSince).toEqual(
+          1719263946,
+        );
         expect(response.headers['x-source']).toBe(expectedHeaders['X-Source']);
       },
     );
@@ -1259,8 +1261,8 @@ describe('v3Get', () => {
         access_token: 'test',
         search: 'abc',
       });
-      expect(apiSpy.mock.lastCall[3].sort.sortBy).toEqual('RELEVANCE');
-      expect(apiSpy.mock.lastCall[3].sort.sortOrder).toEqual('DESC');
+      expect(apiSpy.mock.lastCall?.[3].sort?.sortBy).toEqual('RELEVANCE');
+      expect(apiSpy.mock.lastCall?.[3].sort?.sortOrder).toEqual('DESC');
       expect(response.headers['x-source']).toBe(expectedHeaders['X-Source']);
     });
     it('defaults to newest sort for non-search', async () => {
@@ -1271,8 +1273,8 @@ describe('v3Get', () => {
         consumer_key: 'test',
         access_token: 'test',
       });
-      expect(apiSpy.mock.lastCall[3].sort.sortBy).toEqual('CREATED_AT');
-      expect(apiSpy.mock.lastCall[3].sort.sortOrder).toEqual('DESC');
+      expect(apiSpy.mock.lastCall?.[3].sort?.sortBy).toEqual('CREATED_AT');
+      expect(apiSpy.mock.lastCall?.[3].sort?.sortOrder).toEqual('DESC');
       expect(response.headers['x-source']).toBe(expectedHeaders['X-Source']);
     });
   });

--- a/servers/v3-proxy-api/src/routes/v3Send.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Send.integration.ts
@@ -153,6 +153,28 @@ describe('v3/send', () => {
       });
     });
     describe('actions router', () => {
+      it('throws Unimplemented Action error for adding by item_id alone', async () => {
+        const response = await request(app)
+          .post('/v3/send')
+          .send({
+            consumer_key: 'test',
+            access_token: 'test',
+            actions: [{ action: 'add', item_id: '12345' }],
+          });
+        const expected = {
+          status: 1,
+          action_results: [false],
+          action_errors: [
+            {
+              message: `Invalid Action: 'add (item_id only)'`,
+              type: 'Bad request',
+              code: 130,
+            },
+          ],
+        };
+        expect(response.status).toEqual(200);
+        expect(response.body).toEqual(expected);
+      });
       describe('processActions - unknown ClientError', () => {
         let addSpy;
         beforeEach(

--- a/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
@@ -154,7 +154,7 @@ export const V3GetSchema: Schema = {
     toLowerCase: true,
     customSanitizer: {
       options: (value, { req }) => {
-        const isSearch = req.body.search || req.query.search ? true : false;
+        const isSearch = req.body.search || req.query?.search ? true : false;
         // No value was passed
         if (value == null) {
           // If searching, default to relevance

--- a/servers/v3-proxy-api/src/routes/validations/SendActionValidators.ts
+++ b/servers/v3-proxy-api/src/routes/validations/SendActionValidators.ts
@@ -238,7 +238,7 @@ function HasTimeOrDefault<TBase extends ActionSanitizable>(Base: TBase) {
     readonly time: number;
     constructor(...args: any[]) {
       super(...args);
-      if ('time' in this.input) {
+      if ('time' in this.input && this.input.time != null) {
         // parseInt has some unexpected behavior for strings that
         // contain numerals + numbers, e.g. parseInt('123abc') returns 123.
         // Also, it will parse date timestamps that just have numerals
@@ -286,7 +286,7 @@ function MaybeHasTags<TBase extends ActionSanitizable>(Base: TBase) {
     readonly tags: string[] | undefined;
     constructor(...args: any[]) {
       super(...args);
-      if ('tags' in this.input) {
+      if ('tags' in this.input && this.input.tags != null) {
         let tags: string[];
         if (typeof this.input.tags === 'string') {
           tags = this.input.tags.split(',');
@@ -322,7 +322,7 @@ function HasValidTags<TBase extends ActionSanitizable>(Base: TBase) {
     tags: string[];
     constructor(...args: any[]) {
       super(...args);
-      if (!('tags' in this.input)) {
+      if (!('tags' in this.input) || this.input.tags == null) {
         const error: ArrayFieldError = {
           type: 'array_field',
           path: 'tags',
@@ -362,8 +362,8 @@ function HasNewTag<TBase extends ActionSanitizable>(Base: TBase) {
     readonly newTag: string;
     constructor(...args: any[]) {
       super(...args);
-      nonEmptyStringPropOrError(this.input, 'new_tag');
-      this.newTag = this.input.new_tag;
+      const validated = nonEmptyStringPropOrError(this.input, 'new_tag');
+      this.newTag = validated;
     }
   };
 }
@@ -387,8 +387,8 @@ function HasOldTag<TBase extends ActionSanitizable>(Base: TBase) {
     readonly oldTag: string;
     constructor(...args: any[]) {
       super(...args);
-      nonEmptyStringPropOrError(this.input, 'old_tag');
-      this.oldTag = this.input.old_tag;
+      const validated = nonEmptyStringPropOrError(this.input, 'old_tag');
+      this.oldTag = validated;
     }
   };
 }
@@ -412,8 +412,8 @@ function HasTag<TBase extends ActionSanitizable>(Base: TBase) {
     readonly tag: string;
     constructor(...args: any[]) {
       super(...args);
-      nonEmptyStringPropOrError(this.input, 'tag');
-      this.tag = this.input.tag;
+      const validated = nonEmptyStringPropOrError(this.input, 'tag');
+      this.tag = validated;
     }
   };
 }
@@ -437,8 +437,8 @@ function HasSearchTerm<TBase extends ActionSanitizable>(Base: TBase) {
     readonly term: string;
     constructor(...args: any[]) {
       super(...args);
-      nonEmptyStringPropOrError(this.input, 'search');
-      this.term = this.input.search;
+      const validated = nonEmptyStringPropOrError(this.input, 'search');
+      this.term = validated;
     }
   };
 }
@@ -460,7 +460,7 @@ function HasSearchTerm<TBase extends ActionSanitizable>(Base: TBase) {
  */
 function MaybeHasTitle<TBase extends ActionSanitizable>(Base: TBase) {
   return class MaybeHasTitle extends Base {
-    readonly title: string;
+    readonly title: string | undefined;
     constructor(...args: any[]) {
       super(...args);
       if (
@@ -488,11 +488,12 @@ function MaybeHasTitle<TBase extends ActionSanitizable>(Base: TBase) {
 /**
  * Throws if the property `key` is in the object `input` and is an empty string.
  */
-function nonEmptyStringPropOrError(input: MaybeAction, key: string): void {
+function nonEmptyStringPropOrError(input: MaybeAction, key: string): string {
   if (
     !(key in input) ||
     !(typeof input[key] === 'string') ||
-    input[key] === ''
+    input[key] === '' ||
+    input[key] == null
   ) {
     const error: ArrayFieldError = {
       type: 'array_field',
@@ -502,6 +503,7 @@ function nonEmptyStringPropOrError(input: MaybeAction, key: string): void {
     };
     throw new InputValidationError(error);
   }
+  return input[key] as string;
 }
 
 /**
@@ -606,8 +608,8 @@ function HasAnnotationId<TBase extends ActionSanitizable>(Base: TBase) {
     readonly id: string;
     constructor(...args: any[]) {
       super(...args);
-      nonEmptyStringPropOrError(this.input, 'annotation_id');
-      this.id = this.input.annotation_id;
+      const validated = nonEmptyStringPropOrError(this.input, 'annotation_id');
+      this.id = validated;
     }
   };
 }

--- a/servers/v3-proxy-api/tsconfig.json
+++ b/servers/v3-proxy-api/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "tsconfig/graphql.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "src"
   },
   "exclude": ["node_modules", "dist", "**/.pnpm/*", "src/test"],
   "include": ["src/**/*.ts", "src/config"]


### PR DESCRIPTION
Handle ClientError reponses that are undefined.
Add additional debug logs to understand responses.

Do not accept 'add' by item_id only, and return
InvalidActionError instead.

[POCKET-10354]

I enabled strictNullChecks and fixed all files which interacted with v3/send. The main issue with turning it on for the full repository was the generated graphql types, which were causing unexpected/strange null issues for the compiler.

[POCKET-10354]: https://mozilla-hub.atlassian.net/browse/POCKET-10354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ