### PR TITLE
fix(sentry): ignoring unsupported media type errors

### DIFF
--- a/servers/v3-proxy-api/src/main.ts
+++ b/servers/v3-proxy-api/src/main.ts
@@ -6,7 +6,7 @@ initSentry({
   ...config.sentry,
   skipOpenTelemetrySetup: true,
   // Filter out GraphQL 200 errors from sentry
-  ignoreErrors: ['GraphQL Error (Code: 200)'],
+  ignoreErrors: ['GraphQL Error (Code: 200)', 'UnsupportedMediaTypeError'],
   integrations(integrations) {
     return integrations.filter((integration) => {
       return integration.name !== 'NodeFetch';


### PR DESCRIPTION
# Goal

Some clients send charset UTF8 which is not a valid charset. Ignoring it per https://github.com/expressjs/body-parser/issues/50

https://pocket.sentry.io/issues/5999859912/?project=4504658424102912&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=1