### PR TITLE
fix(v3): bumping task sizes for v3 proxy

### DIFF
--- a/infrastructure/v3-proxy-api/src/main.ts
+++ b/infrastructure/v3-proxy-api/src/main.ts
@@ -88,6 +88,10 @@ class Stack extends TerraformStack {
       tags: config.tags,
       cdn: false,
       domain: config.domain,
+      taskSize: {
+        cpu: config.isDev ? 2048 : 4096,
+        memory: config.isDev ? 4096 : 8192,
+      },
       accessLogs: {
         existingBucket: config.s3LogsBucket,
       },
@@ -184,7 +188,7 @@ class Stack extends TerraformStack {
           'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy',
       },
       autoscalingConfig: {
-        targetMinCapacity: config.isDev ? 1 : 4,
+        targetMinCapacity: config.isDev ? 1 : 8,
         targetMaxCapacity: 20,
       },
       alarms: {


### PR DESCRIPTION
# Goal

Given that this service gets hit from IFTT and other third parties, bumping up the task sizes and task count to avoid 504 errors.