### PR TITLE
fix(alarms): updating dlq alarm logic

### DIFF
--- a/infrastructure/pocket-event-bridge/src/event-rules/utils.ts
+++ b/infrastructure/pocket-event-bridge/src/event-rules/utils.ts
@@ -41,6 +41,8 @@ export function createDeadLetterQueueAlarm(
       period: periodInSeconds,
       threshold: threshold,
       statistic: 'Sum',
+      // At some point on 10/11/2024, AWS changed the behavior for our dlq alarms and they flop from having 0 messages to missing data.
+      treatMissingData: 'notBreaching',
       alarmActions: config.isDev ? [] : [snsTopic.arn],
       okActions: config.isDev ? [] : [snsTopic.arn],
       actionsEnabled: enabled,


### PR DESCRIPTION
# Goal

Remove the new noise in #pkt-alerts that goes off every day since 10/11/2024.  Looking at the alarms nothing is wrong and the alarm is flapping from having '0' to missing data. Something may have changed on AWS's side.. 🤷 

![Screenshot 2024-10-16 at 8 16 23 AM](https://github.com/user-attachments/assets/a57d1503-752a-4438-a8b7-90c6c10f9802)
