### PR TITLE
fix(sentry): ensure sentry tagging checks body

### DIFF
--- a/packages/tracing/src/tracing.ts
+++ b/packages/tracing/src/tracing.ts
@@ -213,7 +213,10 @@ export async function nodeSDKBuilder(config: TracingConfig) {
   });
   const sdk = new NodeSDK({
     textMapPropagator: new CompositePropagator({
-      propagators: [new AWSXRayPropagator(), new SentryPropagator()],
+      // The Propogators are run in the order they are added, and since we want the AWSXRAY to win,
+      // it must come last because it writes the parent context "sampled" data from the trace into the contexts
+      // We Keep Sentry in here, because it adds data that Sentry needs, we just don't want it to control the sample value.
+      propagators: [new SentryPropagator(), new AWSXRayPropagator()],
     }),
     instrumentations,
     sampler: new SentryParentSampler({

--- a/servers/v3-proxy-api/src/middleware/sentryTagHandler.ts
+++ b/servers/v3-proxy-api/src/middleware/sentryTagHandler.ts
@@ -16,7 +16,7 @@ export function sentryTagHandler(
   next: NextFunction,
 ) {
   const scope = Sentry.getCurrentScope();
-  const consumerKey = req.query.consumer_key;
+  const consumerKey = req.query.consumer_key ?? req.body.consumer_key;
   if (consumerKey == null || typeof consumerKey !== 'string') {
     scope.setTag('pocket-api-id', undefined);
     next();


### PR DESCRIPTION
# Goal

Consumer keys can come in via bodies as well as queries.


Also add in a fix to swap the priorty order of Sentry and Xray trace headers, priortizing XRay. (XRay must come last because the proprogators both write data into the same context key (sample data), and the XRay one must win.)