### PR TITLE
fix(preview): updating corpus search node preview object

### DIFF
--- a/servers/parser-graphql-wrapper/schema.graphql
+++ b/servers/parser-graphql-wrapper/schema.graphql
@@ -627,10 +627,18 @@ type CorpusSearchNode @key(fields: "url") {
   For federation only
   """
   url: Url! @inaccessible
+
   """
-  The preview of the search result
+  Attaches the item so we can use the preview field
   """
-  preview: PocketMetadata!
+  item: Item
+
+  """
+  The preview of the search result, the @requires fields must be kept in sync with the preview field in the Item entity
+  """
+  preview: PocketMetadata! @requires(
+      fields: "item { syndicatedArticle { title excerpt mainImage publishedAt authorNames publisherUrl publisher { logo name } } collection { title excerpt publishedAt authors { name } imageUrl } corpusItem { title excerpt datePublished publisher image { url } authors { name sortOrder } }"
+    )
 }
 
 extend type SyndicatedArticle @key(fields: "slug") {

--- a/servers/parser-graphql-wrapper/schema.graphql
+++ b/servers/parser-graphql-wrapper/schema.graphql
@@ -637,7 +637,7 @@ type CorpusSearchNode @key(fields: "url") {
   The preview of the search result, the @requires fields must be kept in sync with the preview field in the Item entity
   """
   preview: PocketMetadata! @requires(
-      fields: "item { syndicatedArticle { title excerpt mainImage publishedAt authorNames publisherUrl publisher { logo name } } collection { title excerpt publishedAt authors { name } imageUrl } corpusItem { title excerpt datePublished publisher image { url } authors { name sortOrder } }"
+      fields: "item { syndicatedArticle { title excerpt mainImage publishedAt authorNames publisherUrl publisher { logo name } } collection { title excerpt publishedAt authors { name } imageUrl } corpusItem { title excerpt datePublished publisher image { url } authors { name sortOrder } } }"
     )
 }
 

--- a/servers/parser-graphql-wrapper/src/__generated__/resolvers-types.ts
+++ b/servers/parser-graphql-wrapper/src/__generated__/resolvers-types.ts
@@ -132,7 +132,9 @@ export type CorpusItemAuthor = {
 /** A node in a CorpusSearchConnection result */
 export type CorpusSearchNode = {
   __typename?: 'CorpusSearchNode';
-  /** The preview of the search result */
+  /** Attaches the item so we can use the preview field */
+  item?: Maybe<Item>;
+  /** The preview of the search result, the @requires fields must be kept in sync with the preview field in the Item entity */
   preview: PocketMetadata;
   /** For federation only */
   url: Scalars['Url']['output'];
@@ -741,7 +743,7 @@ export type ResolversUnionTypes<_RefType extends Record<string, unknown>> = Reso
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
   ListElement: ( BulletedListElement ) | ( NumberedListElement );
-  PocketMetadata: ( Omit<ItemSummary, 'item'> & { item?: Maybe<_RefType['Item']> } ) | ( Omit<OEmbed, 'item'> & { item?: Maybe<_RefType['Item']> } );
+  PocketMetadata: ( Omit<ItemSummary, 'authors' | 'item'> & { authors?: Maybe<Array<_RefType['Author']>>, item?: Maybe<_RefType['Item']> } ) | ( Omit<OEmbed, 'authors' | 'item'> & { authors?: Maybe<Array<_RefType['Author']>>, item?: Maybe<_RefType['Item']> } );
 }>;
 
 /** Mapping between all available schema types and the resolvers types */
@@ -757,17 +759,17 @@ export type ResolversTypes = ResolversObject<{
   CollectionAuthor: ResolverTypeWrapper<CollectionAuthor>;
   CorpusItem: ResolverTypeWrapper<Omit<CorpusItem, 'preview'> & { preview: ResolversTypes['PocketMetadata'] }>;
   CorpusItemAuthor: ResolverTypeWrapper<CorpusItemAuthor>;
-  CorpusSearchNode: ResolverTypeWrapper<Omit<CorpusSearchNode, 'preview'> & { preview: ResolversTypes['PocketMetadata'] }>;
+  CorpusSearchNode: ResolverTypeWrapper<Omit<CorpusSearchNode, 'item' | 'preview'> & { item?: Maybe<ResolversTypes['Item']>, preview: ResolversTypes['PocketMetadata'] }>;
   Date: ResolverTypeWrapper<Scalars['Date']['output']>;
   DateString: ResolverTypeWrapper<Scalars['DateString']['output']>;
   DomainMetadata: ResolverTypeWrapper<DomainMetadata>;
   ISOString: ResolverTypeWrapper<Scalars['ISOString']['output']>;
   Image: ResolverTypeWrapper<Image>;
   Imageness: Imageness;
-  Item: ResolverTypeWrapper<Omit<Item, 'collection' | 'corpusItem' | 'marticle' | 'preview' | 'syndicatedArticle'> & { collection?: Maybe<ResolversTypes['Collection']>, corpusItem?: Maybe<ResolversTypes['CorpusItem']>, marticle?: Maybe<Array<ResolversTypes['MarticleComponent']>>, preview?: Maybe<ResolversTypes['PocketMetadata']>, syndicatedArticle?: Maybe<ResolversTypes['SyndicatedArticle']> }>;
+  Item: ResolverTypeWrapper<Omit<Item, 'authors' | 'collection' | 'corpusItem' | 'marticle' | 'preview' | 'syndicatedArticle'> & { authors?: Maybe<Array<Maybe<ResolversTypes['Author']>>>, collection?: Maybe<ResolversTypes['Collection']>, corpusItem?: Maybe<ResolversTypes['CorpusItem']>, marticle?: Maybe<Array<ResolversTypes['MarticleComponent']>>, preview?: Maybe<ResolversTypes['PocketMetadata']>, syndicatedArticle?: Maybe<ResolversTypes['SyndicatedArticle']> }>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
   ItemNotFound: ResolverTypeWrapper<ItemNotFound>;
-  ItemSummary: ResolverTypeWrapper<Omit<ItemSummary, 'item'> & { item?: Maybe<ResolversTypes['Item']> }>;
+  ItemSummary: ResolverTypeWrapper<Omit<ItemSummary, 'authors' | 'item'> & { authors?: Maybe<Array<ResolversTypes['Author']>>, item?: Maybe<ResolversTypes['Item']> }>;
   ListElement: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['ListElement']>;
   Markdown: ResolverTypeWrapper<Scalars['Markdown']['output']>;
   MarkdownImagePosition: ResolverTypeWrapper<MarkdownImagePosition>;
@@ -782,7 +784,7 @@ export type ResolversTypes = ResolversObject<{
   MarticleText: ResolverTypeWrapper<MarticleText>;
   Mutation: ResolverTypeWrapper<{}>;
   NumberedListElement: ResolverTypeWrapper<NumberedListElement>;
-  OEmbed: ResolverTypeWrapper<Omit<OEmbed, 'item'> & { item?: Maybe<ResolversTypes['Item']> }>;
+  OEmbed: ResolverTypeWrapper<Omit<OEmbed, 'authors' | 'item'> & { authors?: Maybe<Array<ResolversTypes['Author']>>, item?: Maybe<ResolversTypes['Item']> }>;
   OEmbedType: OEmbedType;
   PocketMetadata: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['PocketMetadata']>;
   PocketMetadataSource: PocketMetadataSource;
@@ -813,16 +815,16 @@ export type ResolversParentTypes = ResolversObject<{
   CollectionAuthor: CollectionAuthor;
   CorpusItem: Omit<CorpusItem, 'preview'> & { preview: ResolversParentTypes['PocketMetadata'] };
   CorpusItemAuthor: CorpusItemAuthor;
-  CorpusSearchNode: Omit<CorpusSearchNode, 'preview'> & { preview: ResolversParentTypes['PocketMetadata'] };
+  CorpusSearchNode: Omit<CorpusSearchNode, 'item' | 'preview'> & { item?: Maybe<ResolversParentTypes['Item']>, preview: ResolversParentTypes['PocketMetadata'] };
   Date: Scalars['Date']['output'];
   DateString: Scalars['DateString']['output'];
   DomainMetadata: DomainMetadata;
   ISOString: Scalars['ISOString']['output'];
   Image: Image;
-  Item: Omit<Item, 'collection' | 'corpusItem' | 'marticle' | 'preview' | 'syndicatedArticle'> & { collection?: Maybe<ResolversParentTypes['Collection']>, corpusItem?: Maybe<ResolversParentTypes['CorpusItem']>, marticle?: Maybe<Array<ResolversParentTypes['MarticleComponent']>>, preview?: Maybe<ResolversParentTypes['PocketMetadata']>, syndicatedArticle?: Maybe<ResolversParentTypes['SyndicatedArticle']> };
+  Item: Omit<Item, 'authors' | 'collection' | 'corpusItem' | 'marticle' | 'preview' | 'syndicatedArticle'> & { authors?: Maybe<Array<Maybe<ResolversParentTypes['Author']>>>, collection?: Maybe<ResolversParentTypes['Collection']>, corpusItem?: Maybe<ResolversParentTypes['CorpusItem']>, marticle?: Maybe<Array<ResolversParentTypes['MarticleComponent']>>, preview?: Maybe<ResolversParentTypes['PocketMetadata']>, syndicatedArticle?: Maybe<ResolversParentTypes['SyndicatedArticle']> };
   Boolean: Scalars['Boolean']['output'];
   ItemNotFound: ItemNotFound;
-  ItemSummary: Omit<ItemSummary, 'item'> & { item?: Maybe<ResolversParentTypes['Item']> };
+  ItemSummary: Omit<ItemSummary, 'authors' | 'item'> & { authors?: Maybe<Array<ResolversParentTypes['Author']>>, item?: Maybe<ResolversParentTypes['Item']> };
   ListElement: ResolversInterfaceTypes<ResolversParentTypes>['ListElement'];
   Markdown: Scalars['Markdown']['output'];
   MarkdownImagePosition: MarkdownImagePosition;
@@ -837,7 +839,7 @@ export type ResolversParentTypes = ResolversObject<{
   MarticleText: MarticleText;
   Mutation: {};
   NumberedListElement: NumberedListElement;
-  OEmbed: Omit<OEmbed, 'item'> & { item?: Maybe<ResolversParentTypes['Item']> };
+  OEmbed: Omit<OEmbed, 'authors' | 'item'> & { authors?: Maybe<Array<ResolversParentTypes['Author']>>, item?: Maybe<ResolversParentTypes['Item']> };
   PocketMetadata: ResolversInterfaceTypes<ResolversParentTypes>['PocketMetadata'];
   PocketShare: Omit<PocketShare, 'preview'> & { preview?: Maybe<ResolversParentTypes['PocketMetadata']> };
   Publisher: Publisher;
@@ -919,6 +921,7 @@ export type CorpusItemAuthorResolvers<ContextType = IContext, ParentType extends
 
 export type CorpusSearchNodeResolvers<ContextType = IContext, ParentType extends ResolversParentTypes['CorpusSearchNode'] = ResolversParentTypes['CorpusSearchNode']> = ResolversObject<{
   __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['CorpusSearchNode']>, { __typename: 'CorpusSearchNode' } & GraphQLRecursivePick<ParentType, {"url":true}>, ContextType>;
+  item?: Resolver<Maybe<ResolversTypes['Item']>, ParentType, ContextType>;
   preview?: Resolver<ResolversTypes['PocketMetadata'], ParentType, ContextType>;
   url?: Resolver<ResolversTypes['Url'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/servers/parser-graphql-wrapper/src/apollo/resolvers.ts
+++ b/servers/parser-graphql-wrapper/src/apollo/resolvers.ts
@@ -28,7 +28,13 @@ export const resolvers: Resolvers = {
   ...PocketDefaultScalars,
   CorpusSearchNode: {
     __resolveReference: async (representation, context) => {
-      const item = await itemFromUrl(representation.url, context);
+      const item = {
+        ...(await itemFromUrl(representation.url, context)),
+        // If the item comes in via representation, via Federation, lets spread its contents into the data we got from the parser
+        // this item will have curation, synidcation, collection, corpusItem, etc.
+        ...('item' in representation ? (representation.item as Item) : {}),
+      };
+
       const preview =
         await context.dataSources.pocketMetadataModel.derivePocketMetadata(
           item,

--- a/servers/parser-graphql-wrapper/src/apollo/resolvers.ts
+++ b/servers/parser-graphql-wrapper/src/apollo/resolvers.ts
@@ -41,6 +41,7 @@ export const resolvers: Resolvers = {
           },
         );
       return {
+        item,
         url: representation.url,
         preview,
       };

--- a/servers/parser-graphql-wrapper/src/models/PocketMetadataModel.ts
+++ b/servers/parser-graphql-wrapper/src/models/PocketMetadataModel.ts
@@ -49,7 +49,6 @@ export class PocketMetadataModel {
   ): Promise<PocketMetadata> {
     const { syndicatedArticle, collection, corpusItem } = extraData;
     const url = item.givenUrl; // the url we are going to key everything on.
-
     const syndicatedArticlePocketMetadata = this.transformSyndicatedArticle(
       item,
       syndicatedArticle,


### PR DESCRIPTION
## goal

the corpus search node preview object did not have metadata fields from other native entities. This updates the reference resolver to pull in the federated data.

I do not currently have a way to test federated requests, but I was able to test this locally connecting to the graph. Note that source correctly identifies corpus or syndication


![Screenshot 2024-09-16 at 9 05 32 AM](https://github.com/user-attachments/assets/f61264ea-d216-4753-b489-279b0c53be49)
