### PR TITLE
fix(corpus search): do not index embeddings for articles without excerpts

### DIFF
--- a/lambdas/user-list-search-corpus-parser-hydration/src/types.ts
+++ b/lambdas/user-list-search-corpus-parser-hydration/src/types.ts
@@ -7,6 +7,17 @@ export type EventPayload = {
   detail: ApprovedItemPayload | CollectionPayload;
 };
 
+export type ValidLangEventPayload = Omit<EventPayload, 'detail'> & {
+  detail: ValidLangApprovedItemPayload | CollectionPayload;
+};
+
+export type ValidLangApprovedItemPayload = Omit<
+  ApprovedItemPayload,
+  'language'
+> & {
+  language: string;
+};
+
 export type IndexMeta = {
   meta: { _id: string; _index: string };
 };
@@ -14,8 +25,9 @@ export type IndexMeta = {
 export interface BulkRequestMeta extends IndexMeta {
   url: string;
   messageId: string;
-  title?: string;
-  excerpt?: string;
+  title?: string | null;
+  excerpt?: string | null;
+  isCollection: boolean;
 }
 
 export interface BulkRequestPayload extends BulkRequestMeta {


### PR DESCRIPTION
With the exception of collections which might not have excerpts.

This is because the existence of an excerpt on a Corpus item is a good proxy indicator of quality/review. Items without excerpts tend to have poor metadata (e.g. a url for a title).

[POCKET-10583]

[POCKET-10583]: https://mozilla-hub.atlassian.net/browse/POCKET-10583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ