### PR TITLE
fix(import): fix empty query if import had no tags

### DIFF
--- a/servers/list-api/src/dataService/tagDataService.ts
+++ b/servers/list-api/src/dataService/tagDataService.ts
@@ -263,8 +263,10 @@ export class TagDataService {
         });
       })
       .filter((input) => input != null);
-    await trx('item_tags').insert(itemTags).onConflict().merge();
-    await this.usersMetaService.logTagMutation(now, trx);
+    if (itemTags.length > 0) {
+      await trx('item_tags').insert(itemTags).onConflict().merge();
+      await this.usersMetaService.logTagMutation(now, trx);
+    }
   }
 
   private async insertTagAndUpdateSavedItem(

--- a/servers/list-api/src/resolvers/mutation.ts
+++ b/servers/list-api/src/resolvers/mutation.ts
@@ -132,6 +132,14 @@ export async function batchImport(
     for await (const record of args.input) {
       // Copied from upsertSavedItem
       const url = ensureHttpPrefix(record.url);
+      if (!isHttpUrl(url)) {
+        serverLogger.warn({
+          message: 'Attempted to import invalid url',
+          url,
+          userId: context.userId,
+        });
+        continue;
+      }
       const item = await ParserCaller.getOrCreateItem(url);
       input.push({ item, import: { ...record, url } });
     }


### PR DESCRIPTION
Fixes an issue where the transaction would be rolled back if no tags were imported, due to an empty query error