### PR TITLE
fix(otel): updating google cloud timeout

### DIFF
--- a/servers/otel-collector/otel-collector-config.yaml
+++ b/servers/otel-collector/otel-collector-config.yaml
@@ -12,6 +12,8 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry.io/collector-exported-log
+    # https://www.googlecloudcommunity.com/gc/Data-Analytics/OpenTelemetry-and-GKE/m-p/674090/highlight/true#M3861
+    timeout: 45s
   # debug:
   #   verbosity: detailed
 processors:


### PR DESCRIPTION
## Goal

According to https://www.googlecloudcommunity.com/gc/Data-Analytics/OpenTelemetry-and-GKE/m-p/674090/highlight/true#M3861  we need to increase the timeout. The default is 12s