### PR TITLE
fix(accessToken): make the access token optional to allow for cookie auth

### DIFF
--- a/servers/v3-proxy-api/src/routes/v3Add.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Add.integration.ts
@@ -139,4 +139,31 @@ describe('v3Add', () => {
       expect(response.headers['x-source']).toBe(expectedHeaders['X-Source']);
     });
   });
+
+  describe('with enable_cors', () => {
+    let requestSpy;
+    beforeAll(() => {
+      requestSpy = jest
+        .spyOn(GraphQLClient.prototype, 'request')
+        .mockResolvedValue({
+          upsertSavedItem: mockGraphAddResponses[0],
+        });
+    });
+    afterEach(() => requestSpy.mockClear());
+    it('calls upsert once, with enabled_cors=1 and no access_token', async () => {
+      const response = await request(app).post('/v3/add').send({
+        consumer_key: 'test',
+        enable_cors: '1',
+        url: 'https://isithalloween.com',
+      });
+      expect(requestSpy).toHaveBeenCalledTimes(1);
+      // Struggling with a matcher for toHaveBeenCalledWith... the call signature is nasty
+      // on these functions
+      expect(requestSpy.mock.calls[0].length).toEqual(2);
+      expect((requestSpy.mock.calls[0] as any)[1]).toEqual({
+        input: { timestamp: now / 1000, url: 'https://isithalloween.com' },
+      });
+      expect(response.headers['x-source']).toBe(expectedHeaders['X-Source']);
+    });
+  });
 });

--- a/servers/v3-proxy-api/src/routes/validations/AddSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/AddSchema.ts
@@ -22,6 +22,7 @@ export type V3AddParams = {
  */
 export const V3AddSchema: Schema = {
   access_token: {
+    optional: true,
     isString: true,
     notEmpty: {
       errorMessage: '`access_token` cannot be empty',

--- a/servers/v3-proxy-api/src/routes/validations/FetchSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/FetchSchema.ts
@@ -30,6 +30,7 @@ export type V3FetchParams = {
  */
 export const V3FetchSchema: Schema = {
   access_token: {
+    optional: true,
     isString: true,
     notEmpty: {
       errorMessage: '`access_token` cannot be empty',


### PR DESCRIPTION
# Goal

The access token needs to be optional so that we can allow cookie based auth on requests made to v3 that pass to getpocket.com/graphql