### PR TITLE
fix(bools): allowing true/false in a post body for v3

### DIFF
--- a/servers/v3-proxy-api/src/generated/graphql/types.ts
+++ b/servers/v3-proxy-api/src/generated/graphql/types.ts
@@ -1233,6 +1233,11 @@ export type Mutation = {
    */
   expireUserWebSessionByFxaId: Scalars['ID']['output'];
   /**
+   * Request for an asynchronous export of a user's list.
+   * Returns the request ID associated with the request.
+   */
+  exportList?: Maybe<Scalars['String']['output']>;
+  /**
    * temporary mutation for apple user migration.
    * called by fxa-webhook proxy to update the fxaId and email of the user.
    * Returns the pocket userId on success

--- a/servers/v3-proxy-api/src/routes/v3Fetch.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Fetch.integration.ts
@@ -93,6 +93,7 @@ describe('v3Fetch', () => {
         requestData: {
           detailType: 'complete',
           shares: '1',
+          annotations: '1',
         },
         fixture: {
           requestName: 'callSavedItemsByOffsetComplete' as const,
@@ -112,6 +113,7 @@ describe('v3Fetch', () => {
       {
         requestData: {
           detailType: 'complete',
+          annotations: '1',
         },
         fixture: {
           requestName: 'callSavedItemsByOffsetComplete' as const,
@@ -120,6 +122,48 @@ describe('v3Fetch', () => {
         expected: {
           name: 'savedItemsComplete',
           response: { ...expectedGetCompleteAnnotations, total: '10' },
+        },
+      },
+      {
+        requestData: {
+          detailType: 'complete',
+          shares: true,
+          annotations: true,
+        },
+        fixture: {
+          requestName: 'callSavedItemsByOffsetComplete' as const,
+          requestData: mockGraphGetCompleteAnnotations,
+        },
+        expected: {
+          name: 'savedItemsComplete',
+          response: {
+            ...expectedGetCompleteAnnotations,
+            recent_friends: [],
+            auto_complete_emails: [],
+            unconfirmed_shares: [],
+            total: '10',
+          },
+        },
+      },
+      {
+        requestData: {
+          detailType: 'complete',
+          shares: 'true',
+          annotations: 'true',
+        },
+        fixture: {
+          requestName: 'callSavedItemsByOffsetComplete' as const,
+          requestData: mockGraphGetCompleteAnnotations,
+        },
+        expected: {
+          name: 'savedItemsComplete',
+          response: {
+            ...expectedGetCompleteAnnotations,
+            recent_friends: [],
+            auto_complete_emails: [],
+            unconfirmed_shares: [],
+            total: '10',
+          },
         },
       },
     ])(
@@ -135,7 +179,6 @@ describe('v3Fetch', () => {
             ...requestData,
             consumer_key: 'test',
             access_token: 'test',
-            annotations: '1',
           });
         const passthrough = {
           chunk: '0',
@@ -161,6 +204,7 @@ describe('v3Fetch', () => {
         requestData: {
           detailType: 'complete',
           shares: '1',
+          taglist: '1',
         },
         fixture: {
           requestName: 'callSavedItemsByOffsetComplete' as const,
@@ -181,6 +225,37 @@ describe('v3Fetch', () => {
         requestData: {
           detailType: 'complete',
           total: '1',
+          taglist: '1',
+        },
+        fixture: {
+          requestName: 'callSavedItemsByOffsetComplete' as const,
+          requestData: mockGraphGetCompleteTagsList,
+        },
+        expected: {
+          name: 'savedItemsComplete',
+          response: { ...expectedGetCompleteTagslist, total: '10' },
+        },
+      },
+      {
+        requestData: {
+          detailType: 'complete',
+          total: 'true',
+          taglist: 'true',
+        },
+        fixture: {
+          requestName: 'callSavedItemsByOffsetComplete' as const,
+          requestData: mockGraphGetCompleteTagsList,
+        },
+        expected: {
+          name: 'savedItemsComplete',
+          response: { ...expectedGetCompleteTagslist, total: '10' },
+        },
+      },
+      {
+        requestData: {
+          detailType: 'complete',
+          total: true,
+          taglist: true,
         },
         fixture: {
           requestName: 'callSavedItemsByOffsetComplete' as const,
@@ -205,7 +280,6 @@ describe('v3Fetch', () => {
             ...requestData,
             consumer_key: 'test',
             access_token: 'test',
-            taglist: '1',
             since: 1712766000,
           });
         const passthrough = {

--- a/servers/v3-proxy-api/src/routes/v3Get.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Get.integration.ts
@@ -345,6 +345,36 @@ describe('v3Get', () => {
           response: { ...expectedGetSimpleAnnotations, total: '10' },
         },
       },
+      {
+        requestData: {
+          detailType: 'simple',
+          total: '1',
+          annotations: 'true',
+        },
+        fixture: {
+          requestName: 'callSavedItemsByOffsetSimple' as const,
+          requestData: mockGraphGetSimpleAnnotations,
+        },
+        expected: {
+          name: 'savedItemsSimple',
+          response: { ...expectedGetSimpleAnnotations, total: '10' },
+        },
+      },
+      {
+        requestData: {
+          detailType: 'simple',
+          total: '1',
+          annotations: true,
+        },
+        fixture: {
+          requestName: 'callSavedItemsByOffsetSimple' as const,
+          requestData: mockGraphGetSimpleAnnotations,
+        },
+        expected: {
+          name: 'savedItemsSimple',
+          response: { ...expectedGetSimpleAnnotations, total: '10' },
+        },
+      },
     ])(
       'makes request with annotations',
       async ({ requestData, fixture, expected }) => {
@@ -355,10 +385,10 @@ describe('v3Get', () => {
         const response = await request(app)
           .get('/v3/get')
           .query({
-            ...requestData,
             consumer_key: 'test',
             access_token: 'test',
             annotations: '1',
+            ...requestData,
           });
         expect(response.body).toEqual(expected.response);
         expect(requestSpy).toHaveBeenCalledTimes(1);
@@ -495,6 +525,34 @@ describe('v3Get', () => {
         fixture: {
           requestName: 'callSavedItemsByOffsetSimple' as const,
           requestData: mockGraphGetSimpleFreeAccountNullFeatures,
+        },
+        expected: {
+          name: 'savedItemsSimple',
+          response: expectedGetSimpleFreeAccount,
+        },
+      },
+      {
+        requestData: {
+          detailType: 'simple',
+          forceaccount: 'true',
+        },
+        fixture: {
+          requestName: 'callSavedItemsByOffsetSimple' as const,
+          requestData: mockGraphGetSimpleFreeAccount,
+        },
+        expected: {
+          name: 'savedItemsSimple',
+          response: expectedGetSimpleFreeAccount,
+        },
+      },
+      {
+        requestData: {
+          detailType: 'simple',
+          forceaccount: true,
+        },
+        fixture: {
+          requestName: 'callSavedItemsByOffsetSimple' as const,
+          requestData: mockGraphGetSimpleFreeAccount,
         },
         expected: {
           name: 'savedItemsSimple',
@@ -656,6 +714,34 @@ describe('v3Get', () => {
           response: { ...expectedGetSimple, recent_searches: [] },
         },
       },
+      {
+        requestData: {
+          detailType: 'simple',
+          forcepremium: true,
+        },
+        fixture: {
+          requestName: 'callSavedItemsByOffsetSimple' as const,
+          requestData: mockGraphGetSimpleFreeRecentSearches,
+        },
+        expected: {
+          name: 'savedItemsSimple',
+          response: expectedGetSimple,
+        },
+      },
+      {
+        requestData: {
+          detailType: 'simple',
+          forcepremium: 'true',
+        },
+        fixture: {
+          requestName: 'callSavedItemsByOffsetSimple' as const,
+          requestData: mockGraphGetSimpleFreeRecentSearches,
+        },
+        expected: {
+          name: 'savedItemsSimple',
+          response: expectedGetSimple,
+        },
+      },
     ])(
       'makes request with recent searches data',
       async ({ requestData, fixture, expected }) => {
@@ -806,6 +892,38 @@ describe('v3Get', () => {
           response: { ...expectedGetSimpleTagslist, total: '10' },
         },
       },
+      {
+        requestData: {
+          detailType: 'simple',
+          search: 'abc',
+          sort: 'relevance',
+          taglist: true,
+        },
+        fixture: {
+          requestName: 'callSearchByOffsetSimple' as const,
+          requestData: freeTierSearchGraphSimpleTagList,
+        },
+        expected: {
+          name: 'searchSavedItemsSimple',
+          response: expectedFreeTierResponseSimpleTaglist,
+        },
+      },
+      {
+        requestData: {
+          detailType: 'simple',
+          search: 'abc',
+          sort: 'relevance',
+          taglist: 'true',
+        },
+        fixture: {
+          requestName: 'callSearchByOffsetSimple' as const,
+          requestData: freeTierSearchGraphSimpleTagList,
+        },
+        expected: {
+          name: 'searchSavedItemsSimple',
+          response: expectedFreeTierResponseSimpleTaglist,
+        },
+      },
     ])(
       'makes request with taglist',
       async ({ requestData, fixture, expected }) => {
@@ -817,11 +935,11 @@ describe('v3Get', () => {
         const response = await request(app)
           .get('/v3/get')
           .query({
-            ...requestData,
             consumer_key: 'test',
             access_token: 'test',
             taglist: '1',
             since: 1712766000,
+            ...requestData,
           });
         expect(response.body).toEqual(expected.response);
         expect(requestSpy).toHaveBeenCalledTimes(1);
@@ -881,6 +999,38 @@ describe('v3Get', () => {
           response: { ...expectedGetSimpleTagslist, total: '10' },
         },
       },
+      {
+        requestData: {
+          detailType: 'complete',
+          total: true,
+          taglist: true,
+          forcetaglist: true,
+        },
+        fixture: {
+          requestName: 'callSavedItemsByOffsetComplete' as const,
+          requestData: mockGraphGetCompleteTagsList,
+        },
+        expected: {
+          name: 'savedItemsComplete',
+          response: { ...expectedGetCompleteTagslist, total: '10' },
+        },
+      },
+      {
+        requestData: {
+          detailType: 'complete',
+          total: 'true',
+          taglist: 'true',
+          forcetaglist: 'true',
+        },
+        fixture: {
+          requestName: 'callSavedItemsByOffsetComplete' as const,
+          requestData: mockGraphGetCompleteTagsList,
+        },
+        expected: {
+          name: 'savedItemsComplete',
+          response: { ...expectedGetCompleteTagslist, total: '10' },
+        },
+      },
     ])(
       'makes request with taglist',
       async ({ requestData, fixture, expected }) => {
@@ -892,12 +1042,12 @@ describe('v3Get', () => {
         const response = await request(app)
           .get('/v3/get')
           .query({
-            ...requestData,
             consumer_key: 'test',
             access_token: 'test',
             taglist: '1',
             forcetaglist: '1',
             since: 1712766000,
+            ...requestData,
           });
         expect(response.body).toEqual(expected.response);
         expect(requestSpy).toHaveBeenCalledTimes(1);

--- a/servers/v3-proxy-api/src/routes/validations/FetchSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/FetchSchema.ts
@@ -102,10 +102,11 @@ export const V3FetchSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1', true, false]],
+      options: [['0', '1', true, false, 'true', 'false']],
     },
     customSanitizer: {
-      options: (value) => (value === '1' || value === true ? true : false),
+      options: (value) =>
+        value === '1' || value === true || value === 'true' ? true : false,
     },
   },
   annotations: {
@@ -113,10 +114,11 @@ export const V3FetchSchema: Schema = {
       options: '1',
     },
     isIn: {
-      options: [['0', '1', true, false]],
+      options: [['0', '1', true, false, 'true', 'false']],
     },
     customSanitizer: {
-      options: (value) => (value === '1' || value === true ? true : false),
+      options: (value) =>
+        value === '1' || value === true || value === 'true' ? true : false,
     },
   },
   taglist: {
@@ -124,10 +126,11 @@ export const V3FetchSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1', true, false]],
+      options: [['0', '1', true, false, 'true', 'false']],
     },
     customSanitizer: {
-      options: (value) => (value === '1' || value === true ? true : false),
+      options: (value) =>
+        value === '1' || value === true || value === 'true' ? true : false,
     },
   },
   forcetaglist: {
@@ -135,10 +138,11 @@ export const V3FetchSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1', true, false]],
+      options: [['0', '1', true, false, 'true', 'false']],
     },
     customSanitizer: {
-      options: (value) => (value === '1' || value === true ? true : false),
+      options: (value) =>
+        value === '1' || value === true || value === 'true' ? true : false,
     },
   },
   since: {
@@ -156,10 +160,11 @@ export const V3FetchSchema: Schema = {
   hasAnnotations: {
     optional: true,
     isIn: {
-      options: [['0', '1', true, false]],
+      options: [['0', '1', true, false, 'true', 'false']],
     },
     customSanitizer: {
-      options: (value) => (value === '1' || value === true ? true : false),
+      options: (value) =>
+        value === '1' || value === true || value === 'true' ? true : false,
     },
   },
 };

--- a/servers/v3-proxy-api/src/routes/validations/FetchSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/FetchSchema.ts
@@ -102,10 +102,10 @@ export const V3FetchSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1']],
+      options: [['0', '1', true, false]],
     },
     customSanitizer: {
-      options: (value) => (value === '1' ? true : false),
+      options: (value) => (value === '1' || value === true ? true : false),
     },
   },
   annotations: {
@@ -113,10 +113,10 @@ export const V3FetchSchema: Schema = {
       options: '1',
     },
     isIn: {
-      options: [['0', '1']],
+      options: [['0', '1', true, false]],
     },
     customSanitizer: {
-      options: (value) => (value === '1' ? true : false),
+      options: (value) => (value === '1' || value === true ? true : false),
     },
   },
   taglist: {
@@ -124,10 +124,10 @@ export const V3FetchSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1']],
+      options: [['0', '1', true, false]],
     },
     customSanitizer: {
-      options: (value) => (value === '1' ? true : false),
+      options: (value) => (value === '1' || value === true ? true : false),
     },
   },
   forcetaglist: {
@@ -135,10 +135,10 @@ export const V3FetchSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1']],
+      options: [['0', '1', true, false]],
     },
     customSanitizer: {
-      options: (value) => (value === '1' ? true : false),
+      options: (value) => (value === '1' || value === true ? true : false),
     },
   },
   since: {
@@ -156,10 +156,10 @@ export const V3FetchSchema: Schema = {
   hasAnnotations: {
     optional: true,
     isIn: {
-      options: [['0', '1']],
+      options: [['0', '1', true, false]],
     },
     customSanitizer: {
-      options: (value) => (value === '1' ? true : false),
+      options: (value) => (value === '1' || value === true ? true : false),
     },
   },
 };

--- a/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
@@ -137,10 +137,11 @@ export const V3GetSchema: Schema = {
   favorite: {
     optional: true,
     isIn: {
-      options: [['0', '1', true, false]],
+      options: [['0', '1', true, false, 'true', 'false']],
     },
     customSanitizer: {
-      options: (value) => (value === '1' || value === true ? true : false),
+      options: (value) =>
+        value === '1' || value === true || value === 'true' ? true : false,
     },
   },
   search: {
@@ -187,10 +188,11 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1', true, false]],
+      options: [['0', '1', true, false, 'true', 'false']],
     },
     customSanitizer: {
-      options: (value) => (value === '1' || value === true ? true : false),
+      options: (value) =>
+        value === '1' || value === true || value === 'true' ? true : false,
     },
   },
   annotations: {
@@ -198,10 +200,11 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1', true, false]],
+      options: [['0', '1', true, false, 'true', 'false']],
     },
     customSanitizer: {
-      options: (value) => (value === '1' || value === true ? true : false),
+      options: (value) =>
+        value === '1' || value === true || value === 'true' ? true : false,
     },
   },
   taglist: {
@@ -209,10 +212,11 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1', true, false]],
+      options: [['0', '1', true, false, 'true', 'false']],
     },
     customSanitizer: {
-      options: (value) => (value === '1' || value === true ? true : false),
+      options: (value) =>
+        value === '1' || value === true || value === 'true' ? true : false,
     },
   },
   forcetaglist: {
@@ -220,19 +224,21 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1', true, false]],
+      options: [['0', '1', true, false, 'true', 'false']],
     },
     customSanitizer: {
-      options: (value) => (value === '1' || value === true ? true : false),
+      options: (value) =>
+        value === '1' || value === true || value === 'true' ? true : false,
     },
   },
   hasAnnotations: {
     optional: true,
     isIn: {
-      options: [['0', '1', true, false]],
+      options: [['0', '1', true, false, 'true', 'false']],
     },
     customSanitizer: {
-      options: (value) => (value === '1' || value === true ? true : false),
+      options: (value) =>
+        value === '1' || value === true || value === 'true' ? true : false,
     },
   },
   account: {
@@ -240,10 +246,11 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1', true, false]],
+      options: [['0', '1', true, false, 'true', 'false']],
     },
     customSanitizer: {
-      options: (value) => (value === '1' || value === true ? true : false),
+      options: (value) =>
+        value === '1' || value === true || value === 'true' ? true : false,
     },
   },
   forceaccount: {
@@ -251,10 +258,11 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1', true, false]],
+      options: [['0', '1', true, false, 'true', 'false']],
     },
     customSanitizer: {
-      options: (value) => (value === '1' || value === true ? true : false),
+      options: (value) =>
+        value === '1' || value === true || value === 'true' ? true : false,
     },
   },
   premium: {
@@ -262,10 +270,11 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1', true, false]],
+      options: [['0', '1', true, false, 'true', 'false']],
     },
     customSanitizer: {
-      options: (value) => (value === '1' || value === true ? true : false),
+      options: (value) =>
+        value === '1' || value === true || value === 'true' ? true : false,
     },
   },
   forcepremium: {
@@ -273,10 +282,11 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1', true, false]],
+      options: [['0', '1', true, false, 'true', 'false']],
     },
     customSanitizer: {
-      options: (value) => (value === '1' || value === true ? true : false),
+      options: (value) =>
+        value === '1' || value === true || value === 'true' ? true : false,
     },
   },
 };

--- a/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/GetSchema.ts
@@ -137,10 +137,10 @@ export const V3GetSchema: Schema = {
   favorite: {
     optional: true,
     isIn: {
-      options: [['0', '1']],
+      options: [['0', '1', true, false]],
     },
     customSanitizer: {
-      options: (value) => (value === '1' ? true : false),
+      options: (value) => (value === '1' || value === true ? true : false),
     },
   },
   search: {
@@ -187,10 +187,10 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1']],
+      options: [['0', '1', true, false]],
     },
     customSanitizer: {
-      options: (value) => (value === '1' ? true : false),
+      options: (value) => (value === '1' || value === true ? true : false),
     },
   },
   annotations: {
@@ -198,10 +198,10 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1']],
+      options: [['0', '1', true, false]],
     },
     customSanitizer: {
-      options: (value) => (value === '1' ? true : false),
+      options: (value) => (value === '1' || value === true ? true : false),
     },
   },
   taglist: {
@@ -209,10 +209,10 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1']],
+      options: [['0', '1', true, false]],
     },
     customSanitizer: {
-      options: (value) => (value === '1' ? true : false),
+      options: (value) => (value === '1' || value === true ? true : false),
     },
   },
   forcetaglist: {
@@ -220,19 +220,19 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1']],
+      options: [['0', '1', true, false]],
     },
     customSanitizer: {
-      options: (value) => (value === '1' ? true : false),
+      options: (value) => (value === '1' || value === true ? true : false),
     },
   },
   hasAnnotations: {
     optional: true,
     isIn: {
-      options: [['0', '1']],
+      options: [['0', '1', true, false]],
     },
     customSanitizer: {
-      options: (value) => (value === '1' ? true : false),
+      options: (value) => (value === '1' || value === true ? true : false),
     },
   },
   account: {
@@ -240,10 +240,10 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1']],
+      options: [['0', '1', true, false]],
     },
     customSanitizer: {
-      options: (value) => (value === '1' ? true : false),
+      options: (value) => (value === '1' || value === true ? true : false),
     },
   },
   forceaccount: {
@@ -251,10 +251,10 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1']],
+      options: [['0', '1', true, false]],
     },
     customSanitizer: {
-      options: (value) => (value === '1' ? true : false),
+      options: (value) => (value === '1' || value === true ? true : false),
     },
   },
   premium: {
@@ -262,10 +262,10 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1']],
+      options: [['0', '1', true, false]],
     },
     customSanitizer: {
-      options: (value) => (value === '1' ? true : false),
+      options: (value) => (value === '1' || value === true ? true : false),
     },
   },
   forcepremium: {
@@ -273,10 +273,10 @@ export const V3GetSchema: Schema = {
       options: '0',
     },
     isIn: {
-      options: [['0', '1']],
+      options: [['0', '1', true, false]],
     },
     customSanitizer: {
-      options: (value) => (value === '1' ? true : false),
+      options: (value) => (value === '1' || value === true ? true : false),
     },
   },
 };


### PR DESCRIPTION
## Goal

I noticed https://pocket.sentry.io/issues/5623927204/events/93e309e8c6a54ef5bc55fb0b1102beb5/?project=4504658424102912 errors are all using booleans in the post bodies. 

This adds back that support that Web Repo supported