### PR TITLE
fix(oembed): removing error if oembed provider does not exist

### DIFF
--- a/servers/parser-graphql-wrapper/src/test/queries/oembed.integration.ts
+++ b/servers/parser-graphql-wrapper/src/test/queries/oembed.integration.ts
@@ -125,6 +125,7 @@ describe('oembedPreview', () => {
 
   it.each([
     {
+      hasProvider: true,
       parserData: {},
       oembedData: {
         title: 'oembed video title',
@@ -139,6 +140,7 @@ describe('oembedPreview', () => {
       },
     },
     {
+      hasProvider: true,
       parserData: {},
       oembedData: undefined,
       expected: {
@@ -147,6 +149,7 @@ describe('oembedPreview', () => {
       },
     },
     {
+      hasProvider: true,
       parserData: {},
       oembedData: {
         type: 'video',
@@ -161,9 +164,18 @@ describe('oembedPreview', () => {
         htmlEmbed: 'embeded html',
       },
     },
+    {
+      hasProvider: false,
+      parserData: {},
+      oembedData: undefined,
+      expected: {
+        title: 'parser test',
+        source: PocketMetadataSource.PocketParser,
+      },
+    },
   ])(
     'should return opengraph display data if enabled',
-    async ({ parserData, oembedData, expected }) => {
+    async ({ hasProvider, parserData, oembedData, expected }) => {
       if (oembedData) {
         jest.spyOn(oembed, 'extract').mockImplementation(() => {
           return Promise.resolve({
@@ -172,6 +184,9 @@ describe('oembedPreview', () => {
           });
         });
       }
+      jest.spyOn(oembed, 'hasProvider').mockImplementation(() => {
+        return hasProvider;
+      });
 
       nockResponseForParser(testUrl, {
         data: {


### PR DESCRIPTION
# Goal

Fix [Sentry error](https://pocket.sentry.io/issues/5353210908/?project=5591912&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=4) which started when ted started adding ideas.ted.com.

Instead we not only will catch oembed errors, but will also use the packages hasProvider function.

https://mozilla-hub.atlassian.net/browse/POCKET-10744