### PR TITLE
fix(release): ensuring that semantic release uses real version numbers

### DIFF
--- a/packages/apollo-utils/package.json
+++ b/packages/apollo-utils/package.json
@@ -71,6 +71,7 @@
       [
         "@semantic-release/exec",
         {
+          "verifyConditionsCmd": "pnpm version ${lastRelease.version} --no-git-tag-version",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/event-bridge/package.json
+++ b/packages/event-bridge/package.json
@@ -70,6 +70,7 @@
       [
         "@semantic-release/exec",
         {
+          "verifyConditionsCmd": "pnpm version ${lastRelease.version} --no-git-tag-version",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/feature-flags-client/package.json
+++ b/packages/feature-flags-client/package.json
@@ -66,6 +66,7 @@
       [
         "@semantic-release/exec",
         {
+          "verifyConditionsCmd": "pnpm version ${lastRelease.version} --no-git-tag-version",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/image-utils/package.json
+++ b/packages/image-utils/package.json
@@ -68,6 +68,7 @@
       [
         "@semantic-release/exec",
         {
+          "verifyConditionsCmd": "pnpm version ${lastRelease.version} --no-git-tag-version",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/jwt-utils/package.json
+++ b/packages/jwt-utils/package.json
@@ -68,6 +68,7 @@
       [
         "@semantic-release/exec",
         {
+          "verifyConditionsCmd": "pnpm version ${lastRelease.version} --no-git-tag-version",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/lambda-secrets/package.json
+++ b/packages/lambda-secrets/package.json
@@ -68,6 +68,7 @@
       [
         "@semantic-release/exec",
         {
+          "verifyConditionsCmd": "pnpm version ${lastRelease.version} --no-git-tag-version",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -67,6 +67,7 @@
       [
         "@semantic-release/exec",
         {
+          "verifyConditionsCmd": "pnpm version ${lastRelease.version} --no-git-tag-version",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/terraform-modules/package.json
+++ b/packages/terraform-modules/package.json
@@ -66,6 +66,7 @@
       [
         "@semantic-release/exec",
         {
+          "verifyConditionsCmd": "pnpm version ${lastRelease.version} --no-git-tag-version",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -63,6 +63,7 @@
       [
         "@semantic-release/exec",
         {
+          "verifyConditionsCmd": "pnpm version ${lastRelease.version} --no-git-tag-version",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/ts-logger/package.json
+++ b/packages/ts-logger/package.json
@@ -67,6 +67,7 @@
       [
         "@semantic-release/exec",
         {
+          "verifyConditionsCmd": "pnpm version ${lastRelease.version} --no-git-tag-version",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/turbo.json
+++ b/turbo.json
@@ -69,7 +69,7 @@
       "inputs": ["src/**/*", "eslint.config.js", "package.json"]
     },
     "semantic-release": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "^semantic-release"]
     },
     "test": {
       "inputs": ["src/**/*", "package.json", "jest.config.js", "jest.setup.js"],


### PR DESCRIPTION
# Goal

Semantic release was filling version numbers of our own packages with `0.0.0-development`. This is because the version in package.json only gets updated when it was being released. 

To fix the issue this will:
* Ensure that if a package is being released, any of its dependent packages run semantic release first, which handles ensuring their version is set correctly.
* Updates semantic release to set the version of the package even if its not releasing so it can be used downstream