### PR TITLE
fix(sentry): filter out 200 ok errors

### DIFF
--- a/servers/v3-proxy-api/src/main.ts
+++ b/servers/v3-proxy-api/src/main.ts
@@ -5,6 +5,8 @@ import { initSentry } from '@pocket-tools/sentry';
 initSentry({
   ...config.sentry,
   skipOpenTelemetrySetup: true,
+  // Filter out GraphQL 200 errors from sentry
+  ignoreErrors: ['GraphQL Error (Code: 200)'],
   integrations(integrations) {
     return integrations.filter((integration) => {
       return integration.name !== 'NodeFetch';


### PR DESCRIPTION
# Goal

Turns out our Sentry express middleware was still capturing 200 ok errors.

I was able to emulate our GraphQL router responding this way via proxyman and manually found the options that suppressed it.


Also in testing I determined that we respond with a 200 and an error body in this case.