### PR TITLE
fix(resolvedId): check if the parser returned a resolved id

### DIFF
--- a/servers/list-api/src/externalCaller/parserCaller.spec.ts
+++ b/servers/list-api/src/externalCaller/parserCaller.spec.ts
@@ -67,6 +67,33 @@ describe('ParserCallerTest', function () {
     );
   });
 
+  it('should not throw error if resolved_id is missing, item resolved id is null, but we have a higher level resolved_id', async () => {
+    mockParserGetItemRequest(urlToParse, {
+      resolved_id: '1',
+      item: {
+        item_id: '2',
+        given_url: urlToParse,
+        resolved_id: null,
+      },
+    });
+
+    const res = await ParserCaller.getOrCreateItem(urlToParse, 1);
+    expect(res.resolvedId).toBe('1');
+  });
+
+  it('should not throw error if resolved_id is missing, but we have a higher level resolved_id', async () => {
+    mockParserGetItemRequest(urlToParse, {
+      resolved_id: '1',
+      item: {
+        item_id: '2',
+        given_url: urlToParse,
+      },
+    });
+
+    const res = await ParserCaller.getOrCreateItem(urlToParse, 1);
+    expect(res.resolvedId).toBe('1');
+  });
+
   it('should retry parser request 3 times when fails', async () => {
     nock(config.parserDomain)
       .get(`/${config.parserVersion}/getItemListApi`)

--- a/servers/list-api/src/externalCaller/parserCaller.ts
+++ b/servers/list-api/src/externalCaller/parserCaller.ts
@@ -38,13 +38,19 @@ export class ParserCaller {
     }
     const data: any = await response.json();
     const item = data.item;
-    if (!item || (item && !item.item_id) || (item && !item.resolved_id)) {
+    if (
+      !item ||
+      (item && (!item.item_id || item.item_id === null)) ||
+      (item &&
+        (!item.resolved_id || item.resolved_id === null) &&
+        (!data.resolved_id || data.resolved_id === null))
+    ) {
       throw new Error(`Unable to parse and generate item for url`);
     }
 
     return {
       itemId: item.item_id,
-      resolvedId: item.resolved_id,
+      resolvedId: item.resolved_id ?? data.resolved_id,
       title: item.title ?? '',
     };
   }


### PR DESCRIPTION
# Goal

In some cases the parser does not return a resolvedId in its item object response. We need to check one level up for it.