### PR TITLE
fix(graphql): ensuring we get graphql values in traces

### DIFF
--- a/packages/tracing/src/tracing.ts
+++ b/packages/tracing/src/tracing.ts
@@ -176,6 +176,7 @@ export async function nodeSDKBuilder(config: TracingConfig) {
       },
       '@opentelemetry/instrumentation-graphql': {
         ignoreTrivialResolveSpans: true,
+        allowValues: true,
       },
     }),
   ];

--- a/servers/v3-proxy-api/src/graph/graphQLClient.ts
+++ b/servers/v3-proxy-api/src/graph/graphQLClient.ts
@@ -91,6 +91,8 @@ export class GraphQLClientFactory {
     delete headers['host'];
     delete headers['accept-encoding'];
     delete headers['connection'];
+    // Delete the header so that Fetch will auto add its own from the instrumentation with the right span.
+    delete headers['x-amzn-trace-id'];
 
     // add in that this is the proxy to the graphql call
     headers['apollographql-client-name'] = config.app.serviceName;


### PR DESCRIPTION
## Goal

We need values to ensure that we can debug issues from our traces. The instrumentation will auto remove sensitive values should they exist.


Also fixing an issue in the v3 proxy where it would not add a header for downstream requests.