### PR TITLE
fix(fetch): moving to fetch retry and updated lambda arn

### DIFF
--- a/lambdas/instant-sync-events/package.json
+++ b/lambdas/instant-sync-events/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@pocket-tools/lambda-secrets": "workspace:*",
+    "@pocket-tools/ts-logger": "workspace:*",
     "@sentry/aws-serverless": "8.35.0",
     "knex": "3.1.0",
     "mysql2": "3.11.3",

--- a/packages/lambda-secrets/package.json
+++ b/packages/lambda-secrets/package.json
@@ -76,6 +76,7 @@
     ]
   },
   "dependencies": {
+    "fetch-retry": "^5.0.6",
     "tslib": "2.7.0"
   },
   "devDependencies": {

--- a/packages/lambda-secrets/src/secrets.ts
+++ b/packages/lambda-secrets/src/secrets.ts
@@ -1,4 +1,6 @@
 const debug = process.env.PARAMETERS_SECRETS_EXTENSION_LOG_LEVEL === 'debug';
+import fetchRetry from 'fetch-retry';
+export const fetchWithBackoff = fetchRetry(fetch);
 
 /**
  * Requests and parses a secret from the Lambda Layer extension
@@ -9,7 +11,7 @@ export const fetchSecret = async (
   secretName: string,
 ): Promise<Record<string, string>> => {
   const secretExtensionEndpoint: string = `/secretsmanager/get?secretId=${encodeURIComponent(secretName)}`;
-  const secret = await fetchFromLambda(secretExtensionEndpoint, 3);
+  const secret = await fetchFromLambda(secretExtensionEndpoint);
   // Secret string is itself a JSON string that needs to be decoded
   return JSON.parse(secret.SecretString);
 };
@@ -23,14 +25,11 @@ export const fetchParameter = async (
   parameterName: string,
 ): Promise<string> => {
   const secretExtensionEndpoint: string = `/systemsmanager/parameters/get?name=${encodeURIComponent(parameterName)}`;
-  const secret = await fetchFromLambda(secretExtensionEndpoint, 3);
+  const secret = await fetchFromLambda(secretExtensionEndpoint);
   return secret.Parameter.Value;
 };
 
-const fetchFromLambda = async (
-  url: string,
-  tries: number,
-): Promise<Record<string, any>> => {
+const fetchFromLambda = async (url: string): Promise<Record<string, any>> => {
   if (
     !process.env.AWS_SESSION_TOKEN ||
     process.env.AWS_SESSION_TOKEN === 'undefined'
@@ -44,7 +43,11 @@ const fetchFromLambda = async (
   // Grabs a secret according to https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets_lambda.html from the lambda layer
   // https://aws.amazon.com/blogs/compute/using-the-aws-parameter-and-secrets-lambda-extension-to-cache-parameters-and-secrets/
   try {
-    const secret = await fetch(`http://localhost:${port}${url}`, {
+    const secret = await fetchWithBackoff(`http://localhost:${port}${url}`, {
+      retryOn: [500, 502, 503],
+      retries: 3,
+      retryDelay: 1000,
+      method: 'GET',
       headers: {
         'X-Aws-Parameters-Secrets-Token': process.env.AWS_SESSION_TOKEN,
       },
@@ -62,12 +65,7 @@ const fetchFromLambda = async (
     // endpoint does not return json headers, so we grab the text and then parse it.
     return JSON.parse(await secret.text());
   } catch (err) {
-    if (tries === 0) {
-      console.error(err);
-      throw err;
-    }
-    // adding some retry logic because lambda layer seems to have some socket issues
-    tries = tries - 1;
-    return await fetchFromLambda(url, tries);
+    console.error(err);
+    throw err;
   }
 };

--- a/packages/terraform-modules/src/base/ApplicationVersionedLambda.ts
+++ b/packages/terraform-modules/src/base/ApplicationVersionedLambda.ts
@@ -38,71 +38,73 @@ export enum LAMBDA_RUNTIMES {
  */
 export const LAMBDA_SECRETS_X86_X64_LAYER_ARN_MAP: Record<string, string> = {
   'us-east-2':
-    'arn:aws:lambda:us-east-2:590474943231:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:us-east-2:590474943231:layer:AWS-Parameters-and-Secrets-Lambda-Extension:14',
   'us-east-1':
-    'arn:aws:lambda:us-east-1:177933569100:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:us-east-1:177933569100:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'us-west-1':
-    'arn:aws:lambda:us-west-1:997803712105:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:us-west-1:997803712105:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'us-west-2':
-    'arn:aws:lambda:us-west-2:345057560386:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:us-west-2:345057560386:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'af-south-1':
-    'arn:aws:lambda:af-south-1:317013901791:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:af-south-1:317013901791:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'ap-east-1':
-    'arn:aws:lambda:ap-east-1:768336418462:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:ap-east-1:768336418462:layer:AWS-Parameters-and-Secrets-Lambda-Extension:14',
   'ap-south-2':
-    'arn:aws:lambda:ap-south-2:070087711984:layer:AWS-Parameters-and-Secrets-Lambda-Extension:8',
+    'arn:aws:lambda:ap-south-2:070087711984:layer:AWS-Parameters-and-Secrets-Lambda-Extension:9',
   'ap-southeast-3':
-    'arn:aws:lambda:ap-southeast-3:490737872127:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:ap-southeast-3:490737872127:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'ap-southeast-4':
-    'arn:aws:lambda:ap-southeast-4:090732460067:layer:AWS-Parameters-and-Secrets-Lambda-Extension:1',
+    'arn:aws:lambda:ap-southeast-4:090732460067:layer:AWS-Parameters-and-Secrets-Lambda-Extension:2',
+  'ap-southeast-5':
+    'arn:aws:lambda:ap-southeast-5:090732460067:layer:AWS-Parameters-and-Secrets-Lambda-Extension:1',
   'ap-south-1':
-    'arn:aws:lambda:ap-south-1:176022468876:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:ap-south-1:176022468876:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'ap-northeast-3':
-    'arn:aws:lambda:ap-northeast-3:576959938190:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:ap-northeast-3:576959938190:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'ap-northeast-2':
-    'arn:aws:lambda:ap-northeast-2:738900069198:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:ap-northeast-2:738900069198:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'ap-southeast-1':
-    'arn:aws:lambda:ap-southeast-1:044395824272:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:ap-southeast-1:044395824272:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'ap-southeast-2':
-    'arn:aws:lambda:ap-southeast-2:665172237481:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:ap-southeast-2:665172237481:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'ap-northeast-1':
-    'arn:aws:lambda:ap-northeast-1:133490724326:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:ap-northeast-1:133490724326:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'ca-central-1':
-    'arn:aws:lambda:ca-central-1:200266452380:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:ca-central-1:200266452380:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'ca-west-1':
-    'arn:aws:lambda:ca-west-1:243964427225:layer:AWS-Parameters-and-Secrets-Lambda-Extension:1',
+    'arn:aws:lambda:ca-west-1:243964427225:layer:AWS-Parameters-and-Secrets-Lambda-Extension:2',
   'cn-north-1':
-    'arn:aws-cn:lambda:cn-north-1:287114880934:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws-cn:lambda:cn-north-1:287114880934:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'cn-northwest-1':
-    'arn:aws-cn:lambda:cn-northwest-1:287310001119:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws-cn:lambda:cn-northwest-1:287310001119:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'eu-central-1':
-    'arn:aws:lambda:eu-central-1:187925254637:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:eu-central-1:187925254637:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'eu-west-1':
-    'arn:aws:lambda:eu-west-1:015030872274:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:eu-west-1:015030872274:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'eu-west-2':
-    'arn:aws:lambda:eu-west-2:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:eu-west-2:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'eu-south-1':
-    'arn:aws:lambda:eu-south-1:325218067255:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:eu-south-1:325218067255:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'eu-west-3':
-    'arn:aws:lambda:eu-west-3:780235371811:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:eu-west-3:780235371811:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'eu-south-2':
-    'arn:aws:lambda:eu-south-2:524103009944:layer:AWS-Parameters-and-Secrets-Lambda-Extension:8',
+    'arn:aws:lambda:eu-south-2:524103009944:layer:AWS-Parameters-and-Secrets-Lambda-Extension:9',
   'eu-north-1':
-    'arn:aws:lambda:eu-north-1:427196147048:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:eu-north-1:427196147048:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'il-central-1':
-    'arn:aws:lambda:il-central-1:148806536434:layer:AWS-Parameters-and-Secrets-Lambda-Extension:1',
+    'arn:aws:lambda:il-central-1:148806536434:layer:AWS-Parameters-and-Secrets-Lambda-Extension:2',
   'eu-central-2':
-    'arn:aws:lambda:eu-central-2:772501565639:layer:AWS-Parameters-and-Secrets-Lambda-Extension:8',
+    'arn:aws:lambda:eu-central-2:772501565639:layer:AWS-Parameters-and-Secrets-Lambda-Extension:9',
   'me-south-1':
-    'arn:aws:lambda:me-south-1:832021897121:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:me-south-1:832021897121:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'me-central-1':
-    'arn:aws:lambda:me-central-1:858974508948:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:me-central-1:858974508948:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'sa-east-1':
-    'arn:aws:lambda:sa-east-1:933737806257:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws:lambda:sa-east-1:933737806257:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'us-gov-east-1':
-    'arn:aws-us-gov:lambda:us-gov-east-1:129776340158:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws-us-gov:lambda:us-gov-east-1:129776340158:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
   'us-gov-west-1':
-    'arn:aws-us-gov:lambda:us-gov-west-1:127562683043:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11',
+    'arn:aws-us-gov:lambda:us-gov-west-1:127562683043:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12',
 };
 
 export interface ApplicationVersionedLambdaProps

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: 19.4.1
-        version: 19.4.1(@types/node@22.7.5)(typescript@5.7.0-dev.20241023)
+        version: 19.4.1(@types/node@22.7.5)(typescript@5.7.0-dev.20241024)
       '@commitlint/config-conventional':
         specifier: ^19.5.0
         version: 19.5.0
@@ -45,7 +45,7 @@ importers:
         version: link:packages/eslint-config
       syncpack:
         specifier: ^13.0.0
-        version: 13.0.0(typescript@5.7.0-dev.20241023)
+        version: 13.0.0(typescript@5.7.0-dev.20241024)
       tsconfig:
         specifier: workspace:*
         version: link:packages/tsconfig
@@ -1313,6 +1313,9 @@ importers:
       '@pocket-tools/lambda-secrets':
         specifier: workspace:*
         version: link:../../packages/lambda-secrets
+      '@pocket-tools/ts-logger':
+        specifier: workspace:*
+        version: link:../../packages/ts-logger
       '@sentry/aws-serverless':
         specifier: 8.35.0
         version: 8.35.0(@opentelemetry/api@1.9.0)
@@ -2132,6 +2135,9 @@ importers:
 
   packages/lambda-secrets:
     dependencies:
+      fetch-retry:
+        specifier: ^5.0.6
+        version: 5.0.6
       tslib:
         specifier: 2.7.0
         version: 2.7.0
@@ -14077,8 +14083,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.7.0-dev.20241023:
-    resolution: {integrity: sha512-HB6rRd9ySnFMoQUuDasWnBtvOg1P4CFG3nRfs2ZvFbenUkxSzoeeZ0PUwJJ7MKJp5zz7uMTZamGt7zdj0tP9YA==}
+  typescript@5.7.0-dev.20241024:
+    resolution: {integrity: sha512-PffMQ+uB2IVWjH3/OvtOCjfuZZc+dcIP1HtlEPTsaT6T0EZFmqR+urMPNVFbw0KtiyFWzuSquxb7Uz3NlrfHFg==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -16771,11 +16777,11 @@ snapshots:
     dependencies:
       commander: 12.1.0
 
-  '@commitlint/cli@19.4.1(@types/node@22.7.5)(typescript@5.7.0-dev.20241023)':
+  '@commitlint/cli@19.4.1(@types/node@22.7.5)(typescript@5.7.0-dev.20241024)':
     dependencies:
       '@commitlint/format': 19.5.0
       '@commitlint/lint': 19.5.0
-      '@commitlint/load': 19.5.0(@types/node@22.7.5)(typescript@5.7.0-dev.20241023)
+      '@commitlint/load': 19.5.0(@types/node@22.7.5)(typescript@5.7.0-dev.20241024)
       '@commitlint/read': 19.5.0
       '@commitlint/types': 19.5.0
       execa: 8.0.1
@@ -16822,15 +16828,15 @@ snapshots:
       '@commitlint/rules': 19.5.0
       '@commitlint/types': 19.5.0
 
-  '@commitlint/load@19.5.0(@types/node@22.7.5)(typescript@5.7.0-dev.20241023)':
+  '@commitlint/load@19.5.0(@types/node@22.7.5)(typescript@5.7.0-dev.20241024)':
     dependencies:
       '@commitlint/config-validator': 19.5.0
       '@commitlint/execute-rule': 19.5.0
       '@commitlint/resolve-extends': 19.5.0
       '@commitlint/types': 19.5.0
       chalk: 5.3.0
-      cosmiconfig: 9.0.0(typescript@5.7.0-dev.20241023)
-      cosmiconfig-typescript-loader: 5.0.0(@types/node@22.7.5)(cosmiconfig@9.0.0(typescript@5.7.0-dev.20241023))(typescript@5.7.0-dev.20241023)
+      cosmiconfig: 9.0.0(typescript@5.7.0-dev.20241024)
+      cosmiconfig-typescript-loader: 5.0.0(@types/node@22.7.5)(cosmiconfig@9.0.0(typescript@5.7.0-dev.20241024))(typescript@5.7.0-dev.20241024)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -21970,12 +21976,12 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@5.0.0(@types/node@22.7.5)(cosmiconfig@9.0.0(typescript@5.7.0-dev.20241023))(typescript@5.7.0-dev.20241023):
+  cosmiconfig-typescript-loader@5.0.0(@types/node@22.7.5)(cosmiconfig@9.0.0(typescript@5.7.0-dev.20241024))(typescript@5.7.0-dev.20241024):
     dependencies:
       '@types/node': 22.7.5
-      cosmiconfig: 9.0.0(typescript@5.7.0-dev.20241023)
+      cosmiconfig: 9.0.0(typescript@5.7.0-dev.20241024)
       jiti: 1.21.6
-      typescript: 5.7.0-dev.20241023
+      typescript: 5.7.0-dev.20241024
 
   cosmiconfig@8.3.6(typescript@5.5.4):
     dependencies:
@@ -21995,14 +22001,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.5.4
 
-  cosmiconfig@9.0.0(typescript@5.7.0-dev.20241023):
+  cosmiconfig@9.0.0(typescript@5.7.0-dev.20241024):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.7.0-dev.20241023
+      typescript: 5.7.0-dev.20241024
 
   cpu-features@0.0.2:
     dependencies:
@@ -22340,7 +22346,7 @@ snapshots:
     dependencies:
       semver: 7.6.3
       shelljs: 0.8.5
-      typescript: 5.7.0-dev.20241023
+      typescript: 5.7.0-dev.20241024
 
   dreamopt@0.8.0:
     dependencies:
@@ -27313,13 +27319,13 @@ snapshots:
       '@pkgr/core': 0.1.1
       tslib: 2.7.0
 
-  syncpack@13.0.0(typescript@5.7.0-dev.20241023):
+  syncpack@13.0.0(typescript@5.7.0-dev.20241024):
     dependencies:
       '@effect/schema': 0.71.1(effect@3.6.5)
       chalk: 5.3.0
       chalk-template: 1.1.0
       commander: 12.1.0
-      cosmiconfig: 9.0.0(typescript@5.7.0-dev.20241023)
+      cosmiconfig: 9.0.0(typescript@5.7.0-dev.20241024)
       effect: 3.6.5
       enquirer: 2.4.1
       fast-check: 3.21.0
@@ -27796,7 +27802,7 @@ snapshots:
 
   typescript@5.5.4: {}
 
-  typescript@5.7.0-dev.20241023: {}
+  typescript@5.7.0-dev.20241024: {}
 
   ua-parser-js@1.0.37: {}
 


### PR DESCRIPTION
# Goal

We are still getting GetSecretValue timeout errors against our lambda extension. 

This improves the logging, and switches to a fetch Retry solution that waits between requests.