### PR TITLE
fix: remove preview from CorpusSearchNode

### DIFF
--- a/servers/parser-graphql-wrapper/schema-admin.graphql
+++ b/servers/parser-graphql-wrapper/schema-admin.graphql
@@ -550,7 +550,7 @@ type CorpusSearchNode @key(fields: "url") {
   """
   url: Url! @inaccessible
   """
-  The preview of the search result
+  Attaches the item so we can use the preview field
   """
-  preview: PocketMetadata!
+  item: Item
 }

--- a/servers/parser-graphql-wrapper/schema.graphql
+++ b/servers/parser-graphql-wrapper/schema.graphql
@@ -632,13 +632,6 @@ type CorpusSearchNode @key(fields: "url") {
   Attaches the item so we can use the preview field
   """
   item: Item
-
-  """
-  The preview of the search result, the @requires fields must be kept in sync with the preview field in the Item entity
-  """
-  preview: PocketMetadata! @requires(
-      fields: "item { syndicatedArticle { title excerpt mainImage publishedAt authorNames publisherUrl publisher { logo name } } collection { title excerpt publishedAt authors { name } imageUrl } corpusItem { title excerpt datePublished publisher image { url } authors { name sortOrder } } }"
-    )
 }
 
 extend type SyndicatedArticle @key(fields: "slug publisherUrl") {

--- a/servers/parser-graphql-wrapper/src/__generated__/resolvers-types.ts
+++ b/servers/parser-graphql-wrapper/src/__generated__/resolvers-types.ts
@@ -134,8 +134,6 @@ export type CorpusSearchNode = {
   __typename?: 'CorpusSearchNode';
   /** Attaches the item so we can use the preview field */
   item?: Maybe<Item>;
-  /** The preview of the search result, the @requires fields must be kept in sync with the preview field in the Item entity */
-  preview: PocketMetadata;
   /** For federation only */
   url: Scalars['Url']['output'];
 };
@@ -764,7 +762,7 @@ export type ResolversTypes = ResolversObject<{
   CollectionAuthor: ResolverTypeWrapper<CollectionAuthor>;
   CorpusItem: ResolverTypeWrapper<Omit<CorpusItem, 'preview'> & { preview: ResolversTypes['PocketMetadata'] }>;
   CorpusItemAuthor: ResolverTypeWrapper<CorpusItemAuthor>;
-  CorpusSearchNode: ResolverTypeWrapper<Omit<CorpusSearchNode, 'item' | 'preview'> & { item?: Maybe<ResolversTypes['Item']>, preview: ResolversTypes['PocketMetadata'] }>;
+  CorpusSearchNode: ResolverTypeWrapper<Omit<CorpusSearchNode, 'item'> & { item?: Maybe<ResolversTypes['Item']> }>;
   Date: ResolverTypeWrapper<Scalars['Date']['output']>;
   DateString: ResolverTypeWrapper<Scalars['DateString']['output']>;
   DomainMetadata: ResolverTypeWrapper<DomainMetadata>;
@@ -820,7 +818,7 @@ export type ResolversParentTypes = ResolversObject<{
   CollectionAuthor: CollectionAuthor;
   CorpusItem: Omit<CorpusItem, 'preview'> & { preview: ResolversParentTypes['PocketMetadata'] };
   CorpusItemAuthor: CorpusItemAuthor;
-  CorpusSearchNode: Omit<CorpusSearchNode, 'item' | 'preview'> & { item?: Maybe<ResolversParentTypes['Item']>, preview: ResolversParentTypes['PocketMetadata'] };
+  CorpusSearchNode: Omit<CorpusSearchNode, 'item'> & { item?: Maybe<ResolversParentTypes['Item']> };
   Date: Scalars['Date']['output'];
   DateString: Scalars['DateString']['output'];
   DomainMetadata: DomainMetadata;
@@ -927,7 +925,6 @@ export type CorpusItemAuthorResolvers<ContextType = IContext, ParentType extends
 export type CorpusSearchNodeResolvers<ContextType = IContext, ParentType extends ResolversParentTypes['CorpusSearchNode'] = ResolversParentTypes['CorpusSearchNode']> = ResolversObject<{
   __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['CorpusSearchNode']>, { __typename: 'CorpusSearchNode' } & GraphQLRecursivePick<ParentType, {"url":true}>, ContextType>;
   item?: Resolver<Maybe<ResolversTypes['Item']>, ParentType, ContextType>;
-  preview?: Resolver<ResolversTypes['PocketMetadata'], ParentType, ContextType>;
   url?: Resolver<ResolversTypes['Url'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;

--- a/servers/parser-graphql-wrapper/src/apollo/resolvers.ts
+++ b/servers/parser-graphql-wrapper/src/apollo/resolvers.ts
@@ -26,33 +26,6 @@ import { isInResolverChain } from './utils';
 
 export const resolvers: Resolvers = {
   ...PocketDefaultScalars,
-  CorpusSearchNode: {
-    __resolveReference: async (representation, context) => {
-      const item = {
-        ...(await itemFromUrl(representation.url, context)),
-        // If the item comes in via representation, via Federation, lets spread its contents into the data we got from the parser
-        // this item will have curation, synidcation, collection, corpusItem, etc.
-        ...('item' in representation ? (representation.item as Item) : {}),
-      };
-
-      const preview =
-        await context.dataSources.pocketMetadataModel.derivePocketMetadata(
-          item,
-          context,
-          false,
-          {
-            syndicatedArticle: item.syndicatedArticle,
-            collection: item.collection,
-            corpusItem: item.corpusItem,
-          },
-        );
-      return {
-        item,
-        url: representation.url,
-        preview,
-      };
-    },
-  },
   Item: {
     __resolveReference: async (item, context, info) => {
       // Setting the cache hint manually here because when the gateway(Client API) resolves an item using this
@@ -181,6 +154,11 @@ export const resolvers: Resolvers = {
           },
         );
       return { ...preview, item: parent as Item };
+    },
+  },
+  CorpusSearchNode: {
+    item: async ({ url }, args, context) => {
+      return await itemFromUrl(url, context);
     },
   },
   MarticleComponent: {


### PR DESCRIPTION
Consolidate on Item resolver instead. The CorpusSearchNode preview was throwing nulls in prod.

[POCKET-10601]

[POCKET-10601]: https://mozilla-hub.atlassian.net/browse/POCKET-10601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ