### PR TITLE
fix(export): ensure csv written for small exports

### DIFF
--- a/servers/account-data-deleter/src/dataService/listDataExportService.spec.ts
+++ b/servers/account-data-deleter/src/dataService/listDataExportService.spec.ts
@@ -20,6 +20,9 @@ describe('ListDataExportService', () => {
     expect(notifySpy).toHaveBeenCalledExactlyOnceWith('1a234d', '12345');
   });
   it('notifies that the request is finished if there is no more data left', async () => {
+    const writeSpy = jest
+      .spyOn(S3Bucket.prototype, 'writeCsv')
+      .mockResolvedValue(true);
     jest.spyOn(exporter, 'fetchListData').mockResolvedValue([
       {
         cursor: 1,
@@ -45,6 +48,7 @@ describe('ListDataExportService', () => {
       '12345',
       'http://your-archive.zip',
     );
+    expect(writeSpy).toHaveBeenCalledOnce();
   });
   it('requests the next chunk using the cursor, incrementing the part', async () => {
     jest.spyOn(exporter, 'fetchListData').mockResolvedValue([

--- a/servers/account-data-deleter/src/dataService/listDataExportService.ts
+++ b/servers/account-data-deleter/src/dataService/listDataExportService.ts
@@ -121,6 +121,10 @@ export class ListDataExportService {
       }
       // We're finished!
       else if (entries.length <= size) {
+        await this.exportBucket.writeCsv(
+          entries,
+          `${this.partsPrefix}/part_${part.toString().padStart(6, '0')}`,
+        );
         serverLogger.info({
           message: 'ListDataExportService - zipping files',
           requestId,

--- a/servers/account-data-deleter/src/dataService/s3Service.ts
+++ b/servers/account-data-deleter/src/dataService/s3Service.ts
@@ -97,7 +97,7 @@ export class S3Bucket {
       const fileKeys = await this.listAllObjects(prefix);
       if (fileKeys != null && fileKeys.length > 0) {
         const archive = await this.streamObjectsArchive(fileKeys);
-        serverLogger.debug({
+        serverLogger.info({
           message: 'Archiving export files',
           archiveLen: fileKeys.length,
           prefix,


### PR DESCRIPTION
Fixes a bug where if the CSV was done in one round, it would not be written to the bucket.