### PR TITLE
fix(logging): do not use data key

### DIFF
--- a/lambdas/user-list-search-corpus-parser-hydration/src/bulkIndex.ts
+++ b/lambdas/user-list-search-corpus-parser-hydration/src/bulkIndex.ts
@@ -41,7 +41,7 @@ export async function bulkIndex(
   if (!res.ok) {
     Sentry.addBreadcrumb({ data: { requestBody: body } });
     const data = await res.json();
-    serverLogger.error({ message: 'Request failure', data: data });
+    serverLogger.error({ message: 'Request failure', errorData: data });
     throw new Error(
       `user-list-search-corpus-parser-hydrator: ${res.status}\n${JSON.stringify(data.error)}`,
     );
@@ -64,7 +64,7 @@ export async function bulkIndex(
         });
         serverLogger.error({
           message: 'Error updating corpus item(s)',
-          data: errorData,
+          errorData,
         });
       });
     }


### PR DESCRIPTION
Data key is deleted in the logger, which is why
the error logging was not useful.