### PR TITLE
fix(semantic-release): updating to use a silent command

### DIFF
--- a/packages/apollo-utils/package.json
+++ b/packages/apollo-utils/package.json
@@ -71,7 +71,7 @@
       [
         "@semantic-release/exec",
         {
-          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false &> /dev/null",
+          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false --silent || true",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/event-bridge/package.json
+++ b/packages/event-bridge/package.json
@@ -70,7 +70,7 @@
       [
         "@semantic-release/exec",
         {
-          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false &> /dev/null",
+          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false --silent || true",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/feature-flags-client/package.json
+++ b/packages/feature-flags-client/package.json
@@ -66,7 +66,7 @@
       [
         "@semantic-release/exec",
         {
-          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false &> /dev/null",
+          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false --silent || true",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/image-utils/package.json
+++ b/packages/image-utils/package.json
@@ -68,7 +68,7 @@
       [
         "@semantic-release/exec",
         {
-          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false &> /dev/null",
+          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false --silent || true",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/jwt-utils/package.json
+++ b/packages/jwt-utils/package.json
@@ -68,7 +68,7 @@
       [
         "@semantic-release/exec",
         {
-          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false &> /dev/null",
+          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false --silent || true",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/lambda-secrets/package.json
+++ b/packages/lambda-secrets/package.json
@@ -68,7 +68,7 @@
       [
         "@semantic-release/exec",
         {
-          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false &> /dev/null",
+          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false --silent || true",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -67,7 +67,7 @@
       [
         "@semantic-release/exec",
         {
-          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false &> /dev/null",
+          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false --silent || true",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/terraform-modules/package.json
+++ b/packages/terraform-modules/package.json
@@ -66,7 +66,7 @@
       [
         "@semantic-release/exec",
         {
-          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false &> /dev/null",
+          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false --silent || true",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pocket-tools/tracing",
-  "version": "0.0.0-development",
+  "version": "1.2.3",
   "description": "Utilities for tracing",
   "keywords": [
     "tracing"
@@ -63,7 +63,7 @@
       [
         "@semantic-release/exec",
         {
-          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false &> /dev/null",
+          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false --silent || true",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }

--- a/packages/ts-logger/package.json
+++ b/packages/ts-logger/package.json
@@ -67,7 +67,7 @@
       [
         "@semantic-release/exec",
         {
-          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false &> /dev/null",
+          "analyzeCommitsCmd": "pnpm version ${lastRelease.version} --git-tag-version=false --silent || true",
           "prepareCmd": "pnpm version ${nextRelease.version} --git-tag-version=false",
           "publishCmd": "pnpm publish --no-git-checks"
         }


### PR DESCRIPTION
## Goal

There were issues with the /dev/null redirect so using a --silent instead