### PR TITLE
fix(export): use iam user for presigned url access grant

### DIFF
--- a/infrastructure/account-data-deleter/src/main.ts
+++ b/infrastructure/account-data-deleter/src/main.ts
@@ -7,13 +7,9 @@ import { provider as archiveProvider } from '@cdktf/provider-archive';
 import {
   provider as awsProvider,
   dataAwsCallerIdentity,
-  dataAwsIamPolicyDocument,
   dataAwsKmsAlias,
   dataAwsRegion,
   dataAwsSnsTopic,
-  iamAccessKey,
-  iamUser,
-  iamUserPolicy,
   s3Bucket,
   s3BucketLifecycleConfiguration,
 } from '@cdktf/provider-aws';

--- a/servers/account-data-deleter/src/config/index.ts
+++ b/servers/account-data-deleter/src/config/index.ts
@@ -99,7 +99,15 @@ export const config = {
     partsPrefix: process.env.LIST_EXPORT_PARTS_PREFIX || '',
     archivePrefix: process.env.LIST_EXPORT_ARCHIVE_PREFIX || '',
     queryLimit: 10000,
-    signedUrlExpiry: 60 * 60 * 24 * 7, // 7 days in seconds
+    signedUrlExpiry: 60 * 60 * 24 * 7, // 7 days in seconds,
+    presignedIamUserCredentials:
+      process.env.EXPORT_SIGNEDURL_USER_ACCESS_KEY_ID &&
+      process.env.EXPORT_SIGNEDURL_USER_SECRET_KEY
+        ? {
+            accessKeyId: process.env.EXPORT_SIGNEDURL_USER_ACCESS_KEY_ID,
+            secretAccessKey: process.env.EXPORT_SIGNEDURL_USER_SECRET_KEY,
+          }
+        : undefined,
   },
   unleash: {
     clientKey: process.env.UNLEASH_KEY || 'unleash-key-fake',

--- a/servers/account-data-deleter/src/dataService/listDataExportService.ts
+++ b/servers/account-data-deleter/src/dataService/listDataExportService.ts
@@ -248,6 +248,7 @@ export class ListDataExportService {
       return await this.exportBucket.getSignedUrl(
         this.zipFileKey,
         config.listExport.signedUrlExpiry,
+        config.listExport.presignedIamUserCredentials,
       );
     } else {
       return false;


### PR DESCRIPTION
Use an IAM User instead of the ECS execution task role for the presigned url access grant. This is so that the url does not expire prior to when we want it to (7 days). I can't fully test whether this lasts, but I have a URL that was generated which I can check over the next few days to be sure. At the very least, it shouldn't degrade the experience.

See https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html#who-presigned-url for more info.

- [x] created user and ssm in dev
- [x] created user and ssm in prod
- [x] tested in dev (by copying an extant zipfile)
