### PR TITLE
feat(export): add new mutation with feature flag control

### DIFF
--- a/servers/list-api/schema.graphql
+++ b/servers/list-api/schema.graphql
@@ -607,6 +607,14 @@ type SavedItemsPage @tag(name: "v3proxy") {
   limit: Int!
 }
 
+type ExportAcknowledgment {
+  requestId: String!
+}
+
+type ExportDisabled {
+  message: String!
+}
+
 type ReaderViewResult @key(fields: "slug") {
   slug: ID!
   """
@@ -707,6 +715,8 @@ enum PendingItemStatus {
 }
 
 union ImportUploadResponse = PreSignedUrl | ImportLimited
+
+union ExportResponse = ExportAcknowledgment | ExportDisabled
 
 """
 A presigned URL for uploading to S3
@@ -1027,7 +1037,14 @@ type Mutation {
   Request for an asynchronous export of a user's list.
   Returns the request ID associated with the request.
   """
-  exportList: String @requiresScopes(scopes: [["ROLE_USER"]])
+  exportList: String @requiresScopes(scopes: [["ROLE_USER"]]) @deprecated(reason: "use exportData")
+  """
+  Request data for export. Returns an acknowledgment with the
+  request ID, or an error message (if the export service is
+  temporarily disabled for maintenance)
+  """
+  exportData: ExportResponse @requiresScopes(scopes: [["ROLE_USER"]])
+
   """
   Import a batch of items and (optional) tags into a user's list.
   Duplicate entries will be replaced. Returns true if the import

--- a/servers/list-api/src/featureFlags/client.ts
+++ b/servers/list-api/src/featureFlags/client.ts
@@ -1,10 +1,11 @@
 import { Unleash } from 'unleash-client';
 import config from '../config';
 import { getUnleash, mockUnleash } from '@pocket-tools/feature-flags-client';
+import { FeatureInterface } from 'unleash-client/lib/feature';
 
 let _unleash: Unleash;
 
-export function getClient(): Unleash {
+export function getClient(localMocks?: FeatureInterface[]): Unleash {
   const unleashConfig = {
     url: config.unleash.endpoint,
     appName: config.serviceName,
@@ -18,7 +19,7 @@ export function getClient(): Unleash {
     }
     return _unleash;
   } else {
-    const { unleash } = mockUnleash([]);
+    const { unleash } = mockUnleash(localMocks ?? []);
     return unleash;
   }
 }

--- a/servers/list-api/src/resolvers/index.ts
+++ b/servers/list-api/src/resolvers/index.ts
@@ -26,10 +26,13 @@ import {
   exportList,
   batchImport,
   importUploadUrl,
+  exportData,
 } from './mutation';
 import { tagsSavedItems } from './tag';
 import {
   BaseError,
+  ExportAcknowledgment,
+  ExportDisabled,
   Item,
   NotFound,
   PendingItem,
@@ -61,6 +64,11 @@ const resolvers = {
   },
   SaveByIdResult: {
     __resolveType(parent: PocketSave | NotFound) {
+      return parent.__typename;
+    },
+  },
+  ExportResponse: {
+    __resolveType(parent: ExportAcknowledgment | ExportDisabled) {
       return parent.__typename;
     },
   },
@@ -180,6 +188,7 @@ const resolvers = {
     replaceTags,
     removeTagsByName,
     exportList,
+    exportData,
     batchImport,
     importUploadUrl,
     deleteTagByName: async (

--- a/servers/list-api/src/types/index.ts
+++ b/servers/list-api/src/types/index.ts
@@ -310,3 +310,13 @@ export type ImportLimited = {
   message: string;
   refreshInHours: number;
 };
+
+export type ExportAcknowledgment = {
+  __typename: 'ExportAcknowledgment';
+  requestId: string;
+};
+
+export type ExportDisabled = {
+  __typename: 'ExportDisabled';
+  message: string;
+};


### PR DESCRIPTION
For disabling export for maintenance -- let the queue processing finish, then we can do maintenance when we don't want new messages added to the export queue.