### PR TITLE
fix(errors): removing sending a 200 ok error to sentry

### DIFF
--- a/servers/v3-proxy-api/src/graph/graphQLClient.ts
+++ b/servers/v3-proxy-api/src/graph/graphQLClient.ts
@@ -181,13 +181,18 @@ export class GraphQLClientFactory {
           };
           throw new ClientError(gqlResponse, context);
         }
+      } else if (
+        response instanceof ClientError &&
+        response.response?.error === '' &&
+        response.response?.status === 200
+      ) {
+        serverLogger.error('Received an empty 200 error from Client API', {
+          responseError: response,
+        });
+        throw response;
         // There are unskipped errors; re-throw so that the request
         // evaluates to an error
       } else if (response instanceof Error) {
-        Sentry.addBreadcrumb({
-          message: 'Rethrowing an unskipped error',
-          data: { responseError: response },
-        });
         serverLogger.error('rethrowing an unskipped error', {
           responseError: response,
         });


### PR DESCRIPTION
# Goal

Remove sending the 200 ok error into sentry so that sentry rate limits stop getting gummed up.

We will still be able to see the data within GCP logs.