### PR TITLE
fix(v3proxy): state default to unread

### DIFF
--- a/servers/v3-proxy-api/src/routes/v3Get.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Get.integration.ts
@@ -1124,6 +1124,7 @@ describe('v3Get', () => {
         consumer_key: 'test',
         access_token: 'test',
         detailType: 'complete',
+        state: 'all',
       });
       expect(apiSpy.mock.lastCall?.[3].filter).toBeUndefined();
       expect(response.headers['x-source']).toBe(expectedHeaders['X-Source']);

--- a/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
@@ -61,8 +61,10 @@ export const V3GetSchema: Schema = {
     },
   },
   state: {
-    optional: true,
     toLowerCase: true,
+    default: {
+      options: 'unread',
+    },
     isIn: {
       // The following legacy filters for state are omitted
       // (0-1 requests in past year as of 2024-02 - 23)


### PR DESCRIPTION
update the default state to match our 3rd party dev docs

cc @marcin-kozinski to confirm this change in default is OK with android requests