### PR TITLE
fix(rootFields): upping root field limit for Web Client delete batches

### DIFF
--- a/servers/client-api/config/router.yaml
+++ b/servers/client-api/config/router.yaml
@@ -20,7 +20,7 @@ limits:
   max_depth: 100 # Must be 15 or larger to support standard introspection query
   max_height: 225
   max_aliases: 30
-  max_root_fields: 20
+  max_root_fields: 30
 
 traffic_shaping:
   all:


### PR DESCRIPTION
# Goal

Looking in Client API Error logs there are requests that exceed our Root field limit. Looking at the requests it looks like they are from Web Client batch mutations.

Upping the limit to support our agreed upon batch size

![Screenshot 2024-10-22 at 2 49 21 PM](https://github.com/user-attachments/assets/137e8dff-7152-4b63-876f-de044a0958f5)
