### PR TITLE
chore(user-api): update minimum tasks from 2-3

### DIFF
--- a/infrastructure/user-api/src/main.ts
+++ b/infrastructure/user-api/src/main.ts
@@ -274,7 +274,7 @@ class UserAPI extends TerraformStack {
           'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy',
       },
       autoscalingConfig: {
-        targetMinCapacity: config.environment === 'Prod' ? 2 : 1,
+        targetMinCapacity: config.environment === 'Prod' ? 3 : 1,
         targetMaxCapacity: config.environment === 'Prod' ? 10 : 1,
       },
       alarms: {


### PR DESCRIPTION
The auto-scaling seems to be aggressive for the load - on the dashboards we can see kind of whiplash and increase in response times. Bumping the minimum tasks from 2 to 3 to alleviate the load whiplash.