### PR TITLE
fix(search): update our flakey search tests

### DIFF
--- a/.docker/aws-resources/elasticsearch/esindex_corpus_de.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_de.json
@@ -2,7 +2,7 @@
   "settings": {
     "index": {
       "number_of_shards": 1,
-      "number_of_replicas": 1,
+      "number_of_replicas": 0,
       "knn": true
     }
   },

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_en_luc.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_en_luc.json
@@ -1,8 +1,8 @@
 {
   "settings": {
     "index": {
-      "number_of_shards": 2,
-      "number_of_replicas": 1,
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
       "knn": true
     }
   },

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_es.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_es.json
@@ -2,7 +2,7 @@
   "settings": {
     "index": {
       "number_of_shards": 1,
-      "number_of_replicas": 1,
+      "number_of_replicas": 0,
       "knn": true
     }
   },

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_fr.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_fr.json
@@ -2,7 +2,7 @@
   "settings": {
     "index": {
       "number_of_shards": 1,
-      "number_of_replicas": 1,
+      "number_of_replicas": 0,
       "knn": true
     }
   },

--- a/.docker/aws-resources/elasticsearch/esindex_corpus_it.json
+++ b/.docker/aws-resources/elasticsearch/esindex_corpus_it.json
@@ -2,7 +2,7 @@
   "settings": {
     "index": {
       "number_of_shards": 1,
-      "number_of_replicas": 1,
+      "number_of_replicas": 0,
       "knn": true
     }
   },

--- a/.docker/aws-resources/elasticsearch/esindex_list.json
+++ b/.docker/aws-resources/elasticsearch/esindex_list.json
@@ -1,8 +1,8 @@
 {
   "settings": {
     "index": {
-      "number_of_shards": 10,
-      "number_of_replicas": 2
+      "number_of_shards": 1,
+      "number_of_replicas": 0
     }
   },
   "mappings": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       start_period: 80s
 
   localstack:
-    image: localstack/localstack:3.7.1@sha256:7f4f51bbfcfb42c661b9c02716a3cfcb53433f3c066905329aa911178835b300
+    image: localstack/localstack:4.0.2
     ports:
       - '4566:4566'
     volumes:

--- a/servers/user-list-search/src/corpus/keywordSearch.integration.ts
+++ b/servers/user-list-search/src/corpus/keywordSearch.integration.ts
@@ -23,7 +23,7 @@ describe('Corpus search - keyword', () => {
   beforeAll(async () => {
     await deleteDocuments();
     await seedCorpus();
-    await unleash(
+    unleash(
       mockFlags([
         { name: config.unleash.flags.semanticSearch.name, enabled: false },
       ]),

--- a/servers/user-list-search/src/corpus/semanticSearch.integration.ts
+++ b/servers/user-list-search/src/corpus/semanticSearch.integration.ts
@@ -32,7 +32,7 @@ describe('Corpus search - semantic', () => {
   const clientMock: any = jest.spyOn(Client.prototype, 'search');
 
   beforeAll(async () => {
-    await unleash(
+    unleash(
       mockFlags([
         { name: config.unleash.flags.semanticSearch.name, enabled: true },
       ]),

--- a/servers/user-list-search/src/datasource/elasticsearch/elasticsearchBulk.integration.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/elasticsearchBulk.integration.ts
@@ -3,6 +3,7 @@ import { client } from './index';
 
 import { bulkDocument } from './elasticsearchBulk';
 import { getDocument } from './elasticsearchSearch';
+import { deleteDocuments } from '../../test/utils/searchIntegrationTestHelpers';
 
 const defaultDocProps = {
   resolved_id: 1,
@@ -19,19 +20,7 @@ const defaultDocProps = {
 
 describe('Elasticsearch Bulk', () => {
   beforeAll(async () => {
-    await client.deleteByQuery({
-      index: config.aws.elasticsearch.list.index,
-      body: {
-        query: {
-          match_all: {},
-        },
-      },
-    });
-
-    // Wait for delete to finish
-    await client.indices.refresh({
-      index: config.aws.elasticsearch.list.index,
-    });
+    await deleteDocuments();
 
     await bulkDocument([
       {
@@ -49,6 +38,10 @@ describe('Elasticsearch Bulk', () => {
     await client.indices.refresh({
       index: config.aws.elasticsearch.list.index,
     });
+  });
+
+  afterAll(async () => {
+    await deleteDocuments();
   });
 
   it('can bulk index a document', async () => {

--- a/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.integration.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.integration.ts
@@ -323,8 +323,8 @@ describe('Elasticsearch Search Query', () => {
     expect(response.pageInfo.hasPreviousPage).toBeFalse();
     expect(response.edges.length).toBe(2);
     expect(response.edges[0].cursor).toBe('MA==');
-    expect(response.edges[0].node.savedItem.id).toBe(123);
-    expect(response.edges[1].node.savedItem.id).toBe(789);
+    expect(response.edges[0].node.savedItem.id).toBe(456);
+    expect(response.edges[1].node.savedItem.id).toBe(123);
     expect(response.edges[1].cursor).toBe('MQ==');
   }, 10000);
 

--- a/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.integration.ts
+++ b/servers/user-list-search/src/datasource/elasticsearch/elasticsearchSearch.integration.ts
@@ -8,6 +8,7 @@ import {
 } from '../../__generated__/types';
 import { client } from './index';
 import { config } from '../../config';
+import { deleteDocuments } from '../../test/utils/searchIntegrationTestHelpers';
 
 const defaultDocProps = {
   resolved_id: 1,
@@ -23,19 +24,7 @@ const defaultDocProps = {
 
 describe('Elasticsearch Search Query', () => {
   beforeEach(async () => {
-    await client.deleteByQuery({
-      index: config.aws.elasticsearch.list.index,
-      body: {
-        query: {
-          match_all: {},
-        },
-      },
-    });
-
-    // Wait for delete to finish
-    await client.indices.refresh({
-      index: config.aws.elasticsearch.list.index,
-    });
+    await deleteDocuments();
 
     await bulkDocument([
       {
@@ -137,6 +126,10 @@ describe('Elasticsearch Search Query', () => {
     await client.indices.refresh({
       index: config.aws.elasticsearch.list.index,
     });
+  });
+
+  afterAll(async () => {
+    await deleteDocuments();
   });
 
   // For now this gives us confidence that basic search is not
@@ -330,8 +323,8 @@ describe('Elasticsearch Search Query', () => {
     expect(response.pageInfo.hasPreviousPage).toBeFalse();
     expect(response.edges.length).toBe(2);
     expect(response.edges[0].cursor).toBe('MA==');
-    expect(response.edges[0].node.savedItem.id).toBe(456);
-    expect(response.edges[1].node.savedItem.id).toBe(123);
+    expect(response.edges[0].node.savedItem.id).toBe(123);
+    expect(response.edges[1].node.savedItem.id).toBe(789);
     expect(response.edges[1].cursor).toBe('MQ==');
   }, 10000);
 

--- a/servers/user-list-search/src/saves/elasticsearch.integration.ts
+++ b/servers/user-list-search/src/saves/elasticsearch.integration.ts
@@ -2,6 +2,7 @@ import { client } from '../datasource/elasticsearch';
 import { config } from '../config';
 import { bulkDocument } from '../datasource/elasticsearch/elasticsearchBulk';
 import { deleteSearchIndexByUserId } from './elasticsearch';
+import { deleteDocuments } from '../test/utils/searchIntegrationTestHelpers';
 
 const defaultDocProps = {
   resolved_id: 1,
@@ -17,19 +18,7 @@ const defaultDocProps = {
 
 describe('Elasticsearch - Integration', () => {
   beforeEach(async () => {
-    await client.deleteByQuery({
-      index: config.aws.elasticsearch.list.index,
-      body: {
-        query: {
-          match_all: {},
-        },
-      },
-    });
-
-    // Wait for delete to finish
-    await client.indices.refresh({
-      index: config.aws.elasticsearch.list.index,
-    });
+    await deleteDocuments();
 
     await bulkDocument([
       {

--- a/servers/user-list-search/src/server/routes/batchDelete.ts
+++ b/servers/user-list-search/src/server/routes/batchDelete.ts
@@ -29,10 +29,7 @@ export function validate(
 ): Response {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
-    return res
-      .status(400)
-      .json({ errors: errors.array() })
-      .setHeader('Content-Type', 'application/json');
+    return res.status(400).json({ errors: errors.array() });
   }
   next();
 }

--- a/servers/user-list-search/src/test/utils/corpusSeeder.ts
+++ b/servers/user-list-search/src/test/utils/corpusSeeder.ts
@@ -49,6 +49,11 @@ export async function deleteDocuments() {
         body: { query: { match_all: {} } },
         wait_for_completion: true,
       });
+      // Forcemerge the index because with our updates and number of documents the score can change when it should not.
+      // https://kulekci.medium.com/understanding-and-resolving-elasticsearch-score-changes-after-document-updates-a9f426b76e38
+      await client.indices.forcemerge({
+        index,
+      });
       await client.indices.refresh({
         index,
       });

--- a/servers/user-list-search/src/test/utils/searchIntegrationTestHelpers.ts
+++ b/servers/user-list-search/src/test/utils/searchIntegrationTestHelpers.ts
@@ -28,6 +28,13 @@ export async function deleteDocuments() {
         },
       },
       waitForCompletion: true,
+      conflicts: 'proceed',
+    });
+
+    // Forcemerge the index because with our updates and number of documents the score can change when it should not.
+    // https://kulekci.medium.com/understanding-and-resolving-elasticsearch-score-changes-after-document-updates-a9f426b76e38
+    await client.indices.forcemerge({
+      index: config.aws.elasticsearch.list.index,
     });
 
     // Wait for delete to finish

--- a/servers/user-list-search/src/test/utils/searchIntegrationTestHelpers.ts
+++ b/servers/user-list-search/src/test/utils/searchIntegrationTestHelpers.ts
@@ -1,4 +1,6 @@
 import { Knex } from 'knex';
+import { client } from '../../datasource/elasticsearch';
+import { config } from '../../config';
 
 export type SeedData = {
   favorite: number;
@@ -12,6 +14,30 @@ export type SeedData = {
   isImage?: number;
   isVideo?: number;
 };
+
+/**
+ * Test cleanup: delete all documents in search indices
+ */
+export async function deleteDocuments() {
+  try {
+    await client.deleteByQuery({
+      index: config.aws.elasticsearch.list.index,
+      body: {
+        query: {
+          match_all: {},
+        },
+      },
+      waitForCompletion: true,
+    });
+
+    // Wait for delete to finish
+    await client.indices.refresh({
+      index: config.aws.elasticsearch.list.index,
+    });
+  } catch (error) {
+    console.log(error);
+  }
+}
 
 export async function loadItemExtended(db, seedData: SeedData) {
   const optionalDefaults = {


### PR DESCRIPTION
# Goal

Ensure our search tests return the same results every time. 

This is fixed with a few things:
* Ensure there are no replicas
* Ensure that there is only 1 shard (for testing since shards can take minutes to update when searching)
* Ensure all documents are always deleted
* And the main thing: Setup a forcemerge which runs as an elastic search task in the background to delete old documents which were changing the relevance score, [see this for a better description of the issue](https://kulekci.medium.com/understanding-and-resolving-elasticsearch-score-changes-after-document-updates-a9f426b76e38).
