### PR TITLE
fix(export): export prefix and logger warn

### DIFF
--- a/servers/account-data-deleter/src/dataService/listDataExportService.ts
+++ b/servers/account-data-deleter/src/dataService/listDataExportService.ts
@@ -116,7 +116,7 @@ export class ListDataExportService {
           });
           await this.notifyUser(this.encodedId, requestId);
         } else {
-          serverLogger.warning('Export returned no results');
+          serverLogger.warn('Export returned no results');
         }
       }
       // We're finished!
@@ -128,9 +128,11 @@ export class ListDataExportService {
         serverLogger.info({
           message: 'ListDataExportService - zipping files',
           requestId,
+          prefix: this.partsPrefix,
+          file: this.zipFileKey,
         });
         const zipResponse = await this.exportBucket.zipFilesByPrefix(
-          this.encodedId,
+          this.partsPrefix,
           this.zipFileKey,
         );
         if (zipResponse != null) {

--- a/servers/account-data-deleter/src/dataService/s3Service.ts
+++ b/servers/account-data-deleter/src/dataService/s3Service.ts
@@ -123,7 +123,7 @@ export class S3Bucket {
         await uploads.done();
         return { Bucket: destBucket, Key: zipKey };
       } else {
-        serverLogger.warning({
+        serverLogger.warn({
           message: 'Archive requested, but no files matched prefix',
           prefix,
         });


### PR DESCRIPTION
Forgot to update the zip method when I added the prefix helper -- this fixes that.

Also, even though the typescript transpiler didn't throw an error, at runtime serverLogger.warning was throwing an error due to not being a function... 