### PR TITLE
fix(list): control read/write connection in users meta

### DIFF
--- a/servers/list-api/src/dataLoader/tagsDataLoader.spec.ts
+++ b/servers/list-api/src/dataLoader/tagsDataLoader.spec.ts
@@ -40,7 +40,6 @@ describe('tags dataloader', function () {
         headers: { userid: '1', apiid: '0', premium: 'true' },
       },
       dbClient: db,
-      writeClient: db,
       eventEmitter: null,
     });
     const savedItemService = new SavedItemDataService(context);
@@ -69,7 +68,6 @@ describe('tags dataloader', function () {
         headers: { userid: '1', apiid: '0', premium: 'true' },
       },
       dbClient: db,
-      writeClient: db,
       eventEmitter: null,
     });
     const savedItemService = new SavedItemDataService(context);
@@ -106,7 +104,6 @@ describe('tags dataloader', function () {
         headers: { userid: '1', apiid: '0', premium: 'true' },
       },
       dbClient: db,
-      writeClient: db,
       eventEmitter: null,
     });
     const savedItemService = new SavedItemDataService(context);

--- a/servers/list-api/src/models/tag.spec.ts
+++ b/servers/list-api/src/models/tag.spec.ts
@@ -27,7 +27,6 @@ describe('tag model', () => {
           headers: { userid: '1', apiid: '0', premium: 'true' },
         },
         dbClient: jest.fn() as unknown as Knex,
-        writeClient: jest.fn() as unknown as Knex,
         eventEmitter: null,
       });
       const resp = context.models.tag.getSuggestedBySaveId(parent);
@@ -41,7 +40,6 @@ describe('tag model', () => {
           headers: { userid: '1', apiid: '0', premium: 'false' },
         },
         dbClient: jest.fn() as unknown as Knex,
-        writeClient: jest.fn() as unknown as Knex,
         eventEmitter: null,
       });
       const resp = context.models.tag.getSuggestedBySaveId(parent);

--- a/servers/list-api/src/server/apollo.ts
+++ b/servers/list-api/src/server/apollo.ts
@@ -85,7 +85,6 @@ export async function startServer(port: number): Promise<{
     return new ContextManager({
       request: req,
       dbClient,
-      writeClient: writeClient(),
       eventEmitter: itemsEventEmitter,
       unleash: unleashClient,
     });

--- a/servers/list-api/src/server/context.spec.ts
+++ b/servers/list-api/src/server/context.spec.ts
@@ -46,7 +46,6 @@ describe('context', () => {
             headers: { userid: '1', ...headers },
           },
           dbClient: jest.fn() as unknown as Knex,
-          writeClient: jest.fn() as unknown as Knex,
           eventEmitter: new ItemsEventEmitter(),
         });
         // Mock out the scope methods used in the configureScope callback
@@ -70,7 +69,6 @@ describe('context', () => {
         headers: { userid: '1', apiid: '0' },
       } as unknown as Request,
       dbClient: jest.fn() as unknown as Knex,
-      writeClient: jest.fn() as unknown as Knex,
       eventEmitter: new ItemsEventEmitter(),
     });
     beforeEach(() => {
@@ -143,7 +141,6 @@ describe('context', () => {
           headers: { userid: '1', apiid: '0' },
         },
         dbClient: jest.fn() as unknown as Knex,
-        writeClient: jest.fn() as unknown as Knex,
         eventEmitter: null,
       });
     });

--- a/servers/list-api/src/server/context.ts
+++ b/servers/list-api/src/server/context.ts
@@ -27,7 +27,6 @@ export interface IContext {
   apiId: string;
   userIsPremium: boolean;
   dbClient: Knex;
-  writeClient: Knex;
   eventEmitter: ItemsEventEmitter;
   unleash: Unleash;
   models: {
@@ -62,14 +61,12 @@ export class ContextManager implements IContext {
     private config: {
       request: any;
       dbClient: Knex;
-      writeClient: Knex;
       eventEmitter: ItemsEventEmitter;
       unleash?: Unleash;
     },
   ) {
     this.unleash = config.unleash || getClient();
     this._dbClient = config.dbClient;
-    this._writeClient = config.writeClient;
     this.dataLoaders = {
       ...createTagDataLoaders(this),
       ...createSavedItemDataLoaders(this),
@@ -133,10 +130,6 @@ export class ContextManager implements IContext {
 
   get dbClient(): Knex {
     return this._dbClient;
-  }
-
-  get writeClient(): Knex {
-    return this._writeClient;
   }
 
   /**

--- a/servers/list-api/src/test/integrations/savedItemsService.integration.ts
+++ b/servers/list-api/src/test/integrations/savedItemsService.integration.ts
@@ -53,7 +53,6 @@ describe('SavedItemsService', () => {
         headers: { userid: '1', apiid: '0' },
       },
       dbClient: readClient(),
-      writeClient: writeClient(),
       eventEmitter: null,
     });
 
@@ -71,7 +70,6 @@ describe('SavedItemsService', () => {
         headers: { userid: '1', apiid: '0' },
       },
       dbClient: readClient(),
-      writeClient: writeClient(),
       eventEmitter: null,
     });
 
@@ -89,7 +87,6 @@ describe('SavedItemsService', () => {
         headers: { userid: '1', apiid: '0' },
       },
       dbClient: readClient(),
-      writeClient: writeClient(),
       eventEmitter: null,
     });
 
@@ -106,7 +103,6 @@ describe('SavedItemsService', () => {
         headers: { userid: '1', apiid: '0' },
       },
       dbClient: readClient(),
-      writeClient: writeClient(),
       eventEmitter: null,
     });
 
@@ -123,7 +119,6 @@ describe('SavedItemsService', () => {
         headers: { userid: '1', apiid: '0' },
       },
       dbClient: readClient(),
-      writeClient: writeClient(),
       eventEmitter: null,
     });
 
@@ -168,7 +163,6 @@ describe('SavedItemsService', () => {
           headers: { userid: '1', apiid: '0' },
         },
         dbClient: writeClient(),
-        writeClient: writeClient(),
         eventEmitter: null,
       });
       await new SavedItemDataService(context).deleteSavedItem(itemId);

--- a/servers/list-api/src/test/integrations/usersMetaService.integration.ts
+++ b/servers/list-api/src/test/integrations/usersMetaService.integration.ts
@@ -15,7 +15,6 @@ describe('UsersMetaService ', () => {
       },
     },
     dbClient: readDb,
-    writeClient: writeDb,
     eventEmitter: null,
   });
   const currentTime = new Date();


### PR DESCRIPTION
Users meta can be written to as a side effect of certain v3 queries (e.g. tagslist). Previously the writer was toggled on to be used for everything to avoid a permissions error, but this resulted in heavy load on the writer node once the v3-proxy fully came online, as most v3 queries also make a read request on the users meta table (due to `tagslist`). This update uses the read-only user for read queries rather than the writer or the dynamically set connection based on operation (query/mutation). Since we don't care about the return value of any changed results on this table, we do not need to worry about managing the connection to avoid issues with eventual consistency (replication delay).