### PR TITLE
chore(export): Add Sentry alerts for data export failures (HNT-545)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ servers/v3-proxy-api/schema.graphql
 
 # notebooks
 .ipynb_checkpoints
+
+.idea
+

--- a/servers/account-data-deleter/src/dataService/exportStateService.spec.ts
+++ b/servers/account-data-deleter/src/dataService/exportStateService.spec.ts
@@ -1,6 +1,21 @@
+import * as Sentry from '@sentry/node';
 import { ExportStateService } from './exportStateService';
+import { PocketEventType } from '@pocket-tools/event-bridge';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 
 describe('export state service', () => {
+  let captureExceptionSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    captureExceptionSpy = jest
+      .spyOn(Sentry, 'captureException')
+      .mockImplementation(); // stub, doesn't send
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks(); // clean up spies
+  });
+
   it('marks complete when all services are true', () => {
     const input = {
       annotations: true,
@@ -14,5 +29,101 @@ describe('export state service', () => {
       shareablelistsCompletedAt: '2025-03-06T18:54:19.183Z',
     };
     expect(ExportStateService.isComplete(input)).toBeTrue();
+  });
+
+  it('getExportUrl - sendS Sentry error when zip export fails', async () => {
+    // Mock S3 export bucket
+    const mockExportBucket = {
+      zipFilesByPrefix: jest.fn().mockResolvedValue(null), // create a mock failure
+    };
+    // Mock event bridge
+    const mockEventBridge = {
+      sendPocketEvent: jest.fn(),
+    };
+
+    const mockExportStateService = new ExportStateService(
+      mockEventBridge as any,
+      mockExportBucket as any,
+      {} as DynamoDBDocumentClient,
+    );
+
+
+    await expect(mockExportStateService.getExportUrl('p', 'abc-123')).rejects.toThrow(
+      'ExportStateService - getExportUrl - Failed to zip export files',
+    );
+    // Check zipFilesByPrefix was called
+    expect(mockExportBucket.zipFilesByPrefix).toHaveBeenCalled();
+    // Check for Sentry error
+    expect(captureExceptionSpy).toHaveBeenCalled();
+  });
+
+  it('notifyUser - sends a Sentry error when sending notification fails', async () => {
+    // Mock event bridge
+    const mockEventBridge = {
+      sendPocketEvent: jest.fn().mockRejectedValue(new Error('Failed to send EventBridge notification')),
+    };
+    const mockExportStateService = new ExportStateService(mockEventBridge as any, {} as any, {} as any);
+
+    await expect(
+      mockExportStateService.notifyUser('encoded-id', 'abc-123', 'https://example.com'),
+    ).rejects.toThrow('Failed to send EventBridge notification');
+
+    // Check sendPocketEvent was called
+    expect(mockEventBridge.sendPocketEvent).toHaveBeenCalled();
+    // Check for Sentry error
+    expect(captureExceptionSpy).toHaveBeenCalled();
+  });
+
+  it('startExport - sends a Sentry error when putExportMessage call fails', async () => {
+    const mockExportBucket = {
+      objectExists: jest.fn().mockResolvedValue(false),
+    };
+
+    const mockExportStateService = new ExportStateService(
+      { sendPocketEvent: jest.fn() } as any,
+      mockExportBucket as any,
+      {} as any,
+    );
+
+    jest.spyOn(mockExportStateService, 'updateStatus').mockResolvedValue({
+      requestId: 'abc-123',
+      createdAt: new Date().toISOString(),
+      expiresAt: (Date.now() / 1000) + 1000,
+    });
+    jest.spyOn(mockExportStateService, 'putExportMessage').mockRejectedValue(new Error('Adding export messages to queues failed'));
+
+    const payload = {
+      'detail-type': PocketEventType.EXPORT_REQUESTED,
+      detail: {
+        encodedId: 'abc',
+        requestId: 'abc-123',
+        userId: 123,
+      },
+    };
+
+    await expect(mockExportStateService.startExport(payload as any)).rejects.toThrow('Adding export messages to queues failed');
+    // Check putExportMessage was called
+    expect(mockExportStateService.putExportMessage).toHaveBeenCalled();
+    // Check for Sentry error
+    expect(captureExceptionSpy).toHaveBeenCalled();
+  });
+
+  it('updateStatus - sends a Sentry error when updating export status in Dynamo fails', async () => {
+    const mockDynamo = {
+      send: jest.fn().mockRejectedValue(new Error('Dynamo error')),
+    };
+    const mockExportStateService = new ExportStateService({} as any, {} as any, mockDynamo as any);
+
+    const payload = {
+      'detail-type': PocketEventType.EXPORT_PART_COMPLETE,
+      detail: {
+        requestId: 'abc-123',
+        service: 'list',
+      },
+    };
+
+    await expect(mockExportStateService.updateStatus(payload as any)).rejects.toThrow('Dynamo error');
+    // Check for Sentry error
+    expect(captureExceptionSpy).toHaveBeenCalled();
   });
 });

--- a/servers/account-data-deleter/src/dataService/exportStateService.spec.ts
+++ b/servers/account-data-deleter/src/dataService/exportStateService.spec.ts
@@ -9,11 +9,11 @@ describe('export state service', () => {
   beforeEach(() => {
     captureExceptionSpy = jest
       .spyOn(Sentry, 'captureException')
-      .mockImplementation(); // stub, doesn't send
+      .mockImplementation();
   });
 
   afterEach(() => {
-    jest.restoreAllMocks(); // clean up spies
+    jest.restoreAllMocks();
   });
 
   it('marks complete when all services are true', () => {

--- a/servers/account-data-deleter/src/dataService/exportStateService.ts
+++ b/servers/account-data-deleter/src/dataService/exportStateService.ts
@@ -67,6 +67,7 @@ export class ExportStateService {
           },
         });
         Sentry.captureException(error);
+        throw error;
       }
     }
   }

--- a/servers/account-data-deleter/src/dataService/exportStateService.ts
+++ b/servers/account-data-deleter/src/dataService/exportStateService.ts
@@ -48,15 +48,26 @@ export class ExportStateService {
       body: result,
     });
     if (result != null && ExportStateService.isComplete(result)) {
-      const signedUrl = await this.getExportUrl(
-        payload.detail.prefix,
-        payload.detail.encodedId,
-      );
-      await this.notifyUser(
-        payload.detail.encodedId,
-        payload.detail.requestId,
-        signedUrl,
-      );
+      try {
+        const signedUrl = await this.getExportUrl(
+          payload.detail.prefix,
+          payload.detail.encodedId,
+        );
+        await this.notifyUser(
+          payload.detail.encodedId,
+          payload.detail.requestId,
+          signedUrl,
+        );
+      } catch(error) {
+        Sentry.addBreadcrumb({
+          message: 'ExportStateService - processUpdate failed',
+          data: {
+            requestId: payload.detail.requestId,
+            encodedId: payload.detail.encodedId,
+          },
+        });
+        Sentry.captureException(error);
+      }
     }
   }
 
@@ -65,17 +76,33 @@ export class ExportStateService {
     prefix: string,
     encodedId: string,
   ): Promise<string | undefined> {
-    const zipResponse = await this.exportBucket.zipFilesByPrefix(
-      prefix,
-      this.zipFileKey(encodedId),
-    );
-    if (zipResponse != null) {
+    try {
+      const zipResponse = await this.exportBucket.zipFilesByPrefix(
+        prefix,
+        this.zipFileKey(encodedId),
+      );
+      if (!zipResponse) {
+        const error = new Error('ExportStateService - getExportUrl - Failed to zip export files');
+        Sentry.addBreadcrumb({
+          message: 'ExportStateService - getExportUrl - create zip archive failed',
+          data: { encodedId, prefix },
+        });
+        Sentry.captureException(error);
+        throw error;
+      }
       const { Key: zipKey } = zipResponse;
       const signedUrl = await this.exportBucket.getSignedUrl(
         zipKey,
         config.listExport.signedUrlExpiry,
       );
       return signedUrl;
+    } catch(error) {
+      Sentry.addBreadcrumb({
+        message: 'ExportStateService - getExportUrl failed',
+        data: { encodedId, prefix },
+      });
+      Sentry.captureException(error);
+      throw error;
     }
   }
 
@@ -99,7 +126,8 @@ export class ExportStateService {
         errorData: err,
         payload,
       });
-      Sentry.captureException(err, { data: { payload } });
+      Sentry.addBreadcrumb({ message: 'ExportStateService - notifyUser - Failed to send EventBridge notification', data: { payload } });
+      Sentry.captureException(err);
       // Re-throw for calling function
       throw err;
     }
@@ -133,21 +161,32 @@ export class ExportStateService {
     const cachedExport = await this.lastGoodExport(payload.detail.encodedId);
     if (cachedExport) {
       serverLogger.info({
-        message: 'ExportListHandler - Found valid export',
+        message: 'ExportStateService - Found valid export',
         export: cachedExport,
       });
-      this.notifyUser(
-        payload.detail.encodedId,
-        payload.detail.requestId,
-        cachedExport,
-      );
+      try {
+        await this.notifyUser(
+          payload.detail.encodedId,
+          payload.detail.requestId,
+          cachedExport,
+        );
+      } catch(error) {
+        Sentry.addBreadcrumb({ message: 'exportStateService - startExport - notifyUser call failed'});
+        Sentry.captureException(error);
+        throw error;
+      }
     }
     await this.updateStatus(payload);
-    await this.putExportMessage(payload, config.aws.sqs.listExportQueue.url);
-    await this.putExportMessage(
-      payload,
-      config.aws.sqs.anotationsExportQueue.url,
-    );
+
+    try {
+      Sentry.addBreadcrumb({ message: 'exportStateService - startExport - Adding export messages to list & annotations queues' });
+
+      await this.putExportMessage(payload, config.aws.sqs.listExportQueue.url);
+      await this.putExportMessage(payload, config.aws.sqs.anotationsExportQueue.url);
+    } catch (error) {
+      Sentry.captureException(error);
+      throw error;
+    }
     return true;
   }
 
@@ -176,42 +215,55 @@ export class ExportStateService {
     payload: ExportPartComplete | ExportRequested,
   ): Promise<ExportRequestRecord | undefined> {
     const now = new Date();
-    if (payload['detail-type'] === PocketEventType.EXPORT_REQUESTED) {
+    try {
+      if (payload['detail-type'] === PocketEventType.EXPORT_REQUESTED) {
+        serverLogger.info({
+          message: 'ExportStateService - updateStatus - Creating new export request record',
+          body: payload.detail.requestId
+        });
+        const input = {
+          // Create new export request record
+          TableName: config.listExport.dynamoTable,
+          Key: {
+            requestId: payload.detail.requestId,
+          },
+          UpdateExpression: `SET expiresAt = :ea, createdAt = :ca`,
+          ExpressionAttributeValues: {
+            ':ea': Math.floor(now.getTime() / 1000) + 60 * 60 * 24 * 17, // 17 days (longer than parts retention),
+            ':ca': now.toISOString(),
+          },
+          ReturnValues: 'ALL_NEW' as const,
+        };
+        const result = await this.dynamo.send(new UpdateCommand(input));
+        return result.Attributes as ExportRequestRecord;
+      }
+      // Update the status of the export request to reflect
+      // completed compontents
+      // Remove illegal character
+      const service = payload.detail.service.replace('-', '');
       const input = {
-        // Create new export request record
         TableName: config.listExport.dynamoTable,
         Key: {
           requestId: payload.detail.requestId,
         },
-        UpdateExpression: `SET expiresAt = :ea, createdAt = :ca`,
+        ExpressionAttributeNames: { '#ss': service },
+        UpdateExpression: `SET #ss = :ss, ${service}CompletedAt = :sca`,
         ExpressionAttributeValues: {
-          ':ea': Math.floor(now.getTime() / 1000) + 60 * 60 * 24 * 17, // 17 days (longer than parts retention),
-          ':ca': now.toISOString(),
+          ':ss': true,
+          ':sca': payload.detail.timestamp,
         },
         ReturnValues: 'ALL_NEW' as const,
       };
       const result = await this.dynamo.send(new UpdateCommand(input));
       return result.Attributes as ExportRequestRecord;
+    } catch(error) {
+      Sentry.addBreadcrumb({
+        message: 'ExportStateService - updateStatus - Dynamo error: failed to update status of export',
+        data: { requestId: payload.detail.requestId },
+      });
+      Sentry.captureException(error);
+      throw error;
     }
-    // Update the status of the export request to reflect
-    // completed compontents
-    // Remove illegal character
-    const service = payload.detail.service.replace('-', '');
-    const input = {
-      TableName: config.listExport.dynamoTable,
-      Key: {
-        requestId: payload.detail.requestId,
-      },
-      ExpressionAttributeNames: { '#ss': service },
-      UpdateExpression: `SET #ss = :ss, ${service}CompletedAt = :sca`,
-      ExpressionAttributeValues: {
-        ':ss': true,
-        ':sca': payload.detail.timestamp,
-      },
-      ReturnValues: 'ALL_NEW' as const,
-    };
-    const result = await this.dynamo.send(new UpdateCommand(input));
-    return result.Attributes as ExportRequestRecord;
   }
 
   /**

--- a/servers/account-data-deleter/src/dataService/exportStateService.ts
+++ b/servers/account-data-deleter/src/dataService/exportStateService.ts
@@ -66,7 +66,7 @@ export class ExportStateService {
             encodedId: payload.detail.encodedId,
           },
         });
-        Sentry.captureException(error);
+        Sentry.captureException(error, {tags: { component: 'ExportStateService', function: 'processUpdate' }});
         throw error;
       }
     }
@@ -102,7 +102,7 @@ export class ExportStateService {
         data: { encodedId, prefix },
       });
       // Capture error to Sentry
-      Sentry.captureException(error);
+      Sentry.captureException(error, {tags: { component: 'ExportStateService', function: 'getExportUrl' }});
       throw error;
     }
   }
@@ -172,7 +172,7 @@ export class ExportStateService {
         );
       } catch(error) {
         Sentry.addBreadcrumb({ message: 'ExportStateService - startExport - notifyUser call failed'});
-        Sentry.captureException(error);
+        Sentry.captureException(error, {tags: { component: 'ExportStateService', function: 'startExport' }});
         throw error;
       }
     }
@@ -184,7 +184,7 @@ export class ExportStateService {
       await this.putExportMessage(payload, config.aws.sqs.listExportQueue.url);
       await this.putExportMessage(payload, config.aws.sqs.anotationsExportQueue.url);
     } catch (error) {
-      Sentry.captureException(error);
+      Sentry.captureException(error, {tags: { component: 'ExportStateService', function: 'startExport' }});
       throw error;
     }
     return true;
@@ -242,7 +242,7 @@ export class ExportStateService {
         message: 'ExportStateService - updateStatus - Dynamo error: failed to create new export record',
         data: { requestId: payload.detail.requestId },
       });
-      Sentry.captureException(error);
+      Sentry.captureException(error, {tags: { component: 'ExportStateService', function: 'updateStatus' }});
       throw error;
     }
       // Update the status of the export request to reflect
@@ -270,7 +270,7 @@ export class ExportStateService {
         message: 'ExportStateService - updateStatus - Dynamo error: failed to update status of export record',
         data: { requestId: payload.detail.requestId },
       });
-      Sentry.captureException(error);
+      Sentry.captureException(error, {tags: { component: 'ExportStateService', function: 'updateStatus' }});
       throw error;
     }
   }

--- a/servers/account-data-deleter/src/queueHandlers/exportAnnotationsHandler.ts
+++ b/servers/account-data-deleter/src/queueHandlers/exportAnnotationsHandler.ts
@@ -6,6 +6,7 @@ import { S3Bucket, QueuePoller } from '@pocket-tools/aws-utils';
 import { serverLogger } from '@pocket-tools/ts-logger';
 import { sqs } from '../aws/sqs';
 import { AnnotationsDataExportService } from '../dataService/annotationsExportService';
+import * as Sentry from '@sentry/node';
 
 type ExportMessages = { Message: string } | ExportMessage;
 
@@ -96,6 +97,13 @@ export class ExportAnnotationsHandler extends QueuePoller<ExportMessages> {
         request: message,
         errorMessage: error.message,
       });
+      Sentry.addBreadcrumb({
+        message: 'ExportAnnotationsHandler - handleMessage - Annotations export failed',
+        data: {
+          message: message,
+        },
+      });
+      Sentry.captureException(error);
       // Underlying services handle logging and observability of their errors
       return false;
     }

--- a/servers/account-data-deleter/src/queueHandlers/exportListHandler.spec.ts
+++ b/servers/account-data-deleter/src/queueHandlers/exportListHandler.spec.ts
@@ -2,12 +2,23 @@ import { config } from '../config';
 import { ListDataExportService } from '../dataService/listDataExportService';
 import { ExportListHandler } from './exportListHandler';
 import { EventEmitter } from 'node:stream';
+import * as Sentry from '@sentry/node';
 
 describe('exportHandler', () => {
   const emitter = new EventEmitter();
   const exportListHandler = new ExportListHandler(emitter, false);
-  beforeEach(() => jest.restoreAllMocks());
-  afterAll(() => jest.restoreAllMocks());
+  let captureExceptionSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    captureExceptionSpy = jest
+      .spyOn(Sentry, 'captureException')
+      .mockImplementation(); // stub, doesn't send
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks(); // clean up spies
+  });
+
   it('works for non-nested SQS messages', async () => {
     const message = {
       userId: '12345',
@@ -26,5 +37,34 @@ describe('exportHandler', () => {
       config.listExport.queryLimit,
       1,
     );
+  });
+
+  it('sends a Sentry error when exportChunk fails', async () => {
+    const message = {
+      userId: '12345',
+      requestId: '25be3f55',
+      encodedId: '9324jdfazlsdfljk',
+      cursor: 1186237110,
+      part: 1,
+    };
+
+    const error = new Error('fail exportChunk');
+
+    const exportSpy = jest
+      .spyOn(ListDataExportService.prototype, 'exportChunk',)
+      .mockRejectedValue(error);
+
+    const result = await exportListHandler.handleMessage(message);
+
+    expect(result).toBe(false);
+    expect(exportSpy).toHaveBeenCalledExactlyOnceWith(
+      '25be3f55',
+      1186237110,
+      config.listExport.queryLimit,
+      1,
+    );
+    // check for Sentry error
+    expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+    expect(captureExceptionSpy).toHaveBeenCalledWith(error);
   });
 });

--- a/servers/account-data-deleter/src/queueHandlers/exportListHandler.spec.ts
+++ b/servers/account-data-deleter/src/queueHandlers/exportListHandler.spec.ts
@@ -65,6 +65,14 @@ describe('exportHandler', () => {
     );
     // check for Sentry error
     expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
-    expect(captureExceptionSpy).toHaveBeenCalledWith(error);
+    expect(captureExceptionSpy).toHaveBeenCalledWith(
+      error,
+      {
+        tags: {
+          component: 'ExportListHandler',
+          function: 'handleMessage',
+        },
+      }
+    );
   });
 });

--- a/servers/account-data-deleter/src/queueHandlers/exportListHandler.spec.ts
+++ b/servers/account-data-deleter/src/queueHandlers/exportListHandler.spec.ts
@@ -12,11 +12,11 @@ describe('exportHandler', () => {
   beforeEach(() => {
     captureExceptionSpy = jest
       .spyOn(Sentry, 'captureException')
-      .mockImplementation(); // stub, doesn't send
+      .mockImplementation();
   });
 
   afterEach(() => {
-    jest.restoreAllMocks(); // clean up spies
+    jest.restoreAllMocks();
   });
 
   it('works for non-nested SQS messages', async () => {

--- a/servers/account-data-deleter/src/queueHandlers/exportListHandler.ts
+++ b/servers/account-data-deleter/src/queueHandlers/exportListHandler.ts
@@ -6,6 +6,7 @@ import { ListDataExportService } from '../dataService/listDataExportService';
 import { S3Bucket, QueuePoller } from '@pocket-tools/aws-utils';
 import { serverLogger } from '@pocket-tools/ts-logger';
 import { sqs } from '../aws/sqs';
+import * as Sentry from '@sentry/node';
 
 type ExportMessages = { Message: string } | ExportMessage;
 
@@ -96,6 +97,13 @@ export class ExportListHandler extends QueuePoller<ExportMessages> {
         request: message,
         errorMessage: error.message,
       });
+      Sentry.addBreadcrumb({
+        message: 'ExportListHandler - handleMessage - List export failed',
+        data: {
+          message: message,
+        },
+      });
+      Sentry.captureException(error);
       // Underlying services handle logging and observability of their errors
       return false;
     }

--- a/servers/account-data-deleter/src/queueHandlers/exportListHandler.ts
+++ b/servers/account-data-deleter/src/queueHandlers/exportListHandler.ts
@@ -103,7 +103,7 @@ export class ExportListHandler extends QueuePoller<ExportMessages> {
           message: message,
         },
       });
-      Sentry.captureException(error);
+      Sentry.captureException(error, {tags: { component: 'ExportListHandler', function: 'handleMessage' }});
       // Underlying services handle logging and observability of their errors
       return false;
     }

--- a/servers/account-data-deleter/src/queueHandlers/exportStateHandler.ts
+++ b/servers/account-data-deleter/src/queueHandlers/exportStateHandler.ts
@@ -64,7 +64,7 @@ export class ExportStateHandler extends QueuePoller<{ Message: string }> {
         throw error;
       }
       serverLogger.info({
-        message: 'ExportStatusHandler - received request',
+        message: 'ExportStateHandler - received request',
         body: message,
       });
       const exportBucket = new S3Bucket(config.listExport.exportBucket, {
@@ -97,7 +97,7 @@ export class ExportStateHandler extends QueuePoller<{ Message: string }> {
           messageBody: message,
         },
       });
-      Sentry.captureException(error);
+      Sentry.captureException(error, {tags: { component: 'ExportStateHandler', function: 'handleMessage' }});
       return false;
     }
     return true;

--- a/servers/account-data-deleter/src/queueHandlers/exportStateHandler.ts
+++ b/servers/account-data-deleter/src/queueHandlers/exportStateHandler.ts
@@ -61,7 +61,6 @@ export class ExportStateHandler extends QueuePoller<{ Message: string }> {
           message: 'Invalid SQS message body',
           data: { messageBody: message },
         });
-        Sentry.captureException(error);
         throw error;
       }
       serverLogger.info({
@@ -98,6 +97,7 @@ export class ExportStateHandler extends QueuePoller<{ Message: string }> {
           messageBody: message,
         },
       });
+      Sentry.captureException(error);
       return false;
     }
     return true;

--- a/servers/braze-content-proxy/src/generated/graphql/types.ts
+++ b/servers/braze-content-proxy/src/generated/graphql/types.ts
@@ -66,13 +66,6 @@ export type AdvancedSearchFilters = {
   title?: InputMaybe<Scalars['String']['input']>;
 };
 
-/** Valid grade values for CorpusItem (public graph) and ApprovedItem (admin graph) */
-export enum ApprovedItemGrade {
-  A = 'A',
-  B = 'B',
-  C = 'C'
-}
-
 export type ArchiveNoteInput = {
   /**
    * The ID of the note to archive or unarchive
@@ -327,8 +320,6 @@ export type CorpusItem = {
   datePublished?: Maybe<Scalars['Date']['output']>;
   /** The excerpt of the Approved Item. */
   excerpt: Scalars['String']['output'];
-  /** The quality grade associated with this CorpusItem. */
-  grade?: Maybe<ApprovedItemGrade>;
   /** The GUID that is stored on an approved corpus item */
   id: Scalars['ID']['output'];
   /** The image for this item's accompanying picture. */
@@ -820,6 +811,18 @@ export enum ExpireUserWebSessionReason {
   PasswordChanged = 'PASSWORD_CHANGED'
 }
 
+export type ExportAcknowledgment = {
+  __typename?: 'ExportAcknowledgment';
+  requestId: Scalars['String']['output'];
+};
+
+export type ExportDisabled = {
+  __typename?: 'ExportDisabled';
+  message: Scalars['String']['output'];
+};
+
+export type ExportResponse = ExportAcknowledgment | ExportDisabled;
+
 /** Input field to boost the score of an elasticsearch document based on a specific field and value */
 export type FunctionalBoostField = {
   /** A float number to boost the score by */
@@ -879,6 +882,16 @@ export type IabCategory = {
   externalId: Scalars['String']['output'];
   name: Scalars['String']['output'];
   slug: Scalars['String']['output'];
+};
+
+/**
+ * Represents IAB metadata for a Section.
+ * Used by both admin input/output and public output.
+ */
+export type IabMetadata = {
+  __typename?: 'IABMetadata';
+  categories: Array<Scalars['String']['output']>;
+  taxonomy: Scalars['String']['output'];
 };
 
 export type IabParentCategory = {
@@ -1413,8 +1426,15 @@ export type Mutation = {
    */
   expireUserWebSessionByFxaId: Scalars['ID']['output'];
   /**
+   * Request data for export. Returns an acknowledgment with the
+   * request ID, or an error message (if the export service is
+   * temporarily disabled for maintenance)
+   */
+  exportData?: Maybe<ExportResponse>;
+  /**
    * Request for an asynchronous export of a user's list.
    * Returns the request ID associated with the request.
+   * @deprecated use exportData
    */
   exportList?: Maybe<Scalars['String']['output']>;
   /**
@@ -2497,7 +2517,7 @@ export type Query = {
    * @deprecated Use itemByUrl instead
    */
   getItemByUrl?: Maybe<Item>;
-  /** Retrieves a list of active Sections with their corresponding active SectionItems for a scheduled surface. */
+  /** Retrieves a list of active and enabled Sections with their corresponding active SectionItems for a scheduled surface. */
   getSections: Array<Section>;
   /**
    * Request a specific `Slate` by id
@@ -3522,6 +3542,8 @@ export type Section = {
   createSource: ActivitySource;
   /** An alternative primary key in UUID format. */
   externalId: Scalars['ID']['output'];
+  /** Optional IAB metadata returned to the client (i.e. Merino->Firefox, Admin Tools) */
+  iab?: Maybe<IabMetadata>;
   /** The GUID of the Scheduled Surface. Example: 'NEW_TAB_EN_US'. */
   scheduledSurfaceGuid: Scalars['ID']['output'];
   /**

--- a/servers/shareable-lists-api/src/background/ExportHandler.ts
+++ b/servers/shareable-lists-api/src/background/ExportHandler.ts
@@ -7,6 +7,7 @@ import { ExportDataService } from './ExportDataService';
 import { serverLogger } from '@pocket-tools/ts-logger';
 import { conn } from '../database/client';
 import { sqs } from '../aws/sqs';
+import * as Sentry from '@sentry/node';
 
 export class ExportHandler extends QueuePoller<
   { Message: string } | ExportMessage
@@ -102,6 +103,13 @@ export class ExportHandler extends QueuePoller<
         errorMessage: error.message,
       });
       // Underlying services handle logging and observability of their errors
+      Sentry.addBreadcrumb({
+        message: 'ExportHandler - handleMessage - Shareable-lists export failed',
+        data: {
+          message: message,
+        },
+      });
+      Sentry.captureException(error);
       return false;
     }
     return true;

--- a/servers/v3-proxy-api/src/generated/graphql/types.ts
+++ b/servers/v3-proxy-api/src/generated/graphql/types.ts
@@ -66,13 +66,6 @@ export type AdvancedSearchFilters = {
   title?: InputMaybe<Scalars['String']['input']>;
 };
 
-/** Valid grade values for CorpusItem (public graph) and ApprovedItem (admin graph) */
-export enum ApprovedItemGrade {
-  A = 'A',
-  B = 'B',
-  C = 'C'
-}
-
 export type ArchiveNoteInput = {
   /**
    * The ID of the note to archive or unarchive
@@ -327,8 +320,6 @@ export type CorpusItem = {
   datePublished?: Maybe<Scalars['Date']['output']>;
   /** The excerpt of the Approved Item. */
   excerpt: Scalars['String']['output'];
-  /** The quality grade associated with this CorpusItem. */
-  grade?: Maybe<ApprovedItemGrade>;
   /** The GUID that is stored on an approved corpus item */
   id: Scalars['ID']['output'];
   /** The image for this item's accompanying picture. */
@@ -820,6 +811,18 @@ export enum ExpireUserWebSessionReason {
   PasswordChanged = 'PASSWORD_CHANGED'
 }
 
+export type ExportAcknowledgment = {
+  __typename?: 'ExportAcknowledgment';
+  requestId: Scalars['String']['output'];
+};
+
+export type ExportDisabled = {
+  __typename?: 'ExportDisabled';
+  message: Scalars['String']['output'];
+};
+
+export type ExportResponse = ExportAcknowledgment | ExportDisabled;
+
 /** Input field to boost the score of an elasticsearch document based on a specific field and value */
 export type FunctionalBoostField = {
   /** A float number to boost the score by */
@@ -879,6 +882,16 @@ export type IabCategory = {
   externalId: Scalars['String']['output'];
   name: Scalars['String']['output'];
   slug: Scalars['String']['output'];
+};
+
+/**
+ * Represents IAB metadata for a Section.
+ * Used by both admin input/output and public output.
+ */
+export type IabMetadata = {
+  __typename?: 'IABMetadata';
+  categories: Array<Scalars['String']['output']>;
+  taxonomy: Scalars['String']['output'];
 };
 
 export type IabParentCategory = {
@@ -1413,8 +1426,15 @@ export type Mutation = {
    */
   expireUserWebSessionByFxaId: Scalars['ID']['output'];
   /**
+   * Request data for export. Returns an acknowledgment with the
+   * request ID, or an error message (if the export service is
+   * temporarily disabled for maintenance)
+   */
+  exportData?: Maybe<ExportResponse>;
+  /**
    * Request for an asynchronous export of a user's list.
    * Returns the request ID associated with the request.
+   * @deprecated use exportData
    */
   exportList?: Maybe<Scalars['String']['output']>;
   /**
@@ -2497,7 +2517,7 @@ export type Query = {
    * @deprecated Use itemByUrl instead
    */
   getItemByUrl?: Maybe<Item>;
-  /** Retrieves a list of active Sections with their corresponding active SectionItems for a scheduled surface. */
+  /** Retrieves a list of active and enabled Sections with their corresponding active SectionItems for a scheduled surface. */
   getSections: Array<Section>;
   /**
    * Request a specific `Slate` by id
@@ -3522,6 +3542,8 @@ export type Section = {
   createSource: ActivitySource;
   /** An alternative primary key in UUID format. */
   externalId: Scalars['ID']['output'];
+  /** Optional IAB metadata returned to the client (i.e. Merino->Firefox, Admin Tools) */
+  iab?: Maybe<IabMetadata>;
   /** The GUID of the Scheduled Surface. Example: 'NEW_TAB_EN_US'. */
   scheduledSurfaceGuid: Scalars['ID']['output'];
   /**


### PR DESCRIPTION
## Goal

Adding Sentry alerts if data exports are reaching a failing threshold (i.e. above 5% for 10 minutes).

Services for export:
* list
* annotations
* shared lists

`account-data-deleter` manages the state of the overall export job

## Next steps

Create a Sentry Metric Alert for export failures.

Alert created: https://pocket.sentry.io/issues/alerts/rules/details/337137/

## Deployment steps

- [x] Deployed to dev

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/HNT-545