### PR TITLE
fix(v3proxy): allow cookie auth on v3/send

### DIFF
--- a/servers/v3-proxy-api/src/graph/graphQLClient.ts
+++ b/servers/v3-proxy-api/src/graph/graphQLClient.ts
@@ -43,7 +43,7 @@ import * as Sentry from '@sentry/node';
 import { serverLogger } from '@pocket-tools/ts-logger';
 
 export function getClient(
-  accessToken: string,
+  accessToken: string | null,
   consumerKey: string,
   headers: any,
 ) {
@@ -74,7 +74,7 @@ export function getClient(
 export class GraphQLClientFactory {
   url: string;
   constructor(
-    accessToken: string,
+    accessToken: string | null,
     consumerKey: string,
     private headers: any,
   ) {

--- a/servers/v3-proxy-api/src/routes/ActionsRouter.ts
+++ b/servers/v3-proxy-api/src/routes/ActionsRouter.ts
@@ -101,7 +101,7 @@ type SendActionResult = {
 export class ActionsRouter {
   protected client: GraphQLClientFactory;
   constructor(
-    accessToken: string,
+    accessToken: string | null,
     consumerKey: string,
     headers: Request['headers'],
   ) {

--- a/servers/v3-proxy-api/src/routes/v3Send.integration.ts
+++ b/servers/v3-proxy-api/src/routes/v3Send.integration.ts
@@ -183,6 +183,15 @@ describe('v3/send', () => {
           });
         expect(response.status).toEqual(400);
       });
+      it('makes request without access token (cookie auth)', async () => {
+        const response = await request(app)
+          .post('/v3/send')
+          .send({
+            consumer_key: 'test',
+            actions: [{ action: 'add', url: 'http://domain.com/path' }],
+          });
+        expect(response.status).toEqual(200);
+      });
       it('returns 400 if proper identifiers are not included', async () => {
         const response = await request(app)
           .post('/v3/send')

--- a/servers/v3-proxy-api/src/routes/validations/SendSchema.ts
+++ b/servers/v3-proxy-api/src/routes/validations/SendSchema.ts
@@ -2,7 +2,7 @@ import { Schema } from 'express-validator';
 import { MaybeAction } from './SendActionValidators';
 
 export type V3SendParams = {
-  access_token: string;
+  access_token?: string;
   consumer_key: string;
   actions: MaybeAction[];
 };
@@ -17,6 +17,7 @@ export type V3SendParams = {
  */
 export const V3SendSchemaPost: Schema = {
   access_token: {
+    optional: true,
     isString: true,
     notEmpty: {
       errorMessage: '`access_token` cannot be empty',


### PR DESCRIPTION
We discovered that the web client was still using this endpoint for tag renames. Make access_token optional to enable cookie-based auth (analogous to v3/get).
