### PR TITLE
fix(corpusItem): update the preview field under a corpus Item to use a corpus item id

### DIFF
--- a/servers/parser-graphql-wrapper/schema.graphql
+++ b/servers/parser-graphql-wrapper/schema.graphql
@@ -175,7 +175,7 @@ type Item
   "The client preview/display logic for this url. The requires for each object should be kept in sync with the sub objects requires field."
   preview: PocketMetadata
     @requires(
-      fields: "syndicatedArticle { title excerpt mainImage publishedAt authorNames publisherUrl publisher { logo name } } collection { title excerpt publishedAt authors { name } imageUrl } corpusItem { title excerpt datePublished publisher image { url } authors { name sortOrder } }"
+      fields: "syndicatedArticle { title excerpt mainImage publishedAt authorNames publisherUrl publisher { logo name } } collection { title excerpt publishedAt authors { name } imageUrl } corpusItem { id title excerpt datePublished publisher image { url } authors { name sortOrder } }"
     )
 
   "If the item is a syndicated article, then the syndication information"
@@ -448,6 +448,10 @@ type Mutation {
 
 extend type CorpusItem @key(fields: "url") {
   """
+  The GUID that is stored on an approved corpus item
+  """
+  id: ID! @external
+  """
   Provides short url for the given_url in the format: https://pocket.co/<identifier>.
   marked as beta because it's not ready yet for large client request.
   """
@@ -489,7 +493,7 @@ extend type CorpusItem @key(fields: "url") {
   """
   preview: PocketMetadata!
     @requires(
-      fields: "title excerpt datePublished publisher image { url } authors { name sortOrder }"
+      fields: "id title excerpt datePublished publisher image { url } authors { name sortOrder }"
     )
 }
 

--- a/servers/parser-graphql-wrapper/src/__generated__/resolvers-types.ts
+++ b/servers/parser-graphql-wrapper/src/__generated__/resolvers-types.ts
@@ -104,6 +104,8 @@ export type CorpusItem = {
   datePublished?: Maybe<Scalars['Date']['output']>;
   /** The excerpt of the Approved Item. */
   excerpt: Scalars['String']['output'];
+  /** The GUID that is stored on an approved corpus item */
+  id: Scalars['ID']['output'];
   /** The image for this item's accompanying picture. */
   image: Image;
   /** The preview of the search result */
@@ -907,7 +909,8 @@ export type CorpusItemResolvers<ContextType = IContext, ParentType extends Resol
 
 
 
-  preview?: Resolver<ResolversTypes['PocketMetadata'], { __typename: 'CorpusItem' } & GraphQLRecursivePick<ParentType, {"url":true}> & GraphQLRecursivePick<ParentType, {"title":true,"excerpt":true,"datePublished":true,"publisher":true,"image":{"url":true},"authors":{"name":true,"sortOrder":true}}>, ContextType>;
+
+  preview?: Resolver<ResolversTypes['PocketMetadata'], { __typename: 'CorpusItem' } & GraphQLRecursivePick<ParentType, {"url":true}> & GraphQLRecursivePick<ParentType, {"id":true,"title":true,"excerpt":true,"datePublished":true,"publisher":true,"image":{"url":true},"authors":{"name":true,"sortOrder":true}}>, ContextType>;
 
   shortUrl?: Resolver<Maybe<ResolversTypes['Url']>, { __typename: 'CorpusItem' } & GraphQLRecursivePick<ParentType, {"url":true}>, ContextType>;
   timeToRead?: Resolver<Maybe<ResolversTypes['Int']>, { __typename: 'CorpusItem' } & GraphQLRecursivePick<ParentType, {"url":true}>, ContextType>;
@@ -993,7 +996,7 @@ export type ItemResolvers<ContextType = IContext, ParentType extends ResolversPa
   mimeType?: Resolver<Maybe<ResolversTypes['String']>, { __typename: 'Item' } & (GraphQLRecursivePick<ParentType, {"givenUrl":true}> | GraphQLRecursivePick<ParentType, {"itemId":true}>), ContextType>;
   normalUrl?: Resolver<ResolversTypes['String'], { __typename: 'Item' } & (GraphQLRecursivePick<ParentType, {"givenUrl":true}> | GraphQLRecursivePick<ParentType, {"itemId":true}>), ContextType>;
   originDomainId?: Resolver<Maybe<ResolversTypes['String']>, { __typename: 'Item' } & (GraphQLRecursivePick<ParentType, {"givenUrl":true}> | GraphQLRecursivePick<ParentType, {"itemId":true}>), ContextType>;
-  preview?: Resolver<Maybe<ResolversTypes['PocketMetadata']>, { __typename: 'Item' } & (GraphQLRecursivePick<ParentType, {"givenUrl":true}> | GraphQLRecursivePick<ParentType, {"itemId":true}>) & GraphQLRecursivePick<ParentType, {"syndicatedArticle":{"title":true,"excerpt":true,"mainImage":true,"publishedAt":true,"authorNames":true,"publisherUrl":true,"publisher":{"logo":true,"name":true}},"collection":{"title":true,"excerpt":true,"publishedAt":true,"authors":{"name":true},"imageUrl":true},"corpusItem":{"title":true,"excerpt":true,"datePublished":true,"publisher":true,"image":{"url":true},"authors":{"name":true,"sortOrder":true}}}>, ContextType>;
+  preview?: Resolver<Maybe<ResolversTypes['PocketMetadata']>, { __typename: 'Item' } & (GraphQLRecursivePick<ParentType, {"givenUrl":true}> | GraphQLRecursivePick<ParentType, {"itemId":true}>) & GraphQLRecursivePick<ParentType, {"syndicatedArticle":{"title":true,"excerpt":true,"mainImage":true,"publishedAt":true,"authorNames":true,"publisherUrl":true,"publisher":{"logo":true,"name":true}},"collection":{"title":true,"excerpt":true,"publishedAt":true,"authors":{"name":true},"imageUrl":true},"corpusItem":{"id":true,"title":true,"excerpt":true,"datePublished":true,"publisher":true,"image":{"url":true},"authors":{"name":true,"sortOrder":true}}}>, ContextType>;
   readerSlug?: Resolver<ResolversTypes['String'], { __typename: 'Item' } & (GraphQLRecursivePick<ParentType, {"givenUrl":true}> | GraphQLRecursivePick<ParentType, {"itemId":true}>), ContextType>;
   resolvedId?: Resolver<Maybe<ResolversTypes['String']>, { __typename: 'Item' } & (GraphQLRecursivePick<ParentType, {"givenUrl":true}> | GraphQLRecursivePick<ParentType, {"itemId":true}>), ContextType>;
   resolvedNormalUrl?: Resolver<Maybe<ResolversTypes['Url']>, { __typename: 'Item' } & (GraphQLRecursivePick<ParentType, {"givenUrl":true}> | GraphQLRecursivePick<ParentType, {"itemId":true}>), ContextType>;

--- a/servers/parser-graphql-wrapper/src/models/PocketMetadataModel.ts
+++ b/servers/parser-graphql-wrapper/src/models/PocketMetadataModel.ts
@@ -297,7 +297,7 @@ export class PocketMetadataModel {
     const imageUrl = getOriginalUrlIfPocketImageCached(corpusItem.image.url);
 
     return {
-      id: item.id,
+      id: corpusItem.id,
       image: {
         url: imageUrl,
         imageId: 0,


### PR DESCRIPTION
# Goal

Preview is meant to replace metadata fallback. Clients rely on the id to be present and valid for at least corpus items, which it was null at times for Android (item id... can be null 😮‍💨 ). 

For a corpus item the id field here should be the approved corpus item id, for everything else it should be the Item id (which can be nullable...... _future problem_ ) 