### PR TITLE
fix(semantic-release): ensure semantic release returns nothing

### DIFF
--- a/packages/feature-flags-client/package.json
+++ b/packages/feature-flags-client/package.json
@@ -66,7 +66,7 @@
       [
         "@semantic-release/exec",
         {
-          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --no-git-tag-version",
+          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --no-git-tag-version &> /dev/null",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }


### PR DESCRIPTION
# Goal

Pnpm version was returning output and it should not.