### PR TITLE
fix(v3): move the v3 proxy to be external for CDN

### DIFF
--- a/infrastructure/v3-proxy-api/src/main.ts
+++ b/infrastructure/v3-proxy-api/src/main.ts
@@ -81,8 +81,7 @@ class Stack extends TerraformStack {
     const { region, caller, secretsManagerKmsAlias, snsTopic } = dependencies;
 
     return new PocketALBApplication(this, 'application', {
-      // TODO: "internal: true" deploys service behind VPN, set false or remove this comment
-      internal: true,
+      internal: false,
       prefix: config.prefix,
       alb6CharacterPrefix: config.shortName,
       tags: config.tags,


### PR DESCRIPTION
# Goal

Support moving v3 proxy to be direct behind our CDN instead of web repo.

Given this proxies to Web repo this is safe. We will want to update to only allow requests via the CDN like web repo [does](https://github.com/Pocket/Web/blob/main/.aws/production/public_alb.tf#L260-L261), in the future.

https://mozilla-hub.atlassian.net/browse/POCKET-10700
