### PR TITLE
feat(terraform modules): expose logging for ALB and RDS constructs

### DIFF
--- a/packages/terraform-modules/src/base/ApplicationLoadBalancer.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationLoadBalancer.spec.ts
@@ -44,6 +44,9 @@ describe('ApplicationLoadBalancer', () => {
         accessLogs: {
           bucket: 'logging-bucket',
         },
+        connectionLogs: {
+          bucket: 'connection-logging-bucket',
+        },
       });
     });
     expect(synthed).toMatchSnapshot();
@@ -62,6 +65,10 @@ describe('ApplicationLoadBalancer', () => {
         },
         accessLogs: {
           bucket: 'logging-bucket',
+          prefix: 'logs/ahoy/cool/service',
+        },
+        connectionLogs: {
+          bucket: 'connection-logging-bucket',
           prefix: 'logs/ahoy/cool/service',
         },
       });
@@ -83,6 +90,9 @@ describe('ApplicationLoadBalancer', () => {
         accessLogs: {
           existingBucket: 'logging-bucket',
         },
+        connectionLogs: {
+          existingBucket: 'connection-logging-bucket',
+        },
       });
     });
     expect(synthed).toMatchSnapshot();
@@ -103,12 +113,16 @@ describe('ApplicationLoadBalancer', () => {
           existingBucket: 'logging-bucket',
           prefix: 'logs/ahoy/cool/service',
         },
+        connectionLogs: {
+          existingBucket: 'connection-logging-bucket',
+          prefix: 'logs/ahoy/cool/service',
+        },
       });
     });
     expect(synthed).toMatchSnapshot();
   });
 
-  it('errors when no bucket provided', () => {
+  it('errors when no bucket provided for access logs', () => {
     expect(() => {
       Testing.synthScope((stack) => {
         new ApplicationLoadBalancer(stack, 'testALB', {
@@ -126,7 +140,29 @@ describe('ApplicationLoadBalancer', () => {
         });
       });
     }).toThrow(
-      'If you are configuring access logs you need to define either an existing bucket or a new one to store the logs',
+      'If you are configuring access or connection logs you need to define either an existing bucket or a new one to store the logs',
+    );
+  });
+
+  it('errors when no bucket provided for connection logs', () => {
+    expect(() => {
+      Testing.synthScope((stack) => {
+        new ApplicationLoadBalancer(stack, 'testALB', {
+          prefix: 'test-',
+          alb6CharacterPrefix: 'TEST',
+          vpcId: '123',
+          subnetIds: ['a', 'b'],
+          tags: {
+            name: 'thedude',
+            hobby: 'bowling',
+          },
+          connectionLogs: {
+            prefix: 'logs/ahoy/cool/service',
+          },
+        });
+      });
+    }).toThrow(
+      'If you are configuring access or connection logs you need to define either an existing bucket or a new one to store the logs',
     );
   });
 });

--- a/packages/terraform-modules/src/base/ApplicationLoadBalancer.ts
+++ b/packages/terraform-modules/src/base/ApplicationLoadBalancer.ts
@@ -19,11 +19,11 @@ export interface ApplicationLoadBalancerProps extends TerraformMetaArguments {
   internal?: boolean;
   useCloudfrontManagedPrefixList?: boolean;
   /**
-   * Optional config to dump alb logs to a bucket.
+   * Optional config to dump alb access logs to a bucket.
    */
   accessLogs?: {
     /**
-     * Existing bucket to dump alb logs too, one of existingBucket or bucket must be chosen.
+     * Existing bucket to dump alb logs to, one of existingBucket or bucket must be chosen.
      */
     existingBucket?: string;
 
@@ -33,7 +33,27 @@ export interface ApplicationLoadBalancerProps extends TerraformMetaArguments {
     bucket?: string;
 
     /**
-     * Optional bucket path prefix. If not defined will use server-logs/{service-name}/internal-alb/AWSLogs/{awsaccountid}/elasticloadbalancing/
+     * Optional bucket path prefix. If not defined will use server-logs/{service-name}/alb/AWSLogs/{awsaccountid}/elasticloadbalancing/
+     * Be sure to include a trailing /
+     */
+    prefix?: string;
+  };
+  /**
+   * Optional config to dump alb connection logs to a bucket.
+   */
+  connectionLogs?: {
+    /**
+     * Existing bucket to dump alb logs to, one of existingBucket or bucket must be chosen.
+     */
+    existingBucket?: string;
+
+    /**
+     * Bucket to dump alb logs too, one of existingBucket or bucket must be chosen.
+     */
+    bucket?: string;
+
+    /**
+     * Optional bucket path prefix. If not defined will use server-logs/{service-name}/albConnection/AWSLogs/{awsaccountid}/elasticloadbalancing/
      * Be sure to include a trailing /
      */
     prefix?: string;
@@ -117,7 +137,8 @@ export class ApplicationLoadBalancer extends Construct {
       },
     );
 
-    let logsConfig: alb.AlbAccessLogs | undefined = undefined;
+    let accessLogsConfig: alb.AlbAccessLogs | undefined = undefined;
+
     if (config.accessLogs !== undefined) {
       const defaultPrefix = `server-logs/${config.prefix.toLowerCase()}/alb`;
 
@@ -130,17 +151,50 @@ export class ApplicationLoadBalancer extends Construct {
         prefix.charAt(prefix.length - 1) === '/' ||
         prefix.charAt(0) === '/'
       ) {
-        throw new Error("Logs prefix cannot start or end with '/'");
+        throw new Error("Access logs prefix cannot start or end with '/'");
       }
 
       const bucket = this.getOrCreateBucket({
+        logType: 'access',
         bucket: config.accessLogs.bucket,
         existingBucket: config.accessLogs.existingBucket,
         provider: config.provider,
         tags: config.tags,
       });
 
-      logsConfig = {
+      accessLogsConfig = {
+        bucket,
+        enabled: true,
+        prefix,
+      };
+    }
+
+    let connectionLogsConfig: alb.AlbConnectionLogs | undefined = undefined;
+
+    if (config.connectionLogs !== undefined) {
+      const defaultPrefix = `server-logs/${config.prefix.toLowerCase()}/albConnection`;
+
+      const prefix =
+        config.connectionLogs.prefix === undefined
+          ? defaultPrefix
+          : config.connectionLogs.prefix;
+
+      if (
+        prefix.charAt(prefix.length - 1) === '/' ||
+        prefix.charAt(0) === '/'
+      ) {
+        throw new Error("Connection logs prefix cannot start or end with '/'");
+      }
+
+      const bucket = this.getOrCreateBucket({
+        logType: 'connection',
+        bucket: config.connectionLogs.bucket,
+        existingBucket: config.connectionLogs.existingBucket,
+        provider: config.provider,
+        tags: config.tags,
+      });
+
+      connectionLogsConfig = {
         bucket,
         enabled: true,
         prefix,
@@ -153,9 +207,11 @@ export class ApplicationLoadBalancer extends Construct {
       internal: config.internal !== undefined ? config.internal : false,
       subnets: config.subnetIds,
       tags: config.tags,
-      accessLogs: logsConfig,
+      accessLogs: accessLogsConfig,
+      connectionLogs: connectionLogsConfig,
       provider: config.provider,
     };
+
     this.alb = new alb.Alb(this, `alb`, albConfig);
   }
 
@@ -165,6 +221,7 @@ export class ApplicationLoadBalancer extends Construct {
    * @returns
    */
   private getOrCreateBucket(config: {
+    logType: 'access' | 'connection';
     existingBucket?: string;
     bucket?: string;
     tags?: { [key: string]: string };
@@ -172,32 +229,42 @@ export class ApplicationLoadBalancer extends Construct {
   }): string {
     if (config.existingBucket === undefined && config.bucket === undefined) {
       throw new Error(
-        'If you are configuring access logs you need to define either an existing bucket or a new one to store the logs',
+        'If you are configuring access or connection logs you need to define either an existing bucket or a new one to store the logs',
       );
     }
 
     if (config.existingBucket !== undefined) {
-      return new dataAwsS3Bucket.DataAwsS3Bucket(this, 'log-bucket', {
-        bucket: config.existingBucket,
-        provider: config.provider,
-      }).bucket;
+      return new dataAwsS3Bucket.DataAwsS3Bucket(
+        this,
+        `${config.logType}-log-bucket`,
+        {
+          bucket: config.existingBucket,
+          provider: config.provider,
+        },
+      ).bucket;
     }
 
-    const s3BucketResource = new s3Bucket.S3Bucket(this, 'log-bucket', {
-      bucket: config.bucket,
-      provider: config.provider,
-      tags: config.tags,
-    });
+    const s3BucketResource = new s3Bucket.S3Bucket(
+      this,
+      `${config.logType}-log-bucket`,
+      {
+        bucket: config.bucket,
+        provider: config.provider,
+        tags: config.tags,
+      },
+    );
 
+    // this could be factored out of this function, but i'm not sure it's
+    // worth the complexity
     const albAccountId = new dataAwsElbServiceAccount.DataAwsElbServiceAccount(
       this,
-      'elb-service-account',
+      `${config.logType}-elb-service-account`,
       { provider: config.provider },
     ).id;
 
     const s3IAMDocument = new dataAwsIamPolicyDocument.DataAwsIamPolicyDocument(
       this,
-      'iam-log-bucket-policy-document',
+      `${config.logType}-iam-log-bucket-policy-document`,
       {
         statement: [
           {
@@ -216,11 +283,15 @@ export class ApplicationLoadBalancer extends Construct {
       },
     );
 
-    new s3BucketPolicy.S3BucketPolicy(this, 'log-bucket-policy', {
-      bucket: s3BucketResource.bucket,
-      policy: s3IAMDocument.json,
-      provider: config.provider,
-    });
+    new s3BucketPolicy.S3BucketPolicy(
+      this,
+      `${config.logType}-log-bucket-policy`,
+      {
+        bucket: s3BucketResource.bucket,
+        policy: s3IAMDocument.json,
+        provider: config.provider,
+      },
+    );
 
     return s3BucketResource.bucket;
   }

--- a/packages/terraform-modules/src/base/ApplicationLoadBalancer.ts
+++ b/packages/terraform-modules/src/base/ApplicationLoadBalancer.ts
@@ -172,7 +172,7 @@ export class ApplicationLoadBalancer extends Construct {
     let connectionLogsConfig: alb.AlbConnectionLogs | undefined = undefined;
 
     if (config.connectionLogs !== undefined) {
-      const defaultPrefix = `server-logs/${config.prefix.toLowerCase()}/albConnection`;
+      const defaultPrefix = `server-logs/${config.prefix.toLowerCase()}/alb-connection`;
 
       const prefix =
         config.connectionLogs.prefix === undefined

--- a/packages/terraform-modules/src/base/ApplicationRDSCluster.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationRDSCluster.spec.ts
@@ -22,12 +22,13 @@ describe('ApplicationRDSCluster', () => {
     expect(synthed).toMatchSnapshot();
   });
 
-  it('renders a RDS cluster with a database URL', () => {
+  it('renders a RDS cluster without a name', () => {
     const synthed = Testing.synthScope((stack) => {
       new ApplicationRDSCluster(stack, 'testRDSCluster', {
         prefix: 'bowling-',
         vpcId: 'rug',
         subnetIds: ['0', '1'],
+        useName: false,
         rdsConfig: {
           masterUsername: 'walter',
           masterPassword: 'bowling',
@@ -42,13 +43,13 @@ describe('ApplicationRDSCluster', () => {
     expect(synthed).toMatchSnapshot();
   });
 
-  it('renders a RDS cluster without a name', () => {
+  it('renders a RDS cluster with cloudwatch exporting', () => {
     const synthed = Testing.synthScope((stack) => {
       new ApplicationRDSCluster(stack, 'testRDSCluster', {
+        enableCloudwatchLogsExports: ['audit', 'error', 'general'],
         prefix: 'bowling-',
         vpcId: 'rug',
         subnetIds: ['0', '1'],
-        useName: false,
         rdsConfig: {
           masterUsername: 'walter',
           masterPassword: 'bowling',

--- a/packages/terraform-modules/src/base/ApplicationRDSCluster.spec.ts
+++ b/packages/terraform-modules/src/base/ApplicationRDSCluster.spec.ts
@@ -46,7 +46,6 @@ describe('ApplicationRDSCluster', () => {
   it('renders a RDS cluster with cloudwatch exporting', () => {
     const synthed = Testing.synthScope((stack) => {
       new ApplicationRDSCluster(stack, 'testRDSCluster', {
-        enableCloudwatchLogsExports: ['audit', 'error', 'general'],
         prefix: 'bowling-',
         vpcId: 'rug',
         subnetIds: ['0', '1'],
@@ -55,6 +54,7 @@ describe('ApplicationRDSCluster', () => {
           masterPassword: 'bowling',
           databaseName: 'walter',
           engine: 'aurora-mysql',
+          enabledCloudwatchLogsExports: ['audit', 'error', 'general'],
         },
         tags: {
           whodis: 'walter',

--- a/packages/terraform-modules/src/base/ApplicationRDSCluster.ts
+++ b/packages/terraform-modules/src/base/ApplicationRDSCluster.ts
@@ -29,11 +29,6 @@ export type ApplicationRDSClusterConfig = Omit<
 };
 
 export interface ApplicationRDSClusterProps extends TerraformMetaArguments {
-  // optionally export defined logs to cloudwatch
-  // see https://registry.terraform.io/providers/hashicorp/aws/5.83.1/docs/resources/rds_cluster#enabled_cloudwatch_logs_exports-1
-  // for available options
-  // audit, error, general, slowquery, postgresql (PostgreSQL only)
-  enableCloudwatchLogsExports?: string[];
   prefix: string;
   vpcId: string;
   subnetIds: string[];
@@ -136,6 +131,7 @@ export class ApplicationRDSCluster extends Construct {
     const configCopy: ApplicationRDSClusterConfig = {
       ...config.rdsConfig,
     };
+
     // Remove non standard rds params for passing through.
     delete configCopy.createServerlessV2Instance;
 
@@ -155,7 +151,6 @@ export class ApplicationRDSCluster extends Construct {
         ignoreChanges: ['master_username', 'master_password', 'engine_version'],
       },
       provider: config.provider,
-      enabledCloudwatchLogsExports: config.enableCloudwatchLogsExports ?? [],
     });
 
     if (config.rdsConfig.createServerlessV2Instance) {

--- a/packages/terraform-modules/src/base/ApplicationRDSCluster.ts
+++ b/packages/terraform-modules/src/base/ApplicationRDSCluster.ts
@@ -29,6 +29,11 @@ export type ApplicationRDSClusterConfig = Omit<
 };
 
 export interface ApplicationRDSClusterProps extends TerraformMetaArguments {
+  // optionally export defined logs to cloudwatch
+  // see https://registry.terraform.io/providers/hashicorp/aws/5.83.1/docs/resources/rds_cluster#enabled_cloudwatch_logs_exports-1
+  // for available options
+  // audit, error, general, slowquery, postgresql (PostgreSQL only)
+  enableCloudwatchLogsExports?: string[];
   prefix: string;
   vpcId: string;
   subnetIds: string[];
@@ -150,6 +155,7 @@ export class ApplicationRDSCluster extends Construct {
         ignoreChanges: ['master_username', 'master_password', 'engine_version'],
       },
       provider: config.provider,
+      enabledCloudwatchLogsExports: config.enableCloudwatchLogsExports ?? [],
     });
 
     if (config.rdsConfig.createServerlessV2Instance) {

--- a/packages/terraform-modules/src/base/__snapshots__/ApplicationLoadBalancer.spec.ts.snap
+++ b/packages/terraform-modules/src/base/__snapshots__/ApplicationLoadBalancer.spec.ts.snap
@@ -65,7 +65,7 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket 1`] 
         "connection_logs": {
           "bucket": "\${aws_s3_bucket.testALB_connection-log-bucket_633AB558.bucket}",
           "enabled": true,
-          "prefix": "server-logs/test-/albConnection"
+          "prefix": "server-logs/test-/alb-connection"
         },
         "internal": false,
         "name_prefix": "TEST",
@@ -369,7 +369,7 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with an existing bucke
         "connection_logs": {
           "bucket": "\${data.aws_s3_bucket.testALB_connection-log-bucket_633AB558.bucket}",
           "enabled": true,
-          "prefix": "server-logs/test-/albConnection"
+          "prefix": "server-logs/test-/alb-connection"
         },
         "internal": false,
         "name_prefix": "TEST",

--- a/packages/terraform-modules/src/base/__snapshots__/ApplicationLoadBalancer.spec.ts.snap
+++ b/packages/terraform-modules/src/base/__snapshots__/ApplicationLoadBalancer.spec.ts.snap
@@ -4,11 +4,13 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket 1`] 
 "{
   "data": {
     "aws_elb_service_account": {
-      "testALB_elb-service-account_4BDD06CE": {
+      "testALB_access-elb-service-account_46C6186B": {
+      },
+      "testALB_connection-elb-service-account_01DA28A7": {
       }
     },
     "aws_iam_policy_document": {
-      "testALB_iam-log-bucket-policy-document_C7E41154": {
+      "testALB_access-iam-log-bucket-policy-document_B4319C4B": {
         "statement": [
           {
             "actions": [
@@ -18,13 +20,34 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket 1`] 
             "principals": [
               {
                 "identifiers": [
-                  "arn:aws:iam::\${data.aws_elb_service_account.testALB_elb-service-account_4BDD06CE.id}:root"
+                  "arn:aws:iam::\${data.aws_elb_service_account.testALB_access-elb-service-account_46C6186B.id}:root"
                 ],
                 "type": "AWS"
               }
             ],
             "resources": [
-              "arn:aws:s3:::\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}/*"
+              "arn:aws:s3:::\${aws_s3_bucket.testALB_access-log-bucket_3A8C1D83.bucket}/*"
+            ]
+          }
+        ]
+      },
+      "testALB_connection-iam-log-bucket-policy-document_98C0A07B": {
+        "statement": [
+          {
+            "actions": [
+              "s3:PutObject"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:aws:iam::\${data.aws_elb_service_account.testALB_connection-elb-service-account_01DA28A7.id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "arn:aws:s3:::\${aws_s3_bucket.testALB_connection-log-bucket_633AB558.bucket}/*"
             ]
           }
         ]
@@ -35,9 +58,14 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket 1`] 
     "aws_alb": {
       "testALB_alb_F6B33218": {
         "access_logs": {
-          "bucket": "\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}",
+          "bucket": "\${aws_s3_bucket.testALB_access-log-bucket_3A8C1D83.bucket}",
           "enabled": true,
           "prefix": "server-logs/test-/alb"
+        },
+        "connection_logs": {
+          "bucket": "\${aws_s3_bucket.testALB_connection-log-bucket_633AB558.bucket}",
+          "enabled": true,
+          "prefix": "server-logs/test-/albConnection"
         },
         "internal": false,
         "name_prefix": "TEST",
@@ -55,8 +83,15 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket 1`] 
       }
     },
     "aws_s3_bucket": {
-      "testALB_log-bucket_E9787BB1": {
+      "testALB_access-log-bucket_3A8C1D83": {
         "bucket": "logging-bucket",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
+        }
+      },
+      "testALB_connection-log-bucket_633AB558": {
+        "bucket": "connection-logging-bucket",
         "tags": {
           "hobby": "bowling",
           "name": "thedude"
@@ -64,9 +99,13 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket 1`] 
       }
     },
     "aws_s3_bucket_policy": {
-      "testALB_log-bucket-policy_EB762FB5": {
-        "bucket": "\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}",
-        "policy": "\${data.aws_iam_policy_document.testALB_iam-log-bucket-policy-document_C7E41154.json}"
+      "testALB_access-log-bucket-policy_4EA774F7": {
+        "bucket": "\${aws_s3_bucket.testALB_access-log-bucket_3A8C1D83.bucket}",
+        "policy": "\${data.aws_iam_policy_document.testALB_access-iam-log-bucket-policy-document_B4319C4B.json}"
+      },
+      "testALB_connection-log-bucket-policy_D66BDF5D": {
+        "bucket": "\${aws_s3_bucket.testALB_connection-log-bucket_633AB558.bucket}",
+        "policy": "\${data.aws_iam_policy_document.testALB_connection-iam-log-bucket-policy-document_98C0A07B.json}"
       }
     },
     "aws_security_group": {
@@ -138,11 +177,13 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket and 
 "{
   "data": {
     "aws_elb_service_account": {
-      "testALB_elb-service-account_4BDD06CE": {
+      "testALB_access-elb-service-account_46C6186B": {
+      },
+      "testALB_connection-elb-service-account_01DA28A7": {
       }
     },
     "aws_iam_policy_document": {
-      "testALB_iam-log-bucket-policy-document_C7E41154": {
+      "testALB_access-iam-log-bucket-policy-document_B4319C4B": {
         "statement": [
           {
             "actions": [
@@ -152,13 +193,34 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket and 
             "principals": [
               {
                 "identifiers": [
-                  "arn:aws:iam::\${data.aws_elb_service_account.testALB_elb-service-account_4BDD06CE.id}:root"
+                  "arn:aws:iam::\${data.aws_elb_service_account.testALB_access-elb-service-account_46C6186B.id}:root"
                 ],
                 "type": "AWS"
               }
             ],
             "resources": [
-              "arn:aws:s3:::\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}/*"
+              "arn:aws:s3:::\${aws_s3_bucket.testALB_access-log-bucket_3A8C1D83.bucket}/*"
+            ]
+          }
+        ]
+      },
+      "testALB_connection-iam-log-bucket-policy-document_98C0A07B": {
+        "statement": [
+          {
+            "actions": [
+              "s3:PutObject"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:aws:iam::\${data.aws_elb_service_account.testALB_connection-elb-service-account_01DA28A7.id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "arn:aws:s3:::\${aws_s3_bucket.testALB_connection-log-bucket_633AB558.bucket}/*"
             ]
           }
         ]
@@ -169,7 +231,12 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket and 
     "aws_alb": {
       "testALB_alb_F6B33218": {
         "access_logs": {
-          "bucket": "\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}",
+          "bucket": "\${aws_s3_bucket.testALB_access-log-bucket_3A8C1D83.bucket}",
+          "enabled": true,
+          "prefix": "logs/ahoy/cool/service"
+        },
+        "connection_logs": {
+          "bucket": "\${aws_s3_bucket.testALB_connection-log-bucket_633AB558.bucket}",
           "enabled": true,
           "prefix": "logs/ahoy/cool/service"
         },
@@ -189,8 +256,15 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket and 
       }
     },
     "aws_s3_bucket": {
-      "testALB_log-bucket_E9787BB1": {
+      "testALB_access-log-bucket_3A8C1D83": {
         "bucket": "logging-bucket",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
+        }
+      },
+      "testALB_connection-log-bucket_633AB558": {
+        "bucket": "connection-logging-bucket",
         "tags": {
           "hobby": "bowling",
           "name": "thedude"
@@ -198,9 +272,13 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket and 
       }
     },
     "aws_s3_bucket_policy": {
-      "testALB_log-bucket-policy_EB762FB5": {
-        "bucket": "\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}",
-        "policy": "\${data.aws_iam_policy_document.testALB_iam-log-bucket-policy-document_C7E41154.json}"
+      "testALB_access-log-bucket-policy_4EA774F7": {
+        "bucket": "\${aws_s3_bucket.testALB_access-log-bucket_3A8C1D83.bucket}",
+        "policy": "\${data.aws_iam_policy_document.testALB_access-iam-log-bucket-policy-document_B4319C4B.json}"
+      },
+      "testALB_connection-log-bucket-policy_D66BDF5D": {
+        "bucket": "\${aws_s3_bucket.testALB_connection-log-bucket_633AB558.bucket}",
+        "policy": "\${data.aws_iam_policy_document.testALB_connection-iam-log-bucket-policy-document_98C0A07B.json}"
       }
     },
     "aws_security_group": {
@@ -272,8 +350,11 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with an existing bucke
 "{
   "data": {
     "aws_s3_bucket": {
-      "testALB_log-bucket_E9787BB1": {
+      "testALB_access-log-bucket_3A8C1D83": {
         "bucket": "logging-bucket"
+      },
+      "testALB_connection-log-bucket_633AB558": {
+        "bucket": "connection-logging-bucket"
       }
     }
   },
@@ -281,9 +362,14 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with an existing bucke
     "aws_alb": {
       "testALB_alb_F6B33218": {
         "access_logs": {
-          "bucket": "\${data.aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}",
+          "bucket": "\${data.aws_s3_bucket.testALB_access-log-bucket_3A8C1D83.bucket}",
           "enabled": true,
           "prefix": "server-logs/test-/alb"
+        },
+        "connection_logs": {
+          "bucket": "\${data.aws_s3_bucket.testALB_connection-log-bucket_633AB558.bucket}",
+          "enabled": true,
+          "prefix": "server-logs/test-/albConnection"
         },
         "internal": false,
         "name_prefix": "TEST",
@@ -369,8 +455,11 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with an existing bucke
 "{
   "data": {
     "aws_s3_bucket": {
-      "testALB_log-bucket_E9787BB1": {
+      "testALB_access-log-bucket_3A8C1D83": {
         "bucket": "logging-bucket"
+      },
+      "testALB_connection-log-bucket_633AB558": {
+        "bucket": "connection-logging-bucket"
       }
     }
   },
@@ -378,7 +467,12 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with an existing bucke
     "aws_alb": {
       "testALB_alb_F6B33218": {
         "access_logs": {
-          "bucket": "\${data.aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}",
+          "bucket": "\${data.aws_s3_bucket.testALB_access-log-bucket_3A8C1D83.bucket}",
+          "enabled": true,
+          "prefix": "logs/ahoy/cool/service"
+        },
+        "connection_logs": {
+          "bucket": "\${data.aws_s3_bucket.testALB_connection-log-bucket_633AB558.bucket}",
           "enabled": true,
           "prefix": "logs/ahoy/cool/service"
         },

--- a/packages/terraform-modules/src/base/__snapshots__/ApplicationRDSCluster.spec.ts.snap
+++ b/packages/terraform-modules/src/base/__snapshots__/ApplicationRDSCluster.spec.ts.snap
@@ -35,8 +35,6 @@ exports[`ApplicationRDSCluster renders a RDS cluster 1`] = `
         "copy_tags_to_snapshot": true,
         "database_name": "walter",
         "db_subnet_group_name": "\${aws_db_subnet_group.testRDSCluster_rds_subnet_group_88022457.name}",
-        "enabled_cloudwatch_logs_exports": [
-        ],
         "engine": "aurora-mysql",
         "lifecycle": {
           "ignore_changes": [
@@ -282,8 +280,6 @@ exports[`ApplicationRDSCluster renders a RDS cluster without a name 1`] = `
         "copy_tags_to_snapshot": true,
         "database_name": "walter",
         "db_subnet_group_name": "\${aws_db_subnet_group.testRDSCluster_rds_subnet_group_88022457.name}",
-        "enabled_cloudwatch_logs_exports": [
-        ],
         "engine": "aurora-mysql",
         "lifecycle": {
           "ignore_changes": [

--- a/packages/terraform-modules/src/base/__snapshots__/ApplicationRDSCluster.spec.ts.snap
+++ b/packages/terraform-modules/src/base/__snapshots__/ApplicationRDSCluster.spec.ts.snap
@@ -35,6 +35,8 @@ exports[`ApplicationRDSCluster renders a RDS cluster 1`] = `
         "copy_tags_to_snapshot": true,
         "database_name": "walter",
         "db_subnet_group_name": "\${aws_db_subnet_group.testRDSCluster_rds_subnet_group_88022457.name}",
+        "enabled_cloudwatch_logs_exports": [
+        ],
         "engine": "aurora-mysql",
         "lifecycle": {
           "ignore_changes": [
@@ -121,7 +123,7 @@ exports[`ApplicationRDSCluster renders a RDS cluster 1`] = `
 }"
 `;
 
-exports[`ApplicationRDSCluster renders a RDS cluster with a database URL 1`] = `
+exports[`ApplicationRDSCluster renders a RDS cluster with cloudwatch exporting 1`] = `
 "{
   "data": {
     "aws_vpc": {
@@ -156,6 +158,11 @@ exports[`ApplicationRDSCluster renders a RDS cluster with a database URL 1`] = `
         "copy_tags_to_snapshot": true,
         "database_name": "walter",
         "db_subnet_group_name": "\${aws_db_subnet_group.testRDSCluster_rds_subnet_group_88022457.name}",
+        "enabled_cloudwatch_logs_exports": [
+          "audit",
+          "error",
+          "general"
+        ],
         "engine": "aurora-mysql",
         "lifecycle": {
           "ignore_changes": [
@@ -275,6 +282,8 @@ exports[`ApplicationRDSCluster renders a RDS cluster without a name 1`] = `
         "copy_tags_to_snapshot": true,
         "database_name": "walter",
         "db_subnet_group_name": "\${aws_db_subnet_group.testRDSCluster_rds_subnet_group_88022457.name}",
+        "enabled_cloudwatch_logs_exports": [
+        ],
         "engine": "aurora-mysql",
         "lifecycle": {
           "ignore_changes": [

--- a/packages/terraform-modules/src/pocket/PocketALBApplication.ts
+++ b/packages/terraform-modules/src/pocket/PocketALBApplication.ts
@@ -87,12 +87,36 @@ export interface PocketALBApplicationProps extends TerraformMetaArguments {
   cdn?: boolean;
 
   /**
-   * Optional config to dump alb logs to a bucket.
+   * Optional config to dump alb access logs to a bucket.
 
    */
   accessLogs?: {
     /**
-     * Existing bucket to dump alb logs too, one of existingBucket or bucket must be chosen.
+     * Existing bucket to dump alb access logs to, one of existingBucket or bucket must be chosen.
+     * If using this options, this module assumes that the bucket already exists in your AWS account and has IAM setup according
+     * to https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy which is account wide.
+     */
+    existingBucket?: string;
+
+    /**
+     * Bucket to dump alb logs too, one of existingBucket or bucket must be chosen.
+     */
+    bucket?: string;
+
+    /**
+     * Optional bucket path prefix. If not defined will use server-logs/{service-name}/internal-alb/AWSLogs/{awsaccountid}/elasticloadbalancing/
+     * Be sure to include a trailing /
+     */
+    prefix?: string;
+  };
+
+  /**
+   * Optional config to dump alb access logs to a bucket.
+
+   */
+  connectionLogs?: {
+    /**
+     * Existing bucket to dump alb connection logs to, one of existingBucket or bucket must be chosen.
      * If using this options, this module assumes that the bucket already exists in your AWS account and has IAM setup according
      * to https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy which is account wide.
      */
@@ -427,6 +451,7 @@ export class PocketALBApplication extends Construct {
       internal: this.config.internal,
       tags: this.config.tags,
       accessLogs: this.config.accessLogs,
+      connectionLogs: this.config.connectionLogs,
       provider: this.config.provider,
       useCloudfrontManagedPrefixList:
         this.config.cdn && this.config.wafConfig !== null,

--- a/packages/terraform-modules/src/pocket/PocketALBApplication.ts
+++ b/packages/terraform-modules/src/pocket/PocketALBApplication.ts
@@ -93,7 +93,7 @@ export interface PocketALBApplicationProps extends TerraformMetaArguments {
   accessLogs?: {
     /**
      * Existing bucket to dump alb access logs to, one of existingBucket or bucket must be chosen.
-     * If using this options, this module assumes that the bucket already exists in your AWS account and has IAM setup according
+     * If using this option, this module assumes that the bucket already exists in your AWS account and has IAM setup according
      * to https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy which is account wide.
      */
     existingBucket?: string;
@@ -111,14 +111,14 @@ export interface PocketALBApplicationProps extends TerraformMetaArguments {
   };
 
   /**
-   * Optional config to dump alb access logs to a bucket.
+   * Optional config to dump alb connection logs to a bucket.
 
    */
   connectionLogs?: {
     /**
      * Existing bucket to dump alb connection logs to, one of existingBucket or bucket must be chosen.
-     * If using this options, this module assumes that the bucket already exists in your AWS account and has IAM setup according
-     * to https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy which is account wide.
+     * If using this option, this module assumes that the bucket already exists in your AWS account and has IAM setup according
+     * to https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-connection-logging.html#attach-bucket-policy which is account wide.
      */
     existingBucket?: string;
 


### PR DESCRIPTION
## Goal

increase ability to log system activity to better monitor and investigate potential access anomalies. 

- exposes connection logs for ALBs (in addition to access logs)
- exposes cloudwatch log export for RDS

[HNT-2546](https://mozilla-hub.atlassian.net/browse/HNT-2546)

[HNT-2546]: https://mozilla-hub.atlassian.net/browse/HNT-2546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ