### PR TITLE
feat(search:corpus): ingest removed corpus events

### DIFF
--- a/infrastructure/pocket-event-bridge/src/event-rules/corpus-events/eventConfig.ts
+++ b/infrastructure/pocket-event-bridge/src/event-rules/corpus-events/eventConfig.ts
@@ -2,6 +2,10 @@ export const eventConfig = {
   CorpusItem: {
     name: 'CorpusEvents',
     source: 'curation-migration-datasync',
-    detailType: ['update-approved-item', 'add-approved-item'],
+    detailType: [
+      'update-approved-item',
+      'add-approved-item',
+      'remove-approved-item',
+    ],
   },
 };

--- a/infrastructure/user-list-search/sqs_sns_topic_subscription.tf
+++ b/infrastructure/user-list-search/sqs_sns_topic_subscription.tf
@@ -53,9 +53,18 @@ resource "aws_sns_topic_subscription" "collection_events_sns_topic_subscription"
 }
 
 resource "aws_sns_topic_subscription" "corpus_events_hydration_sns_topic_subscription" {
-  topic_arn = local.corpusEventsSnsTopicArn
-  protocol  = "sqs"
-  endpoint  = aws_sqs_queue.corpus_events_hydration.arn
+  topic_arn           = local.corpusEventsSnsTopicArn
+  protocol            = "sqs"
+  endpoint            = aws_sqs_queue.corpus_events_hydration.arn
+  # Don't need removed events in the hydration queue -- just index-related ones
+  filter_policy_scope = "MessageBody"
+  filter_policy = jsonencode({
+    detail-type = [
+      {
+        anything-but = "remove-approved-item"
+      }
+    ]
+  })
   # Need to do some more work to get this policy to work. It fails with
   # permissions error.
   # redrive_policy = jsonencode({

--- a/lambdas/user-list-search-corpus-indexing/src/commands/RemoveItem.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/commands/RemoveItem.ts
@@ -1,0 +1,21 @@
+import { ValidLanguageApprovedItemPayload } from '../types';
+import { config } from '../config';
+
+/**
+ * Remove an "ApprovedItem" from the search cluster.
+ * Returns commands for bulk operation.
+ * Note that this will not work for deleting parent copies
+ * of Collections in the Curated Corpus. We could do a lookup
+ * similar to how the records are merged when a copy is made
+ * in the corpus, but I don't think this matches the business
+ * logic. The Collection entity should be the source of truth,
+ * not the copy of the parent in the corpus. We already do not
+ * return results if the Collection is archived.
+ * TODO - Model how Collections are deleted.
+ */
+export function removeApprovedItem(
+  event: ValidLanguageApprovedItemPayload,
+): Array<any> {
+  const index = config.indexLangMap[event.language.toLowerCase()];
+  return [{ delete: { _index: index, _id: event.approvedItemExternalId } }];
+}

--- a/lambdas/user-list-search-corpus-indexing/src/index.integration.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/index.integration.ts
@@ -400,6 +400,26 @@ describe('bulk indexer', () => {
     );
     expect(mergedRecord.found).toEqual(false);
   });
+  describe('remove item', () => {
+    it('deletes an existing record', async () => {
+      await processor(exampleInvocationPayload);
+      const id = '3ab75776-42a1-4a54-a6d2-032fbec195eb';
+      expect((await getDocById('corpus_en_luc', id)).found).toEqual(true);
+      const res = await processor({ Records: [deleteRecord] });
+      expect((await getDocById('corpus_en_luc', id)).found).toEqual(false);
+      expect(res).toEqual({
+        batchItemFailures: [],
+      });
+    });
+    it('does not throw error if the record to be deleted does not exist', async () => {
+      const id = '3ab75776-42a1-4a54-a6d2-032fbec195eb';
+      const res = await processor({ Records: [deleteRecord] });
+      expect((await getDocById('corpus_en_luc', id)).found).toEqual(false);
+      expect(res).toEqual({
+        batchItemFailures: [],
+      });
+    });
+  });
   describe('with errors', () => {
     beforeAll(() =>
       jest
@@ -519,4 +539,24 @@ const exampleInvocationPayload = {
       awsRegion: 'us-east-1',
     },
   ],
+};
+
+const deleteRecord = {
+  messageId: '9f9792df-ab70-4884-8b72-cee0b8340afa',
+  receiptHandle:
+    'AQEBN1gA3AxoGK5y86v2mQGNkUJaBIl6K7KtdyEOnBmKgktdTL0fLppwhXWkgq/jrb5nr/uxvMCCFioPbfv5OaBgcSo/yRgj1PLet17pTKmEkczuIqF4MNH/SsiwmgyuG6lKMla53r8qzOoxmckb/Zie3gQ414Bok0AJc4+ts8MvKvwFmCUZgu9aeIzVzDuL1nOpJMda+Q0RxTEltZCmEJKr8cO8oZsy3po5wg9rFk6ITi0k19B76qlq3UTqXj6jB6BokL8z7Qq0JASfXGAxDGFRHg5riK1U5SG+pgfoFGJMfl/bwq+ZR9PrMTAE3+zmMcIZNVxAWeIljrAbgoUw7P5klYQScEsx9hjLn1TnYmHgYxEKQRSCoQv+K1OtaOBIG1xHQkSSakQ0HjkI/5nsrakIfZMsM0GuYrPKFF8QWCCSiyg=',
+  body: '{\n  "Type" : "Notification",\n  "MessageId" : "fe2cd9e6-4978-5680-84e0-8712b3052acf",\n  "TopicArn" : "arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-CorpusEventsTopic",\n  "Message" : "{\\"version\\":\\"0\\",\\"id\\":\\"ad060d80-ac54-cc42-5902-b3e4aef2a6dd\\",\\"detail-type\\":\\"remove-approved-item\\",\\"source\\":\\"curation-migration-datasync\\",\\"account\\":\\"996905175585\\",\\"time\\":\\"2024-06-25T17:02:53Z\\",\\"region\\":\\"us-east-1\\",\\"resources\\":[],\\"detail\\":{\\"eventType\\":\\"remove-approved-item\\",\\"approvedItemExternalId\\":\\"3ab75776-42a1-4a54-a6d2-032fbec195eb\\",\\"url\\":\\"https://snackstack.net/2024/05/25/uh-oh-a-story-of-spaghettios-and-forgotten-history/\\",\\"title\\":\\"Uh-Oh: A Story of SpaghettiOs and Forgotten History\\",\\"excerpt\\":\\"In which a pasta-filled rabbit hole leads to an unexpected place.\\",\\"language\\":\\"EN\\",\\"publisher\\":\\"Snack Stack\\",\\"imageUrl\\":\\"https://s3.us-east-1.amazonaws.com/pocket-curatedcorpusapi-prod-images/b853f9bf-ea90-4280-b738-4feef27a4630.jpeg\\",\\"topic\\":\\"FOOD\\",\\"isSyndicated\\":false,\\"createdAt\\":\\"Tue, 25 Jun 2024 16:01:19 GMT\\",\\"createdBy\\":\\"ad|Mozilla-LDAP|mjeltsen\\",\\"updatedAt\\":\\"Tue, 25 Jun 2024 17:02:52 GMT\\",\\"authors\\":[{\\"externalId\\":\\"492ca986-b2b9-492c-a63d-0b0a713a5885\\",\\"name\\":\\"Doug Mack\\",\\"approvedItemId\\":175874,\\"sortOrder\\":0}],\\"isCollection\\":false,\\"domainName\\":\\"snackstack.net\\",\\"datePublished\\":\\"Sat, 25 May 2024 00:00:00 GMT\\",\\"isTimeSensitive\\":false,\\"source\\":\\"MANUAL\\"}}",\n  "Timestamp" : "2024-06-25T17:02:53.154Z",\n  "SignatureVersion" : "1",\n  "Signature" : "BTyAyJAO53xzanvuF5MAopx839LZJgVtUBym1fBn6nCjs7IhonSheqt1T3Afq4TWB3y8VV5hBcaTFqQqSlLCWjPzM8xbfBYL1gP6Ddasxnv2VR77qdhY8c8HmsYEuXO4WvJxqe8YOWVQHVgpegjuyTScaaCWxVztoDYC7O55KUG7hc/oJJw+RoxYNshtyTfEYVHQuV23zbWaNvp4GsbjEjOGcBb7BLTA10H2HPW9SxrU4IhMitgvuJm83Q57z0/6glheWL/aqYyjokaEgyAMTmypJNRflxv6OlVg1TTdcz31gozbIyg8P+q+LgNmUrxq+7NdgB0bp+fA9OFUSkPktQ==",\n  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-60eadc530605d63b8e62a523676ef735.pem",\n  "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:996905175585:PocketEventBridge-Prod-CorpusEventsTopic:95ac785f-1b3b-48e1-bf91-4f8583bd6ebd"\n}',
+  attributes: {
+    ApproximateReceiveCount: '1',
+    SentTimestamp: '1719600803083',
+    SenderId: 'AROAV7CHE6FNH4IKR3U2R:kschelonka@mozilla.com',
+    ApproximateFirstReceiveTimestamp: '1719600803092',
+  },
+  messageAttributes: {},
+  md5OfMessageAttributes: undefined,
+  md5OfBody: '09fb67b7b9f0899db20fbec34d77092e',
+  eventSource: 'aws:sqs',
+  eventSourceARN:
+    'arn:aws:sqs:us-east-1:410318598490:UserListSearch-Dev-CorpusEvents',
+  awsRegion: 'us-east-1',
 };

--- a/lambdas/user-list-search-corpus-indexing/src/types.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/types.ts
@@ -41,6 +41,7 @@ export const validDetailTypes = [
   'update-approved-item',
   'collection-created',
   'collection-updated',
+  'remove-approved-item',
 ];
 
 type Author = { name: string; sortOrder: number };


### PR DESCRIPTION
Delete items in search index when 'remove-approved-item' event is received.

Does not delete Curated Corpus copy of collections (is this even a valid flow?) since the collection entity should be the source of truth. Will need to connect at some point if data cleanup is required here, but we already hide collections that are not the 'published' status so it's low risk and priority.

Manual testing completed in dev starting from curation tool.