### PR TITLE
chore: clean logs and async Sentry isolation

### DIFF
--- a/servers/account-data-deleter/src/dataService/s3Service.ts
+++ b/servers/account-data-deleter/src/dataService/s3Service.ts
@@ -134,6 +134,7 @@ export class S3Bucket {
         message: 'Error encountered during archive',
         prefix: prefix,
         errorData: err,
+        errorMessage: err.message,
       });
       Sentry.captureException(err, { data: { prefix } });
       throw err;

--- a/servers/account-data-deleter/src/server.ts
+++ b/servers/account-data-deleter/src/server.ts
@@ -29,7 +29,6 @@ app.use(
 
 // Endpoints
 app.get('/health', (req, res) => {
-  serverLogger.info('healthcheck Logger');
   res.status(200).send('ok');
 });
 app.use('/queueDelete', queueDeleteRouter);


### PR DESCRIPTION
Remove noisy healthcheck logger. 

Manually associate async background context -- See https://docs.sentry.io/platforms/javascript/guides/node/configuration/async-context/

Tested in dev, and the polling proceeded as expected. Sentry context did show additional data through the function stack, e.g.

```
	
2024-10-15T11:31:18.124-07:00
{
    "cursor": -1,
    "errorData": {
        "__SENTRY_ERROR_LOCAL_VARIABLES__": [
            {
                "function": "",
                "vars": {
                    "err": "<Error: getaddrinfo ENOTFOUND pocket-db-primary-0-dev-cluster.cluster-ro-c8befui6jgnr.us-east-1.rds.amazonaws.com\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:120:26)\n    at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:130:17)>"
                }
            },
            {
                "function": "Connection.",
                "vars": {
                    "param": "<Error: getaddrinfo ENOTFOUND pocket-db-primary-0-dev-cluster.cluster-ro-c8befui6jgnr.us-east-1.rds.amazonaws.com\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:120:26)\n    at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:130:17)>"
                }
            },
            {
                "function": "Object.onceWrapper",
                "vars": {
                    "arguments": "<Arguments(1)>"
                }
            },
            {
                "function": "Connection.emit",
                "vars": {
                    "args": [
                        null
                    ],
                    "type": "error"
                }
            },
            {
                "function": "Connection._notifyError",
                "vars": {
                    "bubbleErrorToConnection": true,
                    "command": "<undefined>",
                    "err": "<Error: getaddrinfo ENOTFOUND pocket-db-primary-0-dev-cluster.cluster-ro-c8befui6jgnr.us-east-1.rds.amazonaws.com\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:120:26)\n    at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:130:17)>"
                }
            },
            {
                "function": "Connection._handleFatalError",
                "vars": {
                    "err": "<Error: getaddrinfo ENOTFOUND pocket-db-primary-0-dev-cluster.cluster-ro-c8befui6jgnr.us-east-1.rds.amazonaws.com\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:120:26)\n    at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:130:17)>"
                }
            },
            {
                "function": "Connection._handleNetworkError",
                "vars": {
                    "err": "<Error: getaddrinfo ENOTFOUND pocket-db-primary-0-dev-cluster.cluster-ro-c8befui6jgnr.us-east-1.rds.amazonaws.com\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:120:26)\n    at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:130:17)>"
                }
            },
            {
                "function": "Socket.emit",
                "vars": {
                    "args": [
                        null
                    ],
                    "type": "error"
                }
            },
            {
                "function": "emitErrorNT",
                "vars": {
                    "err": "<Error: getaddrinfo ENOTFOUND pocket-db-primary-0-dev-cluster.cluster-ro-c8befui6jgnr.us-east-1.rds.amazonaws.com\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:120:26)\n    at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:130:17)>",
                    "r": "<ReadableState>",
                    "self": "<Socket>",
                    "w": "<WritableState>"
                }
            },
            {
                "function": "emitErrorCloseNT",
                "vars": {
                    "err": "<Error: getaddrinfo ENOTFOUND pocket-db-primary-0-dev-cluster.cluster-ro-c8befui6jgnr.us-east-1.rds.amazonaws.com\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:120:26)\n    at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:130:17)>",
                    "self": "<Socket>"
                }
            },
            {
                "function": "process.processTicksAndRejections",
                "vars": {
                    "tock": "<undefined>"
                }
            }
        ],
        "code": "ENOTFOUND",
        "errno": -3008,
        "fatal": true,
        "hostname": "pocket-db-primary-0-dev-cluster.cluster-ro-c8befui6jgnr.us-east-1.rds.amazonaws.com",
        "syscall": "getaddrinfo"
    },
    "level": "error",
    "message": "Unhandled error occurred during export",
    "part": 0,
    "releaseSha": "ddca79388470633e31031ec54e174ddebc8edfb1",
    "requestId": "4ccd3538-026d-4b84-82c1-11c29f922034",
    "timestamp": "2024-10-15 18:31:18:3118"
```