### PR TITLE
chore: bump size limit on v3 proxy request

### DIFF
--- a/servers/v3-proxy-api/src/server.ts
+++ b/servers/v3-proxy-api/src/server.ts
@@ -22,7 +22,7 @@ export async function startServer(port: number): Promise<{
 }> {
   const app: Application = express();
   const httpServer: Server = createServer(app);
-  const sizeLimit = '15mb';
+  const sizeLimit = '35mb';
 
   app.use(charsetFixHandler);
   app.use(json({ limit: sizeLimit }));


### PR DESCRIPTION
Bump request size for v3-proxy

We are concerned that this may be masking some other issues (currently 5 errors/min from what appears to be a single client)