### PR TITLE
fix(rds): ensuring dev only rds use the latest version

### DIFF
--- a/infrastructure/list-api/src/main.ts
+++ b/infrastructure/list-api/src/main.ts
@@ -90,7 +90,7 @@ class ListAPI extends TerraformStack {
         skipFinalSnapshot: true,
         engine: 'aurora-mysql',
         engineMode: 'provisioned',
-        engineVersion: '8.0.mysql_aurora.3.06.0',
+        engineVersion: '8.0.mysql_aurora.3.07.1',
         serverlessv2ScalingConfiguration: {
           minCapacity: config.rds.minCapacity,
           maxCapacity: config.rds.maxCapacity,

--- a/infrastructure/user-list-search/rds.tf
+++ b/infrastructure/user-list-search/rds.tf
@@ -36,8 +36,22 @@ resource "aws_rds_cluster" "mysql" {
   vpc_security_group_ids      = [aws_security_group.mysql[0].id]
   db_subnet_group_name        = aws_db_subnet_group.mysql_subnet[0].name
   engine                      = "aurora-mysql"
-  engine_mode                 = "serverless"
-  engine_version              = "5.7.mysql_aurora.2.11.4"
+  engine_mode                 = "provisioned"
+  engine_version              = "8.0.mysql_aurora.3.07.1"
   allow_major_version_upgrade = true
   apply_immediately           = true
+  storage_encrypted           = true
+
+  serverlessv2_scaling_configuration {
+    max_capacity = 1.0
+    min_capacity = 0.5
+  }
+}
+
+resource "aws_rds_cluster_instance" "mysql_instance" {
+  count                   = local.env == "Dev" ? 1 : 0
+  cluster_identifier = aws_rds_cluster.mysql[0].id
+  instance_class     = "db.serverless"
+  engine             = aws_rds_cluster.mysql[0].engine
+  engine_version     = aws_rds_cluster.mysql[0].engine_version
 }


### PR DESCRIPTION
# Goal

User list search was creating an outdated database deployment in our dev environment.

This updates it to serverless v2 and ensures we dont get charged for extended support

https://mozilla-hub.atlassian.net/browse/POCKET-10768