### PR TITLE
fix(notes:infra): fix note deployment and separate r/w endpoints

### DIFF
--- a/infrastructure/notes-api/src/main.ts
+++ b/infrastructure/notes-api/src/main.ts
@@ -243,7 +243,11 @@ class NotesAPI extends TerraformStack {
               valueFrom: `${rds.secretARN}:database_url::`,
             },
             {
-              name: 'DATABASE_HOST',
+              name: 'DB_WRITE_HOST',
+              valueFrom: `${rds.secretARN}:host::`,
+            },
+            {
+              name: 'DB_READ_HOST',
               valueFrom: `${rds.secretARN}:host::`,
             },
             {

--- a/packages/terraform-modules/src/base/ApplicationRDSCluster.ts
+++ b/packages/terraform-modules/src/base/ApplicationRDSCluster.ts
@@ -238,10 +238,14 @@ export class ApplicationRDSCluster extends Construct {
       port: rdsPort,
     };
 
-    // Add a database URL to a MySQL-compatible Aurora instance
-    if (engine && engine === 'aurora-mysql') {
-      secretValues.database_url = `mysql://${rds.masterUsername}:${rds.masterPassword}@${rds.endpoint}:${rdsPort}/${rds.databaseName}`;
-      secretValues.reader_database_url = `mysql://${rds.masterUsername}:${rds.masterPassword}@${rds.readerEndpoint}:${rdsPort}/${rds.databaseName}`;
+    // Add a database URL to a MySQL or Postgres-compatible Aurora instance
+    if (
+      (engine && engine === 'aurora-mysql') ||
+      engine === 'aurora-postgresql'
+    ) {
+      const protocol = engine === 'aurora-mysql' ? 'mysql' : 'postgresql';
+      secretValues.database_url = `${protocol}://${rds.masterUsername}:${rds.masterPassword}@${rds.endpoint}:${rdsPort}/${rds.databaseName}`;
+      secretValues.reader_database_url = `${protocol}://${rds.masterUsername}:${rds.masterPassword}@${rds.readerEndpoint}:${rdsPort}/${rds.databaseName}`;
     }
 
     //Create the initial secret version

--- a/servers/notes-api/jest.setup.js
+++ b/servers/notes-api/jest.setup.js
@@ -7,5 +7,6 @@ process.env.DATABASE_URL =
 process.env.DATABASE_NAME = 'pocketnotes';
 process.env.DATABASE_USER = 'pocket';
 process.env.DATABASE_PASSWORD = 'password';
-process.env.DATABASE_HOST = 'localhost';
+process.env.DB_WRITE_HOST = 'localhost';
+process.env.DB_READ_HOST = 'localhost';
 process.env.DATABASE_PORT = '5432';

--- a/servers/notes-api/src/apollo/context.ts
+++ b/servers/notes-api/src/apollo/context.ts
@@ -7,7 +7,7 @@ import {
 } from '@pocket-tools/apollo-utils';
 import { Kysely } from 'kysely';
 import { DB } from '../__generated__/db';
-import { db } from '../datasources/db';
+import { roDb } from '../datasources/db';
 import { NoteModel } from '../models/Note';
 
 /**
@@ -27,13 +27,13 @@ export async function getContext({
 }
 
 export interface IContext extends PocketContext {
-  db: Kysely<DB>;
+  roDb: Kysely<DB>;
   userId: string;
   NoteModel: NoteModel;
 }
 
 export class ContextManager extends PocketContextManager implements IContext {
-  db: Kysely<DB>;
+  roDb: Kysely<DB>;
   _userId: string;
   NoteModel: NoteModel;
   constructor(options: { request: Request }) {
@@ -47,7 +47,7 @@ export class ContextManager extends PocketContextManager implements IContext {
     } else {
       this._userId = super.userId;
     }
-    this.db = db;
+    this.roDb = roDb;
     this.NoteModel = new NoteModel(this);
   }
   /** Override because userId is guaranteed in this Context */

--- a/servers/notes-api/src/config/index.ts
+++ b/servers/notes-api/src/config/index.ts
@@ -41,7 +41,8 @@ export const config = {
     timeout: 2 * 1000, // ms
   },
   database: {
-    host: process.env.DATABASE_HOST || 'localhost',
+    readHost: process.env.DB_READ_HOST || 'localhost',
+    writeHost: process.env.DB_WRITE_HOST || 'localhost',
     username: process.env.DATABASE_USER || 'pocket',
     password: process.env.DATABASE_PASSWORD || 'password',
     dbname: process.env.DATABASE_NAME || 'pocketnotes',

--- a/servers/notes-api/src/datasources/NoteService.ts
+++ b/servers/notes-api/src/datasources/NoteService.ts
@@ -12,7 +12,7 @@ export class NotesService {
    * @returns
    */
   async get(noteId: string) {
-    const result = await this.context.db
+    const result = await this.context.roDb
       .selectFrom('Note')
       .selectAll()
       .where('noteId', '=', noteId)
@@ -28,7 +28,7 @@ export class NotesService {
    * @returns
    */
   async getMany(noteIds: readonly string[]) {
-    const result = await this.context.db
+    const result = await this.context.roDb
       .selectFrom('Note')
       .selectAll()
       .where('userId', '=', this.context.userId)

--- a/servers/notes-api/src/datasources/db.ts
+++ b/servers/notes-api/src/datasources/db.ts
@@ -3,27 +3,44 @@ import { Pool } from 'pg';
 import { Kysely, PostgresDialect } from 'kysely';
 import { config } from '../config';
 
-const dialect = new PostgresDialect({
-  pool: new Pool({
-    database: config.database.dbname,
-    host: config.database.host,
-    user: config.database.username,
-    password: config.database.password,
-    port: config.database.port,
-    max: config.database.maxPool,
-  }),
-});
+const dialect = (host: string) =>
+  new PostgresDialect({
+    pool: new Pool({
+      database: config.database.dbname,
+      host: host,
+      user: config.database.username,
+      password: config.database.password,
+      port: config.database.port,
+      max: config.database.maxPool,
+    }),
+  });
 
+// Readonly
+let _roDb: Kysely<DB>;
+// Writer
 let _db: Kysely<DB>;
-const lazyDb = (): Kysely<DB> => {
+
+const lazyRoDb = (): Kysely<DB> => {
+  if (_roDb != null) {
+    return _roDb;
+  } else {
+    _roDb = new Kysely<DB>({
+      dialect: dialect(config.database.readHost),
+    });
+    return _roDb;
+  }
+};
+
+const lazyWriteDb = (): Kysely<DB> => {
   if (_db != null) {
     return _db;
   } else {
     _db = new Kysely<DB>({
-      dialect,
+      dialect: dialect(config.database.writeHost),
     });
     return _db;
   }
 };
 
-export const db = lazyDb();
+export const roDb = lazyRoDb();
+export const db = lazyWriteDb();


### PR DESCRIPTION
The notes deployment was failing because it was expecting a secret that was only created for mysql RDS instances.

This PR updates the module to create it for Postgres instances too.

It also updates the application code to have separate read/write connections, and changes all the existing connections to be read-only (since no mutations have been implemented).