### PR TITLE
fix(tagsList): ensure we don't pass tagsSince if forced was passed

### DIFF
--- a/servers/v3-proxy-api/src/routes/v3Get.ts
+++ b/servers/v3-proxy-api/src/routes/v3Get.ts
@@ -95,7 +95,7 @@ export async function processV3call(
   // This time is only set if taglist is requested and 'since' is provided;
   // 'forcetaglist' overrides the 'since' check
   const tagListSince =
-    data.taglist && data.since
+    data.taglist && data.since && !data.forcetaglist
       ? new Date(data.since * 1000).toISOString()
       : undefined;
   if (tagListSince) options['tagListSince'] = tagListSince;


### PR DESCRIPTION
## Goal

Android calls /v3/get after initial login with a forced tag list option. This is what returns all a users tags to Android for local use.   When this option is passed, we should not pass a since timestamp to the tags query

https://mozilla-hub.atlassian.net/browse/POCKET-10649