### PR TITLE
fix(braze): standardize and improve observability+logging

### DIFF
--- a/lambdas/transactional-emails/src/handlers/accountDelete.spec.ts
+++ b/lambdas/transactional-emails/src/handlers/accountDelete.spec.ts
@@ -76,9 +76,9 @@ describe('accountDelete handler', () => {
       Records: [record] as SQSRecord[],
     } as SQSEvent);
 
-    expect(serverLoggerSpy).toHaveBeenCalled();
-    expect(serverLoggerSpy.mock.calls[0][0]['errorData']['message']).toContain(
-      'Error 400: Failed to send email',
+    expect(serverLoggerSpy).toHaveBeenCalledTimes(2);
+    expect(serverLoggerSpy.mock.calls[1][0]['errorData']['message']).toContain(
+      'Error 400: Failed to send Account Deletion email',
     );
   });
 

--- a/lambdas/transactional-emails/src/handlers/forgotPassword.spec.ts
+++ b/lambdas/transactional-emails/src/handlers/forgotPassword.spec.ts
@@ -57,9 +57,9 @@ describe('forgotPassword handler', () => {
       Records: [record] as SQSRecord[],
     } as SQSEvent);
 
-    expect(serverLoggerSpy).toHaveBeenCalled();
-    expect(serverLoggerSpy.mock.calls[0][0]['errorData']['message']).toContain(
-      'Error 400: Failed to send email',
+    expect(serverLoggerSpy).toHaveBeenCalledTimes(2);
+    expect(serverLoggerSpy.mock.calls[1][0]['errorData']['message']).toContain(
+      'Error 400: Failed to send Forgot Password email',
     );
   });
 

--- a/lambdas/transactional-emails/src/handlers/listExportReady.spec.ts
+++ b/lambdas/transactional-emails/src/handlers/listExportReady.spec.ts
@@ -79,9 +79,9 @@ describe('listExportReady handler', () => {
     await processor({
       Records: [record] as SQSRecord[],
     } as SQSEvent);
-    expect(serverLoggerSpy).toHaveBeenCalled();
-    expect(serverLoggerSpy.mock.calls[0][0]['errorData']['message']).toContain(
-      'Error 400: Failed to send email',
+    expect(serverLoggerSpy).toHaveBeenCalledTimes(2);
+    expect(serverLoggerSpy.mock.calls[1][0]['errorData']['message']).toContain(
+      'Error 400: Failed to send List Export Ready email',
     );
   });
 

--- a/lambdas/transactional-emails/src/handlers/premiumPurchaseHandler.spec.ts
+++ b/lambdas/transactional-emails/src/handlers/premiumPurchaseHandler.spec.ts
@@ -96,16 +96,16 @@ describe('premium purchase handler', () => {
   it('should throw server error if all 3 retries fails', async () => {
     nock(config.braze.endpoint)
       .post(config.braze.userTrackPath)
-      .times(3)
+      .times(4)
       .reply(500, { errors: ['this is server error'] });
 
     await processor({
       Records: [record] as SQSRecord[],
     } as SQSEvent);
     expect(nock.isDone()).toBeTruthy();
-    expect(serverLoggerSpy).toHaveBeenCalled();
-    expect(serverLoggerSpy.mock.calls[0][0]['errorData']['message']).toContain(
-      'Error 500: Failed to send premium purchase event',
+    expect(serverLoggerSpy).toHaveBeenCalledTimes(2);
+    expect(serverLoggerSpy.mock.calls[1][0]['errorData']['message']).toContain(
+      'Error 500: Failed to call User Track endpoint',
     );
   });
 
@@ -117,9 +117,9 @@ describe('premium purchase handler', () => {
       Records: [record] as SQSRecord[],
     } as SQSEvent);
     expect(nock.isDone()).toBeTruthy();
-    expect(serverLoggerSpy).toHaveBeenCalled();
-    expect(serverLoggerSpy.mock.calls[0][0]['errorData']['message']).toContain(
-      'Error 400: Failed to send premium purchase event',
+    expect(serverLoggerSpy).toHaveBeenCalledTimes(2);
+    expect(serverLoggerSpy.mock.calls[1][0]['errorData']['message']).toContain(
+      'Error 400: Failed to call User Track endpoint',
     );
   });
 

--- a/lambdas/transactional-emails/src/handlers/premiumPurchaseHandler.ts
+++ b/lambdas/transactional-emails/src/handlers/premiumPurchaseHandler.ts
@@ -15,13 +15,7 @@ export async function premiumPurchaseHandler(
 ): Promise<Response | null> {
   if (event?.['detail-type'] === PocketEventType.PREMIUM_PURCHASE) {
     const requestBody = generateUserTrackRequestBody(event, event.time);
-    const res = await sendUserTrack(requestBody);
-    if (!res.ok) {
-      throw new Error(
-        `Error ${res.status}: Failed to send premium purchase event`,
-      );
-    }
-    return res;
+    return await sendUserTrack(requestBody);
   }
   return null;
 }

--- a/lambdas/transactional-emails/src/handlers/userRegistrationEventHandler.spec.ts
+++ b/lambdas/transactional-emails/src/handlers/userRegistrationEventHandler.spec.ts
@@ -93,8 +93,9 @@ describe('user registration event handler', () => {
     await processor({
       Records: [record] as SQSRecord[],
     } as SQSEvent);
-    expect(serverLoggerSpy).toHaveBeenCalled();
-    expect(serverLoggerSpy.mock.calls[0][0]['errorData']['message']).toContain(
+    // Logging the HTTP failure and overall error data
+    expect(serverLoggerSpy).toHaveBeenCalledTimes(2);
+    expect(serverLoggerSpy.mock.calls[1][0]['errorData']['message']).toContain(
       'Error 400: Failed to create user alias',
     );
   });
@@ -118,9 +119,9 @@ describe('user registration event handler', () => {
     await processor({
       Records: [record] as SQSRecord[],
     } as SQSEvent);
-    expect(serverLoggerSpy).toHaveBeenCalled();
-    expect(serverLoggerSpy.mock.calls[0][0]['errorData']['message']).toContain(
-      `Error 400: Failed to set subscription for id: ${config.braze.marketingSubscriptionId}`,
+    expect(serverLoggerSpy).toHaveBeenCalledTimes(2);
+    expect(serverLoggerSpy.mock.calls[1][0]['errorData']['message']).toContain(
+      `Error 400: Failed to update subscription`,
     );
   });
 
@@ -152,7 +153,7 @@ describe('user registration event handler', () => {
   it('should throw server error if all 3 retries fails', async () => {
     nock(config.braze.endpoint)
       .post(config.braze.userTrackPath)
-      .times(3)
+      .times(4)
       .reply(500, { errors: ['this is server error'] });
 
     await processor({
@@ -161,7 +162,7 @@ describe('user registration event handler', () => {
     expect(nock.isDone()).toBeTruthy();
     expect(serverLoggerSpy).toHaveBeenCalled();
     expect(serverLoggerSpy.mock.calls[1][0]['errorData']['message']).toContain(
-      'Error 500: Failed to create user profile',
+      'Error 500: Failed to call User Track endpoint',
     );
   });
 
@@ -176,7 +177,7 @@ describe('user registration event handler', () => {
     expect(nock.isDone()).toBeTruthy();
     expect(serverLoggerSpy).toHaveBeenCalled();
     expect(serverLoggerSpy.mock.calls[1][0]['errorData']['message']).toContain(
-      'Error 400: Failed to create user profile',
+      'Error 400: Failed to call User Track endpoint',
     );
   });
 

--- a/lambdas/transactional-emails/src/index.ts
+++ b/lambdas/transactional-emails/src/index.ts
@@ -37,7 +37,6 @@ export async function processor(event: SQSEvent): Promise<SQSBatchResponse> {
           pocketEvent,
           data: record.body,
         });
-        batchFailures.push({ itemIdentifier: record.messageId });
         continue;
       }
       await handlers[pocketEvent['detail-type']](pocketEvent);
@@ -45,7 +44,7 @@ export async function processor(event: SQSEvent): Promise<SQSBatchResponse> {
       serverLogger.error({
         message: 'Failed to send request to Braze',
         errorData: error,
-        errorMessage: error.mesage,
+        errorMessage: error.message,
         request: record,
       });
       Sentry.captureException(error);


### PR DESCRIPTION
Update fetch-retry to actually retry 3 times (not 2)

Add 504 Bad Gateway as a retryable status

Centralize HTTP response error logging and breadcrumb capture for Sentry

Remove unnecessary info logging statements in favor of breadcrumbs when errors are encountered.

[POCKET-10928]

[POCKET-10928]: https://mozilla-hub.atlassian.net/browse/POCKET-10928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ