### PR TITLE
fix(image): removing alarm for image api

### DIFF
--- a/infrastructure/image-api/src/main.ts
+++ b/infrastructure/image-api/src/main.ts
@@ -240,7 +240,7 @@ class ImageAPI extends TerraformStack {
           threshold: 25,
           evaluationPeriods: 4,
           period: 300,
-          actions: config.isProd ? [snsTopic.arn] : [],
+          actions: config.isProd ? [] : [],
         },
       },
     });


### PR DESCRIPTION
## Goal

Image API is rarely used at this time and because of that, when it does get used we get an alarm message that it is going into an ok state.

Instead for now, lets turn it off until it is used more.