### PR TITLE
chore(parser): bump minimum tasks to 12

### DIFF
--- a/infrastructure/parser-graphql-wrapper/src/main.ts
+++ b/infrastructure/parser-graphql-wrapper/src/main.ts
@@ -358,7 +358,7 @@ class ParserGraphQLWrapper extends TerraformStack {
       },
 
       autoscalingConfig: {
-        targetMinCapacity: config.environment === 'Prod' ? 8 : 1,
+        targetMinCapacity: config.environment === 'Prod' ? 12 : 1,
         targetMaxCapacity: config.environment === 'Prod' ? 20 : 10,
       },
       alarms: {


### PR DESCRIPTION
The parser-graphql-wrapper is causing latency issues on graphql requests; bump minimum tasks to handle load. Scaling on cpu and memory does not correlate with increasing request latency.