### PR TITLE
fix(parser): bump request size limit

### DIFF
--- a/servers/parser-graphql-wrapper/src/apollo/server.ts
+++ b/servers/parser-graphql-wrapper/src/apollo/server.ts
@@ -17,6 +17,7 @@ import { getRedis, getRedisCache } from '../cache';
 import { ContextManager, IContext } from './context';
 import { setMorgan, serverLogger } from '@pocket-tools/ts-logger';
 import { unleash } from '../unleash';
+import config from '../config';
 
 export async function startServer(port: number): Promise<{
   app: Application;
@@ -83,7 +84,7 @@ export async function startServer(port: number): Promise<{
     url,
     cors<cors.CorsRequest>(),
     // JSON parser to enable POST body with JSON
-    json(),
+    json({ limit: config.app.maxRequestSize }),
     sentryPocketMiddleware,
     // Logging Setup, Express app-specific
     setMorgan(serverLogger),

--- a/servers/parser-graphql-wrapper/src/config/index.ts
+++ b/servers/parser-graphql-wrapper/src/config/index.ts
@@ -22,6 +22,7 @@ export default {
     environment: process.env.NODE_ENV || 'development',
     defaultMaxAge: 21100, // ~6 hours
     serverPort: 4001,
+    maxRequestSize: '1mb',
   },
   aws: {
     region: process.env.AWS_REGION || 'us-east-1',


### PR DESCRIPTION
Bump request size limit. Sentry is showing that we are getting 413 errors originating from the parser, for some v3proxy requests.

[POCKET-10351]

[POCKET-10351]: https://mozilla-hub.atlassian.net/browse/POCKET-10351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ