### PR TITLE
fix(status-checks): switching to a polling job for status checks

### DIFF
--- a/.github/actions/ecs-codedeploy/action.yml
+++ b/.github/actions/ecs-codedeploy/action.yml
@@ -50,7 +50,7 @@ runs:
       with:
         token: ${{ github.token }}
         environment-url: https://${{ fromJSON(inputs.terraform-output).ecs-application-url.value }}
-        environment: ${{ inputs.name }}${{ github.ref == 'refs/heads/dev' && '-dev' }}
+        environment: ${{ inputs.name }}${{ github.ref == 'refs/heads/dev' && '-dev' || '' }}
         transient-environment: ${{ github.ref == 'refs/heads/main' && 'false' || 'true' }}
         production-environment: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
         initial-status: pending

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -5,49 +5,19 @@
 # We also use this because re-usable workflows can not be targeted for Github Required Status Checks as of 8/15/2024 
 name: Status Checks
 on:
-  workflow_run:
-    workflows: 
-      - Pull Request
-      - User API
-      - List API
-      - Account Delete Monitor
-      - Annotations API
-      - Braze
-      - Client API
-      - Feature Flags
-      - FxA Webhook Proxy
-      - Image API
-      - Instant Sync Events
-      - Parser GraphQL Wrapper
-      - Pocket Event Bridge
-      - Push Server
-      - Sendgrid Data
-      - Shareable Lists API
-      - Shared Snowplow Consumer
-      - Shares API
-      - Transactional Emails
-      - V3 Proxy API
-      - User List Search
-    types: [ completed ]
+  pull_request:
 
 jobs:
   status-check:
     runs-on: ubuntu-latest
-
+    if: always()
     steps:
-      - uses: actions/checkout@v2
-      - uses: ahmadnassri/action-workflow-run-wait@v1
-
-  # Note: If the workflow_run trigger does not work out, this can be used instead with a pull_request event to trigger a long polling job.
-  # status-check:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Wait for workflows
-  #       id: wait
-  #       uses: smartcontractkit/chainlink-github-actions/utils/wait-for-workflows@main
-  #       with:
-  #         max-timeout: "900"
-  #         polling-interval: "15"
-  #         exclude-workflow-names: ""
-  #         exclude-workflow-ids: ""
-  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Wait for workflows
+        id: wait
+        uses: smartcontractkit/chainlink-github-actions/utils/wait-for-workflows@main
+        with:
+          max-timeout: "900"
+          polling-interval: "15"
+          exclude-workflow-names: ""
+          exclude-workflow-ids: ""
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Goal

We should use a polling job instead of a trigger. The trigger was nice, but it created a bunch of notifications.