### PR TITLE
fix(account-delete): making emails optional for deletion in account deleter

### DIFF
--- a/infrastructure/account-data-deleter/src/config/index.ts
+++ b/infrastructure/account-data-deleter/src/config/index.ts
@@ -50,7 +50,7 @@ export const config = {
     batchDeleteLambda: {
       name: 'BatchDeleteLambda',
       reservedConcurrencyLimit: 1,
-      triggerInHours: 1,
+      trigger: '1 hour',
     },
   },
   tags: {

--- a/infrastructure/account-data-deleter/src/lambda/batchDeleteLambdaResources.ts
+++ b/infrastructure/account-data-deleter/src/lambda/batchDeleteLambdaResources.ts
@@ -108,7 +108,7 @@ export class BatchDeleteLambdaResources extends Construct {
         description: 'event to trigger AccountDeletion- batchDeleteLambda',
         name: `${config.prefix}-BatchDelete-Lambda-Trigger`,
         //todo: set proper limit after testing
-        scheduleExpression: `rate(${config.lambda.batchDeleteLambda.triggerInHours} hours)`,
+        scheduleExpression: `rate(${config.lambda.batchDeleteLambda.trigger})`,
         targets: [
           {
             arn: this.batchDeleteLambda.lambda.defaultLambda.arn,

--- a/lambdas/account-data-deleter-events/src/handlers/accountDelete/index.spec.ts
+++ b/lambdas/account-data-deleter-events/src/handlers/accountDelete/index.spec.ts
@@ -31,7 +31,7 @@ describe('accountDelete handler', () => {
       body: JSON.stringify({
         Message: JSON.stringify({
           detail: {
-            userId: 1,
+            email: 'test@test.com',
             isPremium: false,
           },
         }),
@@ -41,7 +41,7 @@ describe('accountDelete handler', () => {
     try {
       await accountDeleteHandler(recordWithoutEmail as SQSRecord);
     } catch (e) {
-      expect(e.message).toContain('email does not exist in message');
+      expect(e.message).toContain('userId does not exist in message');
     }
   });
   it('throws an error if queueDelete response is not 200 OK', async () => {

--- a/lambdas/account-data-deleter-events/src/handlers/accountDelete/index.ts
+++ b/lambdas/account-data-deleter-events/src/handlers/accountDelete/index.ts
@@ -30,7 +30,7 @@ export function validatePostBody(
 
   const postBody = {
     userId: message['userId'],
-    email: message['email'] ?? null,
+    email: message['email'] ?? undefined,
     isPremium: message['isPremium'],
   };
   if (message['traceId']) {

--- a/lambdas/account-data-deleter-events/src/handlers/accountDelete/index.ts
+++ b/lambdas/account-data-deleter-events/src/handlers/accountDelete/index.ts
@@ -23,14 +23,14 @@ export function validatePostBody(
   message: AccountDeleteEvent,
 ): AccountDeleteBody {
   AccountDeleteEvent.getAttributeTypeMap().forEach((type) => {
-    if (message[type.name] == null) {
+    if (message[type.name] == null && type.name !== 'email') {
       throw new Error(`${type.name} does not exist in message`);
     }
   });
 
   const postBody = {
     userId: message['userId'],
-    email: message['email'],
+    email: message['email'] ?? null,
     isPremium: message['isPremium'],
   };
   if (message['traceId']) {

--- a/servers/account-data-deleter/src/routes/queueDelete.ts
+++ b/servers/account-data-deleter/src/routes/queueDelete.ts
@@ -20,7 +20,7 @@ import { serverLogger } from '@pocket-tools/ts-logger';
 
 export type SqsMessage = {
   userId: number;
-  email: string;
+  email: string | undefined;
   isPremium: boolean;
   primaryKeyValues: any[][];
   primaryKeyNames: string[];
@@ -86,6 +86,13 @@ export async function enqueueTablesForDeletion(
   const tableNames = tables ?? config.queueDelete.tableNames;
 
   for (const { table, where } of tableNames) {
+    if (where.includes('email') && email == null) {
+      serverLogger.info({
+        message:
+          'Skipping delete of table with email where clause, due to no email',
+      });
+      continue;
+    }
     try {
       const whereCond =
         where === 'user_id'
@@ -98,6 +105,11 @@ export async function enqueueTablesForDeletion(
       if (whereCond == null) {
         throw new Error(
           `Unexpected where condition encountered -- logic for column ${where} not implemented`,
+        );
+      }
+      if (whereCond.user_id == null) {
+        throw new Error(
+          `Unexpected where condition encountered -- no user id found in where condition`,
         );
       }
       let offset = 0;

--- a/servers/account-data-deleter/src/routes/queueDelete.ts
+++ b/servers/account-data-deleter/src/routes/queueDelete.ts
@@ -107,11 +107,6 @@ export async function enqueueTablesForDeletion(
           `Unexpected where condition encountered -- logic for column ${where} not implemented`,
         );
       }
-      if (whereCond.user_id == null) {
-        throw new Error(
-          `Unexpected where condition encountered -- no user id found in where condition`,
-        );
-      }
       let offset = 0;
       const sqsSendBatchCommands: SendMessageBatchCommand[] = [];
       let sqsEntries: SendMessageBatchRequestEntry[] = [];
@@ -123,7 +118,8 @@ export async function enqueueTablesForDeletion(
           await accountDeleteDataService.getTableIds(
             table,
             offset,
-            whereCond,
+            // force casting due to type error
+            whereCond as Record<string, string | number>,
             limit,
           );
         if (!ids.primaryKeyValues.length) break;
@@ -174,7 +170,7 @@ export async function enqueueTablesForDeletion(
       serverLogger.error({
         message: errorMessage,
         error: error,
-        data: errorData,
+        errorData,
       });
       Sentry.addBreadcrumb({ message: errorMessage, data: errorData });
       Sentry.captureException(error);

--- a/servers/account-data-deleter/src/routes/schemas.ts
+++ b/servers/account-data-deleter/src/routes/schemas.ts
@@ -14,6 +14,7 @@ export const accountDeleteSchema: Schema = {
     toInt: true,
   },
   email: {
+    optional: true,
     in: ['body'],
     errorMessage: 'Must provide valid email',
   },


### PR DESCRIPTION
# Goal

Ensure that deletes allow for a null/undefined email address since some really old users do not have associated emails