### PR TITLE
fix(apiId): update the regex to use a named capture group

### DIFF
--- a/servers/v3-proxy-api/src/utils.ts
+++ b/servers/v3-proxy-api/src/utils.ts
@@ -10,8 +10,8 @@ import config from './config';
  * format is prefixed by "<api_id>-"
  */
 export function parseApiId(consumerKey: string): number | undefined {
-  const re = new RegExp(/^(\d+)-[\w\d]+/);
-  const apiId = consumerKey.match(re)?.[0];
+  const re = new RegExp(/^(?<apiId>\d+)-[\w\d]+/i);
+  const apiId = consumerKey.match(re)?.groups?.apiId;
   return apiId != null ? parseInt(apiId) : undefined;
 }
 


### PR DESCRIPTION
# Goal

The api id was not parsing into sentry. This updates to use a named capture group to specifically pull out its data. 

Note: no idea why the other one worked in tests, but not in a debugger context.