### PR TITLE
fix(packages): package deployment concurrency to 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "list-mismatches": "syncpack list-mismatches",
     "list-packages": "syncpack list",
     "prepare": "husky",
-    "semantic-release": "dotenv -- turbo run semantic-release",
+    "semantic-release": "dotenv -- turbo run semantic-release --concurrency 1",
     "synth": "dotenv -- turbo run synth",
     "test": "dotenv -- turbo run test",
     "test-integrations": "dotenv -- turbo run test-integrations"


### PR DESCRIPTION
# Goal

Package deployment concurrency needs to be 1 because all semantic releases try and tag the repo and hit race conditions.