### PR TITLE
feat(export): limit caching to 72 hours

### DIFF
--- a/infrastructure/account-data-deleter/src/main.ts
+++ b/infrastructure/account-data-deleter/src/main.ts
@@ -112,17 +112,17 @@ class AccountDataDeleter extends TerraformStack {
             filter: {
               prefix: `${partsPrefix}/`,
             },
-            id: 'list-export-part-15days-expire',
+            id: 'list-export-part-10days-expire',
             status: 'Enabled',
-            expiration: { days: 15 },
+            expiration: { days: 10 },
           },
           {
             filter: {
               prefix: `${archivesPrefix}/`,
             },
-            id: 'list-export-archive-30days-expire',
+            id: 'list-export-archive-3days-expire',
             status: 'Enabled',
-            expiration: { days: 30 },
+            expiration: { days: 3 },
           },
         ],
       },

--- a/servers/account-data-deleter/src/config/index.ts
+++ b/servers/account-data-deleter/src/config/index.ts
@@ -118,7 +118,7 @@ export const config = {
     partsPrefix: process.env.LIST_EXPORT_PARTS_PREFIX || '',
     archivePrefix: process.env.LIST_EXPORT_ARCHIVE_PREFIX || '',
     queryLimit: 10000,
-    signedUrlExpiry: 60 * 60 * 24 * 7, // 7 days in seconds,
+    signedUrlExpiry: 60 * 60 * 24 * 2, // 2 days in seconds,
     presignedIamUserCredentials:
       process.env.EXPORT_SIGNEDURL_USER_ACCESS_KEY_ID &&
       process.env.EXPORT_SIGNEDURL_USER_SECRET_KEY


### PR DESCRIPTION
Update signed url ttl to 48 hours

Lets users request new exports more frequently.

TODO: Update the Braze email template to reflect once this change is merged in (change is drafted and just needs to be deployed)