### PR TITLE
fix(title): deriving title to url if blank

### DIFF
--- a/servers/parser-graphql-wrapper/src/models/PocketMetadataModel.ts
+++ b/servers/parser-graphql-wrapper/src/models/PocketMetadataModel.ts
@@ -342,7 +342,7 @@ export class PocketMetadataModel {
       id: item.id,
       image: item.topImage ?? item.images?.[0],
       excerpt: item.excerpt,
-      title: item.title ?? item.givenUrl,
+      title: item.title && item.title != '' ? item.title : item.givenUrl,
       authors: item.authors,
       domain: item.domainMetadata,
       datePublished: item.datePublished


### PR DESCRIPTION
## Goal

Titles can be empty strings, instead of showing those we should show the url.