### PR TITLE
fix(router): adding in router retries for errors

### DIFF
--- a/servers/client-api/config/router.yaml
+++ b/servers/client-api/config/router.yaml
@@ -21,6 +21,20 @@ limits:
   max_height: 225
   max_aliases: 30
   max_root_fields: 20
+
+traffic_shaping:
+  all:
+    ### Note: Recs api does not support gzip compression as of 10/16/2024, so this can not be turned on.
+    # compression: gzip # Enable gzip compression for all subgraphs. 
+
+    # We enable experimental retry for all subgraphs because our parser can cause things to fail the first time and succeed the second time.
+    # Also, it doesn't hurt to have this enabled for all subgraphs, just adds latency for any requests that may fail.
+    experimental_retry:
+      min_per_sec: 10 # minimal number of retries per second (`min_per_sec`, default is 10 retries per second)
+      ttl: 10s # for each successful request, we register a token, that expires according to this option (default: 10s)
+      retry_percent: 0.2 # defines the proportion of available retries to the current number of tokens
+      retry_mutations: false # allows retries on mutations. This should only be enabled if mutations are idempotent
+
 authentication:
   router:
     jwt:


### PR DESCRIPTION
# Goal

Redploy of https://github.com/Pocket/pocket-monorepo/pull/831 without compression turned off and on.

Testing locally, it appears recs api does not support compression, (see screenshot). This retry setting does work though with compression not enabled.


![Screenshot 2024-10-16 at 5 25 53 PM](https://github.com/user-attachments/assets/1ceffc7c-ed8e-4fe9-bc46-88b8a94662a6)
