### PR TITLE
feat(search): ingest isTimeSensitive field

### DIFF
--- a/.docker/aws-resources/elasticsearch/esindex_corpus_de.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_de.json
@@ -32,6 +32,9 @@
       "is_syndicated": {
         "type": "boolean"
       },
+      "is_time_sensitive": {
+        "type": "boolean"
+      },
       "language": {
         "type": "keyword"
       },

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_en_luc.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_en_luc.json
@@ -32,6 +32,9 @@
       "is_syndicated": {
         "type": "boolean"
       },
+      "is_time_sensitive": {
+        "type": "boolean"
+      },
       "language": {
         "type": "keyword"
       },

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_es.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_es.json
@@ -32,6 +32,9 @@
       "is_syndicated": {
         "type": "boolean"
       },
+      "is_time_sensitive": {
+        "type": "boolean"
+      },
       "language": {
         "type": "keyword"
       },

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_fr.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_fr.json
@@ -32,6 +32,9 @@
       "is_syndicated": {
         "type": "boolean"
       },
+      "is_time_sensitive": {
+        "type": "boolean"
+      },
       "language": {
         "type": "keyword"
       },

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_it.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_it.json
@@ -32,6 +32,9 @@
       "is_syndicated": {
         "type": "boolean"
       },
+      "is_time_sensitive": {
+        "type": "boolean"
+      },
       "language": {
         "type": "keyword"
       },

--- a/lambdas/user-list-search-corpus-indexing/src/commands/ApprovedItem.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/commands/ApprovedItem.ts
@@ -31,6 +31,7 @@ export function upsertApprovedItem(event: ValidLanguageApprovedItemPayload) {
       quality_rank: event.grade
         ? config.gradeRankMap[event.grade.toLowerCase()]
         : undefined,
+      is_time_sensitive: event.isTimeSensitive,
     },
   ];
 }

--- a/lambdas/user-list-search-corpus-indexing/src/commands/ApprovedItemCollection.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/commands/ApprovedItemCollection.ts
@@ -30,6 +30,7 @@ export async function mergeCollection(event: CollectionApprovedItemPayload) {
           quality_rank: event.grade
             ? config.gradeRankMap[event.grade.toLowerCase()]
             : undefined,
+          is_time_sensitive: event.isTimeSensitive,
         },
       },
     ];

--- a/lambdas/user-list-search-corpus-indexing/src/index.integration.ts
+++ b/lambdas/user-list-search-corpus-indexing/src/index.integration.ts
@@ -165,6 +165,7 @@ describe('bulk indexer', () => {
           url: 'http://some-url.com',
           approvedItemExternalId: 'aaaaa',
           language: 'en',
+          isTimeSensitive: true,
         },
       },
     ];
@@ -176,6 +177,7 @@ describe('bulk indexer', () => {
       url: 'http://some-url.com',
       language: 'en',
       corpusId: 'aaaaa',
+      is_time_sensitive: true,
     });
   });
   it('successfully indexes a batch of corpus items', async () => {


### PR DESCRIPTION
isTimeSensitive is sent for Approved Items -- ingest it into the corpus now.

I have already updated the mappings for dev and prod search clusters.

[POCKET-10628]

[POCKET-10628]: https://mozilla-hub.atlassian.net/browse/POCKET-10628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ