### PR TITLE
fix(v3proxy:extensions): flatten /send response for extensions

### DIFF
--- a/servers/v3-proxy-api/src/config/index.ts
+++ b/servers/v3-proxy-api/src/config/index.ts
@@ -6,6 +6,12 @@ export default {
     defaultMaxAge: 86400,
     port: 4030,
   },
+  // IDs of native extensions which have special routing/handling
+  // (the response and request params are mutated after receiving request
+  // and differ from other client behavior)
+  extensionApiIds: [
+    9346, 7035, 15449, 22931, 23283, 53720, 60289, 70018, 73360,
+  ],
   tracing: {
     host: process.env.OTLP_COLLECTOR_HOST || 'localhost',
     serviceName: 'v3-api-proxy',

--- a/servers/v3-proxy-api/src/graph/graphQLClient.ts
+++ b/servers/v3-proxy-api/src/graph/graphQLClient.ts
@@ -157,7 +157,7 @@ export class GraphQLClientFactory {
             !(
               error.path &&
               Array.isArray(error.path) &&
-              error.path.indexOf('recentSearches') &&
+              error.path.indexOf('recentSearches') >= 0 &&
               error.extensions.code === 'FORBIDDEN'
             ),
         );

--- a/servers/v3-proxy-api/src/routes/v3Add.ts
+++ b/servers/v3-proxy-api/src/routes/v3Add.ts
@@ -13,6 +13,7 @@ import { InputValidationError } from '../errors/InputValidationError';
 import { AddItemTransformer } from '../graph/add/toRest';
 import { GraphQLClient } from 'graphql-request';
 import { asyncHandler } from '../middleware/asyncHandler';
+import { AddResponse, PendingAddResponse } from '../graph/types';
 
 const router: Router = Router();
 
@@ -86,7 +87,7 @@ export async function processV3Add(
     | AddSavedItemCompleteMutationVariables // these are the same
     | AddSavedItemBeforeTagMutationVariables,
   tags?: string[],
-) {
+): Promise<AddResponse | PendingAddResponse> {
   if (tags == null) {
     const result = await addSavedItem(client, variables);
     return AddItemTransformer(result['upsertSavedItem']);

--- a/servers/v3-proxy-api/src/routes/v3Send.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Send.integration.ts
@@ -258,7 +258,7 @@ describe('v3/send', () => {
           () =>
             (addSpy = jest
               .spyOn(ActionsRouter.prototype, 'add')
-              .mockResolvedValueOnce(expectedAddResponses[0])
+              .mockResolvedValueOnce(expectedAddResponses[0]['item'])
               .mockRejectedValueOnce(
                 new ClientError(
                   {
@@ -273,7 +273,7 @@ describe('v3/send', () => {
                   {} as any,
                 ),
               )
-              .mockResolvedValueOnce(expectedAddResponses[1])),
+              .mockResolvedValueOnce(expectedAddResponses[1]['item'])),
         );
         afterEach(() => addSpy.mockRestore());
         it('sends an array of responses and errors', async () => {
@@ -291,9 +291,9 @@ describe('v3/send', () => {
           const expected = {
             status: 1,
             action_results: [
-              expectedAddResponses[0],
+              expectedAddResponses[0]['item'],
               false,
-              expectedAddResponses[1],
+              expectedAddResponses[1]['item'],
             ],
             action_errors: [
               null,
@@ -322,7 +322,7 @@ describe('v3/send', () => {
             });
           const expected = {
             status: 1,
-            action_results: [false, expectedAddResponses[0], false],
+            action_results: [false, expectedAddResponses[0]['item'], false],
             action_errors: [
               {
                 message: `Invalid Action: 'action_imposter'`,
@@ -1019,7 +1019,7 @@ describe('v3/send', () => {
               expect(clientSpy.mock.calls[0][1]).toEqual(expectedCall);
               expect(res.body).toEqual({
                 status: 1,
-                action_results: [expectedAddResponses[0]],
+                action_results: [expectedAddResponses[0]['item']],
                 action_errors: [null],
               });
             },

--- a/servers/v3-proxy-api/src/routes/v3Send.ts
+++ b/servers/v3-proxy-api/src/routes/v3Send.ts
@@ -7,8 +7,8 @@ import {
   V3SendSchemaPost,
 } from './validations';
 import { InputValidationError } from '../errors/InputValidationError';
-import { ActionsRouter } from './ActionsRouter';
 import { asyncHandler } from '../middleware/asyncHandler';
+import { ActionsRouter } from './ActionsRouter';
 
 const router: Router = Router();
 

--- a/servers/v3-proxy-api/src/utils.spec.ts
+++ b/servers/v3-proxy-api/src/utils.spec.ts
@@ -1,0 +1,26 @@
+import { isExtension, parseApiId } from './utils';
+
+describe('utils', () => {
+  describe('parseApiId from consumer key', () => {
+    it.each(['123-test', '123-456', '123-a34df234'])(
+      'works for expected keys',
+      (key) => {
+        expect(parseApiId(key)).toEqual(123);
+      },
+    );
+    it.each(['test', 'abc-1234', '1232', '123aa-test'])(
+      'returns undefined for malformed/nonconforming keys',
+      (key) => {
+        expect(parseApiId(key)).toBeUndefined();
+      },
+    );
+  });
+  describe('isExtension', () => {
+    it.each([7035, 73360])('works for extensions', (key) => {
+      expect(isExtension(key)).toEqual(true);
+    });
+    it.each([NaN, undefined, 9999999, 0])('works for non-extensions', (key) => {
+      expect(isExtension(key)).toEqual(false);
+    });
+  });
+});

--- a/servers/v3-proxy-api/src/utils.ts
+++ b/servers/v3-proxy-api/src/utils.ts
@@ -1,0 +1,20 @@
+import config from './config';
+
+/**
+ * Parse the API ID (prefix) from the consumer key string.
+ * We don't need to do a ton of validation because this is
+ * just used to determine if the request comes from an extension
+ * and whether we need to return special responses; if people pass
+ * weird stuff in the consumer keys it will just be ignored.
+ * @param consumerKey consumer key provided to API by Pocket;
+ * format is prefixed by "<api_id>-"
+ */
+export function parseApiId(consumerKey: string): number | undefined {
+  const re = new RegExp(/^(\d+)-[\w\d]+/);
+  const apiId = consumerKey.match(re)?.[0];
+  return apiId != null ? parseInt(apiId) : undefined;
+}
+
+export function isExtension(apiId: number | undefined) {
+  return config.extensionApiIds.indexOf(apiId) >= 0 ? true : false;
+}


### PR DESCRIPTION
Note that I have some extension-specific code checks which I ended up not using in this PR, but they will be used in subsequent PRs (due to changing `/v3/get` response for extensions).

This is a follow up from #663, which we reverted due to reports from 3rd party API users.

I am reasonably certain that _only_ the `/v3/send` response for the `add` action is flattened, and not the response for `/v3/add` itself.

Investigation and testing:
* When #663 was merged, I received bug reports from 3rd party API users about the unnesting
* Our [developer documentation](https://getpocket.com/developer/docs/v3/add) indicates that `/v3/add` response data is nested under the `item` key
* Our native apps and extensions return nested `/v3/add` results (tested with ios and chrome extension consumer keys)
* The response type is **not** documented for `/v3/send`, but requests made with both ios and chrome extension consumer keys returned the flattened (unnested) result
* There is special handling for native apps and extensions, but it doesn't appear to be called in these code paths (discovered elsewhere, to be continued)
* Android handles errors and makes a fresh `fetch` request, so it was not materially impacted by either of the `add` or `send` response shapes 

[POCKET-19379]