### PR TITLE
feat(clientapi): add operation name and errors to otel instrumentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
       retries: 30
     ports:
       - '9090:9090'
-  
+
   otlpcollector:
     image: grafana/otel-lgtm
     ports:
@@ -106,14 +106,17 @@ services:
       - 4318:4318 # OTLP http receiver
       - 3000:3000 # Grafana
 
-  # Uncomment this if you want to run the collector locally and send to GCP instead of the one used for local development
-  # Make sure to have a service json in GOOGLE_APPLICATION_CREDENTIALS_JSON in the .env file
+
+  # # Uncomment this if you want to run the collector locally and send to GCP instead of the one used for local development
+  # # Make sure to have a service json in GOOGLE_APPLICATION_CREDENTIALS_JSON in the .env file
   # otlpcollector:
   #   build:
   #     context: ./servers/otel-collector
   #     dockerfile: Dockerfile
   #   env_file:
   #     - .env
+  #   volumes:
+  #     - ./servers/otel-collector/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
   #   environment:
   #     - DEPLOYMENT_ENVIRONMENT_NAME=local
   #   ports:

--- a/servers/client-api/config/router.yaml
+++ b/servers/client-api/config/router.yaml
@@ -94,10 +94,17 @@ telemetry:
               request_header: 'apollographql-client-version'
         http.server.request.duration:
           attributes:
+            http.response.status_code: true
             'http.request.header.apollographql-client-name':
               request_header: 'apollographql-client-name'
             'http.request.header.apollographql-client-version':
               request_header: 'apollographql-client-version'
+            'graphql.operation.name': # Will set this attribute with the operation name
+              operation_name: string
+            'graphql.errors': # Will set this attribute to true if it contains graphql error (includes unauthorized)
+              on_graphql_error: true
+            'graphql.critical.error':
+              error: reason
       subgraph:
         http.client.request.body.size:
           attributes:


### PR DESCRIPTION
Tested locally to confirm the attributes were sent as expected.

Note that "graphql.errors" will be true for 'unauthorized' error, but it will not show an error reason in the 'critical' error field.