### PR TITLE
feat(notes): return markdown content

### DIFF
--- a/servers/notes-api/schema.graphql
+++ b/servers/notes-api/schema.graphql
@@ -24,8 +24,13 @@ type Note @key(fields: "id") {
   title: String
   """
   JSON representation of a ProseMirror document
+  (compatible with Markdown)
   """
   docContent: ProseMirrorJson
+  """
+  Markdown representation of the note content
+  """
+  docMarkdown: Markdown
   """
   Markdown preview of the note content for summary view.
   """

--- a/servers/notes-api/src/__generated__/graphql.ts
+++ b/servers/notes-api/src/__generated__/graphql.ts
@@ -186,8 +186,13 @@ export type Note = {
    * storage if this value is true.
    */
   deleted: Scalars['Boolean']['output'];
-  /** JSON representation of a ProseMirror document */
+  /**
+   * JSON representation of a ProseMirror document
+   * (compatible with Markdown)
+   */
   docContent?: Maybe<Scalars['ProseMirrorJson']['output']>;
+  /** Markdown representation of the note content */
+  docMarkdown?: Maybe<Scalars['Markdown']['output']>;
   /** This Note's identifier */
   id: Scalars['ID']['output'];
   /**
@@ -499,6 +504,7 @@ export type NoteResolvers<ContextType = IContext, ParentType extends ResolversPa
   createdAt?: Resolver<ResolversTypes['ISOString'], ParentType, ContextType>;
   deleted?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   docContent?: Resolver<Maybe<ResolversTypes['ProseMirrorJson']>, ParentType, ContextType>;
+  docMarkdown?: Resolver<Maybe<ResolversTypes['Markdown']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   savedItem?: Resolver<Maybe<ResolversTypes['SavedItem']>, ParentType, ContextType>;
   source?: Resolver<Maybe<ResolversTypes['ValidUrl']>, ParentType, ContextType>;

--- a/servers/notes-api/src/models/Note.ts
+++ b/servers/notes-api/src/models/Note.ts
@@ -74,6 +74,10 @@ export class NoteModel {
       title: note.title,
       updatedAt: note.updatedAt,
       source: note.sourceUrl,
+      docMarkdown:
+        note.docContent != null
+          ? new ProseMirrorDoc(note.docContent).markdown
+          : null,
       // TODO - Non-default schema
       contentPreview:
         note.docContent != null

--- a/servers/notes-api/src/models/ProseMirrorDoc.spec.ts
+++ b/servers/notes-api/src/models/ProseMirrorDoc.spec.ts
@@ -12,6 +12,12 @@ describe('ProseMirrorDoc', () => {
       expect(doc.preview).toBeString();
     });
   });
+  describe('markdown', () => {
+    it('smoke test: converts a multi-paragraph input to a string', () => {
+      const doc = new ProseMirrorDoc(basicText, schema);
+      expect(doc.markdown).toBeString();
+    });
+  });
   describe('quote constructor', () => {
     it('wraps quote in blockquote and adds attribution', () => {
       const { input, expectedSource } = fromQuote;

--- a/servers/notes-api/src/models/ProseMirrorDoc.ts
+++ b/servers/notes-api/src/models/ProseMirrorDoc.ts
@@ -28,6 +28,14 @@ export class ProseMirrorDoc {
   get preview() {
     return defaultMarkdownSerializer.serialize(this.document);
   }
+  /**
+   * Markdown representation of the document content.
+   * Returns the document serialized
+   * to [CommonMark](http://commonmark.org/).
+   */
+  get markdown() {
+    return defaultMarkdownSerializer.serialize(this.document);
+  }
 }
 
 /**

--- a/servers/notes-api/src/test/operations/mutations.ts
+++ b/servers/notes-api/src/test/operations/mutations.ts
@@ -6,6 +6,7 @@ const NoteFragment = gql`
     id
     title
     docContent
+    docMarkdown
     contentPreview
     createdAt
     updatedAt

--- a/servers/notes-api/src/test/operations/queries.ts
+++ b/servers/notes-api/src/test/operations/queries.ts
@@ -6,6 +6,7 @@ const NoteFragment = gql`
     id
     title
     docContent
+    docMarkdown
     contentPreview
     createdAt
     updatedAt

--- a/servers/notes-api/src/test/queries/note.integration.ts
+++ b/servers/notes-api/src/test/queries/note.integration.ts
@@ -52,9 +52,11 @@ describe('note', () => {
     if (noteSeed.docContent != null) {
       expect(JSON.parse(note.docContent)).toEqual(noteSeed.docContent);
       expect(note.contentPreview).toBeString();
+      expect(note.docMarkdown).toBeString();
     } else {
       expect(note.docContent).toBeNull();
       expect(note.contentPreview).toBeNull();
+      expect(note.docMarkdown).toBeNull();
     }
     if (noteSeed.sourceUrl != null) {
       expect(note.savedItem).toEqual({


### PR DESCRIPTION
Return markdown representation of docContent. Does not do validation.

[POCKET-10896]