### PR TITLE
fix(shareable lists): [MC-1162] Fix Admin subgraph errors for shareable lists

### DIFF
--- a/.circleci/shareable-lists-api.yml
+++ b/.circleci/shareable-lists-api.yml
@@ -21,8 +21,8 @@ workflows:
           fed_graph_name: pocket-admin-api
           graph_name: shareable-lists-api
           schema_file_path: servers/shareable-lists-api/schema-admin-api.graphql
-          prod_graph_url: https://shareablelistsapi.readitlater.com
-          dev_graph_url: https://shareablelistsapi.getpocket.dev
+          prod_graph_url: https://shareablelistsapi.readitlater.com/admin
+          dev_graph_url: https://shareablelistsapi.getpocket.dev/admin
           build_command: pnpm run build --filter=shareable-lists-api...
           apollo_key_env: APOLLO_ADMIN_KEY
           scope: shareable-lists-api


### PR DESCRIPTION
## Goal

Fix errors in Curation Admin Tools on the Shareable Lists Moderation page - an error was coming back from the graph saying `searchShareableLists` query does not exist. It turns out there was a misconfiguration in the Admin graph - while the schema was correct, the subgraph for Shareable Lists was pointing to the public URL instead of the admin URL.

Note: deployed to Dev for verification.

Previously on Dev:

```
rover subgraph list pocket-admin-api@development
Listing subgraphs for pocket-admin-api@development using credentials from the default profile.

<snip>
────────────────┼────────────────────────────┤
│ shareable-lists-api │ https://shareablelistsapi.getpocket.dev        │ 2024-02-03 09:59:30 +11:00 │
├─────────────────────┼────────────────────────────────
<snip>
```


Now on Dev:

```
rover subgraph list pocket-admin-api@development
Listing subgraphs for pocket-admin-api@development using credentials from the default profile.
┌─────────────────────┬────────────────────────────────────────────────┬────────────────────────────┐
│        Name         │                  Routing Url                   │        Last Updated        │
├─────────────────────┼────────────────────────────────────────────────┼────────────────────────────┤
│ shareable-lists-api │ https://shareablelistsapi.getpocket.dev/admin  │ 2024-07-25 18:53:19 +10:00 │
```

A search query in Curation Admin Tools now responds with "[GraphQL error]: Error - Not Found: List 111 cannot be found." instead of a 400 error 🎉.

## References

https://mozilla-hub.atlassian.net/browse/MC-1162